### PR TITLE
Minor fixes

### DIFF
--- a/ql/src/semmle/go/Decls.qll
+++ b/ql/src/semmle/go/Decls.qll
@@ -156,7 +156,7 @@ class FuncDecl extends @funcdecl, Decl, Documentable, FuncDef {
   override BlockStmt getBody() { result = getChildStmt(2) }
 
   /** Gets the function declared by this function declaration. */
-  DeclaredFunction getFunction() { this = result.getDecl() }
+  DeclaredFunction getFunction() { this = result.getFuncDecl() }
 
   override string toString() { result = "function declaration" }
 }

--- a/ql/src/semmle/go/Expr.qll
+++ b/ql/src/semmle/go/Expr.qll
@@ -482,7 +482,7 @@ class CallExpr extends CallOrConversionExpr {
    * interface type.
    */
   FuncDef getACallee() {
-    result = getTarget().(DeclaredFunction).getDecl()
+    result = getTarget().(DeclaredFunction).getFuncDecl()
     or
     exists(SelectorExpr sel, InterfaceType declaredRecv, Type actualRecv |
       sel = getCalleeExpr().stripParens() and

--- a/ql/src/semmle/go/Locations.qll
+++ b/ql/src/semmle/go/Locations.qll
@@ -31,7 +31,7 @@ class Location extends @location {
   string toString() {
     exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
       hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) and
-      result = filepath + "@" + startline + ":" + startcolumn + "-" + endline + ":" + endcolumn
+      result = filepath + "@" + startline + ":" + startcolumn + ":" + endline + ":" + endcolumn
     )
   }
 

--- a/ql/src/semmle/go/Scopes.qll
+++ b/ql/src/semmle/go/Scopes.qll
@@ -254,7 +254,7 @@ class ResultVariable extends DeclaredVariable {
 }
 
 /** A struct field. */
-class Field extends ValueEntity {
+class Field extends Variable {
   StructType declaringType;
 
   Field() { fieldstructs(this, declaringType) }

--- a/ql/src/semmle/go/Scopes.qll
+++ b/ql/src/semmle/go/Scopes.qll
@@ -124,6 +124,24 @@ class Entity extends @object {
 
   /** Gets a textual representation of this entity. */
   string toString() { result = getName() }
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    // take the location of the declaration if there is one
+    getDeclaration().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    or
+    // otherwise fall back on dummy location
+    not exists(getDeclaration()) and
+    filepath = "" and startline = 0 and startcolumn = 0 and endline = 0 and endcolumn = 0
+  }
 }
 
 /** A declared entity (that is, type, constant, variable or function). */

--- a/ql/src/semmle/go/Scopes.qll
+++ b/ql/src/semmle/go/Scopes.qll
@@ -128,9 +128,6 @@ class Entity extends @object {
 
 /** A declared entity (that is, type, constant, variable or function). */
 class DeclaredEntity extends Entity, @declobject {
-  /** Gets the declaration of this entity. */
-  Decl getDecl() { none() }
-
   /** Gets the expression to which this entity is initialized, if any. */
   Expr getInit() {
     exists(ValueSpec spec, int i |
@@ -151,9 +148,6 @@ class TypeEntity extends Entity, @typeobject { }
 
 /** A declared named type. */
 class DeclaredType extends TypeEntity, DeclaredEntity, @decltypeobject {
-  /** Gets the declaration of this type. */
-  override TypeDecl getDecl() { result.getASpec() = this.getSpec() }
-
   /** Gets the declaration specifier declaring this type. */
   TypeSpec getSpec() { result.getNameExpr() = this.getDeclaration() }
 }
@@ -175,9 +169,6 @@ class Constant extends ValueEntity, @constobject { }
 
 /** A declared constant. */
 class DeclaredConstant extends Constant, DeclaredEntity, @declconstobject {
-  /** Gets the declaration of this constant. */
-  override ConstDecl getDecl() { result.getASpec() = this.getSpec() }
-
   /** Gets the declaration specifier declaring this constant. */
   ValueSpec getSpec() { result.getANameExpr() = this.getDeclaration() }
 }
@@ -195,9 +186,6 @@ class Variable extends ValueEntity, @varobject { }
 
 /** A declared variable. */
 class DeclaredVariable extends Variable, DeclaredEntity, @declvarobject {
-  /** Gets the declaration of this variable. */
-  override VarDecl getDecl() { result.getASpec() = this.getSpec() }
-
   /** Gets the declaration specifier declaring this variable. */
   ValueSpec getSpec() { result.getANameExpr() = this.getDeclaration() }
 }
@@ -297,6 +285,12 @@ class Function extends ValueEntity, @functionobject {
 
   /** Gets the body of this function, if any. */
   BlockStmt getBody() { none() }
+
+  /** Gets the `i`th parameter of this function. */
+  Parameter getParameter(int i) { none() }
+
+  /** Gets a parameter of this function. */
+  Parameter getAParameter() { result = getParameter(_) }
 }
 
 /** A method, that is, a function with a receiver variable. */
@@ -371,9 +365,11 @@ class Method extends Function {
 /** A declared function. */
 class DeclaredFunction extends Function, DeclaredEntity, @declfunctionobject {
   /** Gets the declaration of this function. */
-  override FuncDecl getDecl() { result.getNameExpr() = this.getDeclaration() }
+  FuncDecl getFuncDecl() { result.getNameExpr() = this.getDeclaration() }
 
-  override BlockStmt getBody() { result = getDecl().getBody() }
+  override BlockStmt getBody() { result = getFuncDecl().getBody() }
+
+  override Parameter getParameter(int i) { result = getFuncDecl().getParameter(i) }
 
   override predicate mayHaveSideEffects() {
     not exists(getBody())

--- a/ql/src/semmle/go/Scopes.qll
+++ b/ql/src/semmle/go/Scopes.qll
@@ -260,6 +260,18 @@ class Field extends Variable {
   Field() { fieldstructs(this, declaringType) }
 
   StructType getDeclaringType() { result = declaringType }
+
+  /**
+   * Holds if this field has name `f` and it belongs to a type  `tp` declared in package `pkg`.
+   *
+   * Note that due to field embedding the same field may belong to multiple types.
+   */
+  predicate hasQualifiedName(string pkg, string tp, string f) {
+    exists(Type base |
+      base.hasQualifiedName(pkg, tp) and
+      this = base.getField(f)
+    )
+  }
 }
 
 /** A built-in or declared function. */

--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -240,13 +240,7 @@ class GlobalFunctionNode extends FunctionNode, MkGlobalFunctionNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    func
-        .(DeclaredFunction)
-        .getDecl()
-        .hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-    or
-    not func instanceof DeclaredFunction and
-    FunctionNode.super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    func.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -223,7 +223,7 @@ class GlobalFunctionNode extends FunctionNode, MkGlobalFunctionNode {
   GlobalFunctionNode() { this = MkGlobalFunctionNode(func) }
 
   override ParameterNode getParameter(int i) {
-    result = parameterNode(func.(DeclaredFunction).getDecl().getParameter(i))
+    result = parameterNode(func.getParameter(i))
   }
 
   override string getName() { result = func.getName() }

--- a/ql/src/semmle/go/security/ZipSlipCustomizations.qll
+++ b/ql/src/semmle/go/security/ZipSlipCustomizations.qll
@@ -31,12 +31,8 @@ module ZipSlip {
   /** A file name from a zip or tar entry, as a source for zip slip. */
   class FileNameSource extends Source, DataFlow::FieldReadNode {
     FileNameSource() {
-      exists(Type t |
-        t.hasQualifiedName("archive/zip", "File") or
-        t.hasQualifiedName("archive/tar", "Header")
-      |
-        getField() = t.getField("Name")
-      )
+      getField().hasQualifiedName("archive/zip", "File", "Name") or
+      getField().hasQualifiedName("archive/tar", "Header", "Name")
     }
   }
 

--- a/ql/test/library-tests/semmle/go/Scopes/DeclaredEntity.expected
+++ b/ql/test/library-tests/semmle/go/Scopes/DeclaredEntity.expected
@@ -1,22 +1,22 @@
-| a | types.go:24:22:24:22 | a |
-| bump | main.go:23:16:23:19 | bump |
-| foo | main.go:17:6:17:8 | foo |
-| iHaveAMethod | types.go:3:6:3:17 | iHaveAMethod |
-| main | main.go:9:6:9:9 | main |
-| meth | main.go:13:16:13:19 | meth |
-| meth | types.go:4:2:4:5 | meth |
-| meth1 | types.go:8:2:8:6 | meth1 |
-| meth1 | types.go:14:18:14:22 | meth1 |
-| meth1 | types.go:24:16:24:20 | meth1 |
-| meth2 | types.go:9:2:9:6 | meth2 |
-| meth2 | types.go:18:17:18:21 | meth2 |
-| meth2 | types.go:28:16:28:20 | meth2 |
-| notImpl | types.go:22:6:22:12 | notImpl |
-| recv | main.go:13:7:13:10 | recv |
-| recv | main.go:23:7:23:10 | recv |
-| starImpl | types.go:12:6:12:13 | starImpl |
-| t | main.go:5:6:5:6 | t |
-| twoMethods | types.go:7:6:7:15 | twoMethods |
-| x | main.go:6:2:6:2 | x |
-| x | main.go:17:10:17:10 | x |
-| y | main.go:17:26:17:26 | y |
+| main.go:5:6:5:6 | t | main.go:5:6:5:6 | t |
+| main.go:6:2:6:2 | x | main.go:6:2:6:2 | x |
+| main.go:9:6:9:9 | main | main.go:9:6:9:9 | main |
+| main.go:13:7:13:10 | recv | main.go:13:7:13:10 | recv |
+| main.go:13:16:13:19 | meth | main.go:13:16:13:19 | meth |
+| main.go:17:6:17:8 | foo | main.go:17:6:17:8 | foo |
+| main.go:17:10:17:10 | x | main.go:17:10:17:10 | x |
+| main.go:17:26:17:26 | y | main.go:17:26:17:26 | y |
+| main.go:23:7:23:10 | recv | main.go:23:7:23:10 | recv |
+| main.go:23:16:23:19 | bump | main.go:23:16:23:19 | bump |
+| types.go:3:6:3:17 | iHaveAMethod | types.go:3:6:3:17 | iHaveAMethod |
+| types.go:4:2:4:5 | meth | types.go:4:2:4:5 | meth |
+| types.go:7:6:7:15 | twoMethods | types.go:7:6:7:15 | twoMethods |
+| types.go:8:2:8:6 | meth1 | types.go:8:2:8:6 | meth1 |
+| types.go:9:2:9:6 | meth2 | types.go:9:2:9:6 | meth2 |
+| types.go:12:6:12:13 | starImpl | types.go:12:6:12:13 | starImpl |
+| types.go:14:18:14:22 | meth1 | types.go:14:18:14:22 | meth1 |
+| types.go:18:17:18:21 | meth2 | types.go:18:17:18:21 | meth2 |
+| types.go:22:6:22:12 | notImpl | types.go:22:6:22:12 | notImpl |
+| types.go:24:16:24:20 | meth1 | types.go:24:16:24:20 | meth1 |
+| types.go:24:22:24:22 | a | types.go:24:22:24:22 | a |
+| types.go:28:16:28:20 | meth2 | types.go:28:16:28:20 | meth2 |

--- a/ql/test/library-tests/semmle/go/Scopes/EntityRead.expected
+++ b/ql/test/library-tests/semmle/go/Scopes/EntityRead.expected
@@ -1,13 +1,13 @@
-| Println | main.go:10:2:10:12 | selection of Println |
-| a | types.go:25:9:25:9 | a |
-| false | types.go:15:9:15:13 | false |
-| meth | main.go:18:2:18:7 | selection of meth |
-| meth | main.go:19:2:19:7 | selection of meth |
-| meth | main.go:20:2:20:10 | selection of meth |
-| recv | main.go:14:9:14:12 | recv |
-| recv | main.go:24:2:24:5 | recv |
-| x | main.go:14:9:14:14 | selection of x |
-| x | main.go:18:2:18:2 | x |
-| x | main.go:24:2:24:7 | selection of x |
-| y | main.go:19:2:19:2 | y |
-| y | main.go:20:12:20:12 | y |
+| file://:0:0:0:0 | Println | main.go:10:2:10:12 | selection of Println |
+| file://:0:0:0:0 | false | types.go:15:9:15:13 | false |
+| main.go:6:2:6:2 | x | main.go:14:9:14:14 | selection of x |
+| main.go:6:2:6:2 | x | main.go:24:2:24:7 | selection of x |
+| main.go:13:7:13:10 | recv | main.go:14:9:14:12 | recv |
+| main.go:13:16:13:19 | meth | main.go:19:2:19:7 | selection of meth |
+| main.go:13:16:13:19 | meth | main.go:20:2:20:10 | selection of meth |
+| main.go:17:10:17:10 | x | main.go:18:2:18:2 | x |
+| main.go:17:26:17:26 | y | main.go:19:2:19:2 | y |
+| main.go:17:26:17:26 | y | main.go:20:12:20:12 | y |
+| main.go:23:7:23:10 | recv | main.go:24:2:24:5 | recv |
+| types.go:4:2:4:5 | meth | main.go:18:2:18:7 | selection of meth |
+| types.go:24:22:24:22 | a | types.go:25:9:25:9 | a |

--- a/ql/test/library-tests/semmle/go/Scopes/EntityReference.expected
+++ b/ql/test/library-tests/semmle/go/Scopes/EntityReference.expected
@@ -1,61 +1,61 @@
-| Println | <library> | main.go:10:2:10:12 | selection of Println |
-| Println | <library> | main.go:10:6:10:12 | Println |
-| a | types.go@24:22-24:22 | types.go:24:22:24:22 | a |
-| a | types.go@24:22-24:22 | types.go:25:9:25:9 | a |
-| bool | <library> | types.go:8:10:8:13 | bool |
-| bool | <library> | types.go:14:26:14:29 | bool |
-| bool | <library> | types.go:24:29:24:32 | bool |
-| bump | main.go@23:16-23:19 | main.go:23:16:23:19 | bump |
-| false | <library> | types.go:15:9:15:13 | false |
-| fmt | <library> | main.go:10:2:10:4 | fmt |
-| foo | main.go@17:6-17:8 | main.go:17:6:17:8 | foo |
-| iHaveAMethod | types.go@3:6-3:17 | main.go:17:12:17:23 | iHaveAMethod |
-| iHaveAMethod | types.go@3:6-3:17 | types.go:3:6:3:17 | iHaveAMethod |
-| int | <library> | main.go:6:4:6:6 | int |
-| int | <library> | main.go:13:23:13:25 | int |
-| int | <library> | types.go:4:9:4:11 | int |
-| int | <library> | types.go:9:10:9:12 | int |
-| int | <library> | types.go:18:25:18:27 | int |
-| int | <library> | types.go:24:24:24:26 | int |
-| int | <library> | types.go:28:24:28:26 | int |
-| main | main.go@9:6-9:9 | main.go:9:6:9:9 | main |
-| meth | main.go@13:16-13:19 | main.go:13:16:13:19 | meth |
-| meth | main.go@13:16-13:19 | main.go:19:2:19:7 | selection of meth |
-| meth | main.go@13:16-13:19 | main.go:19:4:19:7 | meth |
-| meth | main.go@13:16-13:19 | main.go:20:2:20:10 | selection of meth |
-| meth | main.go@13:16-13:19 | main.go:20:7:20:10 | meth |
-| meth | types.go@4:2-4:5 | main.go:18:2:18:7 | selection of meth |
-| meth | types.go@4:2-4:5 | main.go:18:4:18:7 | meth |
-| meth | types.go@4:2-4:5 | types.go:4:2:4:5 | meth |
-| meth1 | types.go@8:2-8:6 | types.go:8:2:8:6 | meth1 |
-| meth1 | types.go@14:18-14:22 | types.go:14:18:14:22 | meth1 |
-| meth1 | types.go@24:16-24:20 | types.go:24:16:24:20 | meth1 |
-| meth2 | types.go@9:2-9:6 | types.go:9:2:9:6 | meth2 |
-| meth2 | types.go@18:17-18:21 | types.go:18:17:18:21 | meth2 |
-| meth2 | types.go@28:16-28:20 | types.go:28:16:28:20 | meth2 |
-| notImpl | types.go@22:6-22:12 | types.go:22:6:22:12 | notImpl |
-| notImpl | types.go@22:6-22:12 | types.go:24:7:24:13 | notImpl |
-| notImpl | types.go@22:6-22:12 | types.go:28:7:28:13 | notImpl |
-| recv | main.go@13:7-13:10 | main.go:13:7:13:10 | recv |
-| recv | main.go@13:7-13:10 | main.go:14:9:14:12 | recv |
-| recv | main.go@23:7-23:10 | main.go:23:7:23:10 | recv |
-| recv | main.go@23:7-23:10 | main.go:24:2:24:5 | recv |
-| starImpl | types.go@12:6-12:13 | types.go:12:6:12:13 | starImpl |
-| starImpl | types.go@12:6-12:13 | types.go:14:8:14:15 | starImpl |
-| starImpl | types.go@12:6-12:13 | types.go:18:7:18:14 | starImpl |
-| t | main.go@5:6-5:6 | main.go:5:6:5:6 | t |
-| t | main.go@5:6-5:6 | main.go:13:13:13:13 | t |
-| t | main.go@5:6-5:6 | main.go:17:29:17:29 | t |
-| t | main.go@5:6-5:6 | main.go:20:4:20:4 | t |
-| t | main.go@5:6-5:6 | main.go:23:13:23:13 | t |
-| twoMethods | types.go@7:6-7:15 | types.go:7:6:7:15 | twoMethods |
-| x | main.go@6:2-6:2 | main.go:6:2:6:2 | x |
-| x | main.go@6:2-6:2 | main.go:14:9:14:14 | selection of x |
-| x | main.go@6:2-6:2 | main.go:14:14:14:14 | x |
-| x | main.go@6:2-6:2 | main.go:24:2:24:7 | selection of x |
-| x | main.go@6:2-6:2 | main.go:24:7:24:7 | x |
-| x | main.go@17:10-17:10 | main.go:17:10:17:10 | x |
-| x | main.go@17:10-17:10 | main.go:18:2:18:2 | x |
-| y | main.go@17:26-17:26 | main.go:17:26:17:26 | y |
-| y | main.go@17:26-17:26 | main.go:19:2:19:2 | y |
-| y | main.go@17:26-17:26 | main.go:20:12:20:12 | y |
+| file://:0:0:0:0 | Println | <library> | main.go:10:2:10:12 | selection of Println |
+| file://:0:0:0:0 | Println | <library> | main.go:10:6:10:12 | Println |
+| file://:0:0:0:0 | bool | <library> | types.go:8:10:8:13 | bool |
+| file://:0:0:0:0 | bool | <library> | types.go:14:26:14:29 | bool |
+| file://:0:0:0:0 | bool | <library> | types.go:24:29:24:32 | bool |
+| file://:0:0:0:0 | false | <library> | types.go:15:9:15:13 | false |
+| file://:0:0:0:0 | fmt | <library> | main.go:10:2:10:4 | fmt |
+| file://:0:0:0:0 | int | <library> | main.go:6:4:6:6 | int |
+| file://:0:0:0:0 | int | <library> | main.go:13:23:13:25 | int |
+| file://:0:0:0:0 | int | <library> | types.go:4:9:4:11 | int |
+| file://:0:0:0:0 | int | <library> | types.go:9:10:9:12 | int |
+| file://:0:0:0:0 | int | <library> | types.go:18:25:18:27 | int |
+| file://:0:0:0:0 | int | <library> | types.go:24:24:24:26 | int |
+| file://:0:0:0:0 | int | <library> | types.go:28:24:28:26 | int |
+| main.go:5:6:5:6 | t | main.go@5:6:5:6 | main.go:5:6:5:6 | t |
+| main.go:5:6:5:6 | t | main.go@5:6:5:6 | main.go:13:13:13:13 | t |
+| main.go:5:6:5:6 | t | main.go@5:6:5:6 | main.go:17:29:17:29 | t |
+| main.go:5:6:5:6 | t | main.go@5:6:5:6 | main.go:20:4:20:4 | t |
+| main.go:5:6:5:6 | t | main.go@5:6:5:6 | main.go:23:13:23:13 | t |
+| main.go:6:2:6:2 | x | main.go@6:2:6:2 | main.go:6:2:6:2 | x |
+| main.go:6:2:6:2 | x | main.go@6:2:6:2 | main.go:14:9:14:14 | selection of x |
+| main.go:6:2:6:2 | x | main.go@6:2:6:2 | main.go:14:14:14:14 | x |
+| main.go:6:2:6:2 | x | main.go@6:2:6:2 | main.go:24:2:24:7 | selection of x |
+| main.go:6:2:6:2 | x | main.go@6:2:6:2 | main.go:24:7:24:7 | x |
+| main.go:9:6:9:9 | main | main.go@9:6:9:9 | main.go:9:6:9:9 | main |
+| main.go:13:7:13:10 | recv | main.go@13:7:13:10 | main.go:13:7:13:10 | recv |
+| main.go:13:7:13:10 | recv | main.go@13:7:13:10 | main.go:14:9:14:12 | recv |
+| main.go:13:16:13:19 | meth | main.go@13:16:13:19 | main.go:13:16:13:19 | meth |
+| main.go:13:16:13:19 | meth | main.go@13:16:13:19 | main.go:19:2:19:7 | selection of meth |
+| main.go:13:16:13:19 | meth | main.go@13:16:13:19 | main.go:19:4:19:7 | meth |
+| main.go:13:16:13:19 | meth | main.go@13:16:13:19 | main.go:20:2:20:10 | selection of meth |
+| main.go:13:16:13:19 | meth | main.go@13:16:13:19 | main.go:20:7:20:10 | meth |
+| main.go:17:6:17:8 | foo | main.go@17:6:17:8 | main.go:17:6:17:8 | foo |
+| main.go:17:10:17:10 | x | main.go@17:10:17:10 | main.go:17:10:17:10 | x |
+| main.go:17:10:17:10 | x | main.go@17:10:17:10 | main.go:18:2:18:2 | x |
+| main.go:17:26:17:26 | y | main.go@17:26:17:26 | main.go:17:26:17:26 | y |
+| main.go:17:26:17:26 | y | main.go@17:26:17:26 | main.go:19:2:19:2 | y |
+| main.go:17:26:17:26 | y | main.go@17:26:17:26 | main.go:20:12:20:12 | y |
+| main.go:23:7:23:10 | recv | main.go@23:7:23:10 | main.go:23:7:23:10 | recv |
+| main.go:23:7:23:10 | recv | main.go@23:7:23:10 | main.go:24:2:24:5 | recv |
+| main.go:23:16:23:19 | bump | main.go@23:16:23:19 | main.go:23:16:23:19 | bump |
+| types.go:3:6:3:17 | iHaveAMethod | types.go@3:6:3:17 | main.go:17:12:17:23 | iHaveAMethod |
+| types.go:3:6:3:17 | iHaveAMethod | types.go@3:6:3:17 | types.go:3:6:3:17 | iHaveAMethod |
+| types.go:4:2:4:5 | meth | types.go@4:2:4:5 | main.go:18:2:18:7 | selection of meth |
+| types.go:4:2:4:5 | meth | types.go@4:2:4:5 | main.go:18:4:18:7 | meth |
+| types.go:4:2:4:5 | meth | types.go@4:2:4:5 | types.go:4:2:4:5 | meth |
+| types.go:7:6:7:15 | twoMethods | types.go@7:6:7:15 | types.go:7:6:7:15 | twoMethods |
+| types.go:8:2:8:6 | meth1 | types.go@8:2:8:6 | types.go:8:2:8:6 | meth1 |
+| types.go:9:2:9:6 | meth2 | types.go@9:2:9:6 | types.go:9:2:9:6 | meth2 |
+| types.go:12:6:12:13 | starImpl | types.go@12:6:12:13 | types.go:12:6:12:13 | starImpl |
+| types.go:12:6:12:13 | starImpl | types.go@12:6:12:13 | types.go:14:8:14:15 | starImpl |
+| types.go:12:6:12:13 | starImpl | types.go@12:6:12:13 | types.go:18:7:18:14 | starImpl |
+| types.go:14:18:14:22 | meth1 | types.go@14:18:14:22 | types.go:14:18:14:22 | meth1 |
+| types.go:18:17:18:21 | meth2 | types.go@18:17:18:21 | types.go:18:17:18:21 | meth2 |
+| types.go:22:6:22:12 | notImpl | types.go@22:6:22:12 | types.go:22:6:22:12 | notImpl |
+| types.go:22:6:22:12 | notImpl | types.go@22:6:22:12 | types.go:24:7:24:13 | notImpl |
+| types.go:22:6:22:12 | notImpl | types.go@22:6:22:12 | types.go:28:7:28:13 | notImpl |
+| types.go:24:16:24:20 | meth1 | types.go@24:16:24:20 | types.go:24:16:24:20 | meth1 |
+| types.go:24:22:24:22 | a | types.go@24:22:24:22 | types.go:24:22:24:22 | a |
+| types.go:24:22:24:22 | a | types.go@24:22:24:22 | types.go:25:9:25:9 | a |
+| types.go:28:16:28:20 | meth2 | types.go@28:16:28:20 | types.go:28:16:28:20 | meth2 |

--- a/ql/test/library-tests/semmle/go/Scopes/EntityType.expected
+++ b/ql/test/library-tests/semmle/go/Scopes/EntityType.expected
@@ -1,22 +1,22 @@
-| a | int |
-| bump | func()  |
-| foo | func(iHaveAMethod, * t)  |
-| iHaveAMethod | iHaveAMethod |
-| main | func()  |
-| meth | func() int |
-| meth | func() int |
-| meth1 | func() bool |
-| meth1 | func() bool |
-| meth1 | func(int) bool |
-| meth2 | func() int |
-| meth2 | func() int |
-| meth2 | func() int |
-| notImpl | notImpl |
-| recv | * t |
-| recv | * t |
-| starImpl | starImpl |
-| t | t |
-| twoMethods | twoMethods |
-| x | iHaveAMethod |
-| x | int |
-| y | * t |
+| main.go:5:6:5:6 | t | t |
+| main.go:6:2:6:2 | x | int |
+| main.go:9:6:9:9 | main | func()  |
+| main.go:13:7:13:10 | recv | * t |
+| main.go:13:16:13:19 | meth | func() int |
+| main.go:17:6:17:8 | foo | func(iHaveAMethod, * t)  |
+| main.go:17:10:17:10 | x | iHaveAMethod |
+| main.go:17:26:17:26 | y | * t |
+| main.go:23:7:23:10 | recv | * t |
+| main.go:23:16:23:19 | bump | func()  |
+| types.go:3:6:3:17 | iHaveAMethod | iHaveAMethod |
+| types.go:4:2:4:5 | meth | func() int |
+| types.go:7:6:7:15 | twoMethods | twoMethods |
+| types.go:8:2:8:6 | meth1 | func() bool |
+| types.go:9:2:9:6 | meth2 | func() int |
+| types.go:12:6:12:13 | starImpl | starImpl |
+| types.go:14:18:14:22 | meth1 | func() bool |
+| types.go:18:17:18:21 | meth2 | func() int |
+| types.go:22:6:22:12 | notImpl | notImpl |
+| types.go:24:16:24:20 | meth1 | func(int) bool |
+| types.go:24:22:24:22 | a | int |
+| types.go:28:16:28:20 | meth2 | func() int |

--- a/ql/test/library-tests/semmle/go/Scopes/EntityWrite.expected
+++ b/ql/test/library-tests/semmle/go/Scopes/EntityWrite.expected
@@ -1,6 +1,6 @@
-| a | types.go:24:22:24:22 | initialization of a |
-| recv | main.go:13:7:13:10 | initialization of recv |
-| recv | main.go:23:7:23:10 | initialization of recv |
-| x | main.go:17:10:17:10 | initialization of x |
-| x | main.go:24:2:24:9 | increment statement |
-| y | main.go:17:26:17:26 | initialization of y |
+| main.go:6:2:6:2 | x | main.go:24:2:24:9 | increment statement |
+| main.go:13:7:13:10 | recv | main.go:13:7:13:10 | initialization of recv |
+| main.go:17:10:17:10 | x | main.go:17:10:17:10 | initialization of x |
+| main.go:17:26:17:26 | y | main.go:17:26:17:26 | initialization of y |
+| main.go:23:7:23:10 | recv | main.go:23:7:23:10 | initialization of recv |
+| types.go:24:22:24:22 | a | types.go:24:22:24:22 | initialization of a |

--- a/ql/test/library-tests/semmle/go/Scopes/Methods.expected
+++ b/ql/test/library-tests/semmle/go/Scopes/Methods.expected
@@ -1,9 +1,9 @@
-| bump | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.t.bump | recv | * t |
-| meth | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.iHaveAMethod.meth |  | iHaveAMethod |
-| meth | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.t.meth | recv | * t |
-| meth1 | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.notImpl.meth1 |  | notImpl |
-| meth1 | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.starImpl.meth1 |  | * starImpl |
-| meth1 | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.twoMethods.meth1 |  | twoMethods |
-| meth2 | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.notImpl.meth2 |  | notImpl |
-| meth2 | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.starImpl.meth2 |  | starImpl |
-| meth2 | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.twoMethods.meth2 |  | twoMethods |
+| main.go:13:16:13:19 | meth | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.t.meth | main.go:13:7:13:10 | recv | * t |
+| main.go:23:16:23:19 | bump | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.t.bump | main.go:23:7:23:10 | recv | * t |
+| types.go:4:2:4:5 | meth | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.iHaveAMethod.meth | file://:0:0:0:0 |  | iHaveAMethod |
+| types.go:8:2:8:6 | meth1 | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.twoMethods.meth1 | file://:0:0:0:0 |  | twoMethods |
+| types.go:9:2:9:6 | meth2 | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.twoMethods.meth2 | file://:0:0:0:0 |  | twoMethods |
+| types.go:14:18:14:22 | meth1 | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.starImpl.meth1 | file://:0:0:0:0 |  | * starImpl |
+| types.go:18:17:18:21 | meth2 | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.starImpl.meth2 | file://:0:0:0:0 |  | starImpl |
+| types.go:24:16:24:20 | meth1 | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.notImpl.meth1 | file://:0:0:0:0 |  | notImpl |
+| types.go:28:16:28:20 | meth2 | github.com/Semmle/go/ql/test/library-tests/semmle/go/Scopes.notImpl.meth2 | file://:0:0:0:0 |  | notImpl |

--- a/ql/test/library-tests/semmle/go/concepts/EscapeFunction/EscapeFunction.expected
+++ b/ql/test/library-tests/semmle/go/concepts/EscapeFunction/EscapeFunction.expected
@@ -1,7 +1,7 @@
-| HTMLEscape | html |
-| HTMLEscapeString | html |
-| HTMLEscaper | html |
-| JSEscape | js |
-| JSEscapeString | js |
-| JSEscaper | js |
-| URLQueryEscaper | url |
+| file://:0:0:0:0 | HTMLEscape | html |
+| file://:0:0:0:0 | HTMLEscapeString | html |
+| file://:0:0:0:0 | HTMLEscaper | html |
+| file://:0:0:0:0 | JSEscape | js |
+| file://:0:0:0:0 | JSEscapeString | js |
+| file://:0:0:0:0 | JSEscaper | js |
+| file://:0:0:0:0 | URLQueryEscaper | url |

--- a/ql/test/library-tests/semmle/go/concepts/Regexp/RegexpMatchFunction.expected
+++ b/ql/test/library-tests/semmle/go/concepts/Regexp/RegexpMatchFunction.expected
@@ -1,3 +1,3 @@
-| Match | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:28:11:28:24 | type conversion | stdlib.go:28:2:28:25 | call to Match |
-| MatchReader | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:29:17:29:37 | call to NewReader | stdlib.go:29:2:29:38 | call to MatchReader |
-| MatchString | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:17:17:17:22 | "posi" | stdlib.go:17:2:17:23 | call to MatchString |
+| file://:0:0:0:0 | Match | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:28:11:28:24 | type conversion | stdlib.go:28:2:28:25 | call to Match |
+| file://:0:0:0:0 | MatchReader | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:29:17:29:37 | call to NewReader | stdlib.go:29:2:29:38 | call to MatchReader |
+| file://:0:0:0:0 | MatchString | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:17:17:17:22 | "posi" | stdlib.go:17:2:17:23 | call to MatchString |

--- a/ql/test/library-tests/semmle/go/concepts/Regexp/RegexpReplaceFunction.expected
+++ b/ql/test/library-tests/semmle/go/concepts/Regexp/RegexpReplaceFunction.expected
@@ -1,6 +1,6 @@
-| ReplaceAll | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:21:16:21:29 | type conversion | stdlib.go:21:2:21:46 | call to ReplaceAll |
-| ReplaceAllFunc | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:22:20:22:33 | type conversion | stdlib.go:22:2:22:85 | call to ReplaceAllFunc |
-| ReplaceAllLiteral | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:23:23:23:36 | type conversion | stdlib.go:23:2:23:53 | call to ReplaceAllLiteral |
-| ReplaceAllLiteralString | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:24:29:24:34 | "src3" | stdlib.go:24:2:24:43 | call to ReplaceAllLiteralString |
-| ReplaceAllString | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:25:22:25:27 | "src4" | stdlib.go:25:2:25:36 | call to ReplaceAllString |
-| ReplaceAllStringFunc | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:26:26:26:31 | "src5" | stdlib.go:26:2:26:75 | call to ReplaceAllStringFunc |
+| file://:0:0:0:0 | ReplaceAll | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:21:16:21:29 | type conversion | stdlib.go:21:2:21:46 | call to ReplaceAll |
+| file://:0:0:0:0 | ReplaceAllFunc | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:22:20:22:33 | type conversion | stdlib.go:22:2:22:85 | call to ReplaceAllFunc |
+| file://:0:0:0:0 | ReplaceAllLiteral | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:23:23:23:36 | type conversion | stdlib.go:23:2:23:53 | call to ReplaceAllLiteral |
+| file://:0:0:0:0 | ReplaceAllLiteralString | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:24:29:24:34 | "src3" | stdlib.go:24:2:24:43 | call to ReplaceAllLiteralString |
+| file://:0:0:0:0 | ReplaceAllString | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:25:22:25:27 | "src4" | stdlib.go:25:2:25:36 | call to ReplaceAllString |
+| file://:0:0:0:0 | ReplaceAllStringFunc | stdlib.go:16:30:16:37 | "posix?" | stdlib.go:26:26:26:31 | "src5" | stdlib.go:26:2:26:75 | call to ReplaceAllStringFunc |

--- a/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalFlowStep.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalFlowStep.expected
@@ -34,9 +34,9 @@
 | main.go:26:2:26:17 | ... := ...[1] | main.go:26:5:26:6 | definition of ok |
 | main.go:26:5:26:6 | definition of ok | main.go:27:5:27:6 | ok |
 | main.go:26:11:26:11 | x | main.go:26:11:26:17 | type assertion |
-| main.go:34:2:34:6 | test1 | main.go:3:1:12:1 | function test1 |
-| main.go:34:8:34:12 | test2 | main.go:14:1:20:1 | function test2 |
-| main.go:34:19:34:23 | test2 | main.go:14:1:20:1 | function test2 |
+| main.go:34:2:34:6 | test1 | main.go:3:6:3:10 | function test1 |
+| main.go:34:8:34:12 | test2 | main.go:14:6:14:10 | function test2 |
+| main.go:34:19:34:23 | test2 | main.go:14:6:14:10 | function test2 |
 | strings.go:8:12:8:12 | argument corresponding to s | strings.go:8:12:8:12 | definition of s |
 | strings.go:8:12:8:12 | definition of s | strings.go:9:24:9:24 | s |
 | strings.go:8:12:8:12 | definition of s | strings.go:10:27:10:27 | s |

--- a/ql/test/library-tests/semmle/go/dataflow/SSA/DefUse.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/SSA/DefUse.expected
@@ -1,30 +1,30 @@
-| main.go:15:12:15:12 | x | main.go:13:6:13:6 | definition of x | x |
-| main.go:15:15:15:15 | y | main.go:14:2:14:2 | definition of y | y |
-| main.go:17:3:17:3 | y | main.go:14:2:14:2 | definition of y | y |
-| main.go:19:12:19:12 | x | main.go:13:6:13:6 | definition of x | x |
-| main.go:19:15:19:15 | y | main.go:19:2:19:2 | y = phi(def@14:2, def@17:3) | y |
-| main.go:21:7:21:7 | y | main.go:19:2:19:2 | y = phi(def@14:2, def@17:3) | y |
-| main.go:23:12:23:12 | x | main.go:23:2:23:2 | x = phi(def@13:6, def@21:3) | x |
-| main.go:23:15:23:15 | y | main.go:19:2:19:2 | y = phi(def@14:2, def@17:3) | y |
-| main.go:27:10:27:10 | x | main.go:26:10:26:10 | definition of x | x |
-| main.go:29:10:29:10 | b | main.go:27:5:27:5 | definition of b | b |
-| main.go:29:13:29:13 | a | main.go:27:2:27:2 | definition of a | a |
-| main.go:31:9:31:9 | a | main.go:31:9:31:9 | a = phi(def@27:2, def@29:3) | a |
-| main.go:31:12:31:12 | b | main.go:31:9:31:9 | b = phi(def@27:5, def@29:6) | b |
-| main.go:35:3:35:3 | x | main.go:34:11:34:11 | definition of x | x |
-| main.go:40:10:40:10 | x | main.go:39:2:39:2 | definition of x | x |
-| main.go:42:8:42:10 | ptr | main.go:40:2:40:4 | definition of ptr | ptr |
-| main.go:44:12:44:12 | x | main.go:39:2:39:2 | definition of x | x |
-| main.go:47:13:47:18 | implicit read of result | main.go:48:2:48:7 | definition of result | result |
-| main.go:52:14:52:19 | implicit read of result | main.go:52:14:52:19 | definition of result | result |
-| main.go:61:12:61:12 | x | main.go:58:6:58:6 | x = phi(def@57:6, def@59:3) | x |
-| main.go:64:16:64:16 | i | main.go:65:6:65:6 | i = phi(def@64:16, def@64:6) | i |
-| main.go:70:12:70:12 | y | main.go:65:6:65:6 | y = phi(def@63:2, def@68:3) | y |
-| main.go:73:16:73:16 | i | main.go:74:3:74:3 | i = phi(def@73:16, def@73:6) | i |
-| main.go:79:12:79:12 | z | main.go:74:3:74:3 | definition of z | z |
-| main.go:82:18:82:18 | implicit read of a | main.go:84:5:84:5 | definition of a | a |
-| main.go:82:25:82:25 | implicit read of b | main.go:82:25:82:25 | definition of b | b |
-| main.go:84:9:84:9 | x | main.go:83:2:83:2 | definition of x | x |
-| main.go:84:15:84:15 | x | main.go:83:2:83:2 | definition of x | x |
-| main.go:94:2:94:8 | wrapper | main.go:92:22:92:28 | definition of wrapper | wrapper |
-| main.go:97:9:97:9 | x | main.go:94:2:96:3 | capture variable x | x |
+| main.go:15:12:15:12 | x | main.go:13:6:13:6 | definition of x | main.go:13:6:13:6 | x |
+| main.go:15:15:15:15 | y | main.go:14:2:14:2 | definition of y | main.go:14:2:14:2 | y |
+| main.go:17:3:17:3 | y | main.go:14:2:14:2 | definition of y | main.go:14:2:14:2 | y |
+| main.go:19:12:19:12 | x | main.go:13:6:13:6 | definition of x | main.go:13:6:13:6 | x |
+| main.go:19:15:19:15 | y | main.go:19:2:19:2 | y = phi(def@14:2, def@17:3) | main.go:14:2:14:2 | y |
+| main.go:21:7:21:7 | y | main.go:19:2:19:2 | y = phi(def@14:2, def@17:3) | main.go:14:2:14:2 | y |
+| main.go:23:12:23:12 | x | main.go:23:2:23:2 | x = phi(def@13:6, def@21:3) | main.go:13:6:13:6 | x |
+| main.go:23:15:23:15 | y | main.go:19:2:19:2 | y = phi(def@14:2, def@17:3) | main.go:14:2:14:2 | y |
+| main.go:27:10:27:10 | x | main.go:26:10:26:10 | definition of x | main.go:26:10:26:10 | x |
+| main.go:29:10:29:10 | b | main.go:27:5:27:5 | definition of b | main.go:27:5:27:5 | b |
+| main.go:29:13:29:13 | a | main.go:27:2:27:2 | definition of a | main.go:27:2:27:2 | a |
+| main.go:31:9:31:9 | a | main.go:31:9:31:9 | a = phi(def@27:2, def@29:3) | main.go:27:2:27:2 | a |
+| main.go:31:12:31:12 | b | main.go:31:9:31:9 | b = phi(def@27:5, def@29:6) | main.go:27:5:27:5 | b |
+| main.go:35:3:35:3 | x | main.go:34:11:34:11 | definition of x | main.go:34:11:34:11 | x |
+| main.go:40:10:40:10 | x | main.go:39:2:39:2 | definition of x | main.go:39:2:39:2 | x |
+| main.go:42:8:42:10 | ptr | main.go:40:2:40:4 | definition of ptr | main.go:40:2:40:4 | ptr |
+| main.go:44:12:44:12 | x | main.go:39:2:39:2 | definition of x | main.go:39:2:39:2 | x |
+| main.go:47:13:47:18 | implicit read of result | main.go:48:2:48:7 | definition of result | main.go:47:13:47:18 | result |
+| main.go:52:14:52:19 | implicit read of result | main.go:52:14:52:19 | definition of result | main.go:52:14:52:19 | result |
+| main.go:61:12:61:12 | x | main.go:58:6:58:6 | x = phi(def@57:6, def@59:3) | main.go:57:6:57:6 | x |
+| main.go:64:16:64:16 | i | main.go:65:6:65:6 | i = phi(def@64:16, def@64:6) | main.go:64:6:64:6 | i |
+| main.go:70:12:70:12 | y | main.go:65:6:65:6 | y = phi(def@63:2, def@68:3) | main.go:63:2:63:2 | y |
+| main.go:73:16:73:16 | i | main.go:74:3:74:3 | i = phi(def@73:16, def@73:6) | main.go:73:6:73:6 | i |
+| main.go:79:12:79:12 | z | main.go:74:3:74:3 | definition of z | main.go:72:2:72:2 | z |
+| main.go:82:18:82:18 | implicit read of a | main.go:84:5:84:5 | definition of a | main.go:82:18:82:18 | a |
+| main.go:82:25:82:25 | implicit read of b | main.go:82:25:82:25 | definition of b | main.go:82:25:82:25 | b |
+| main.go:84:9:84:9 | x | main.go:83:2:83:2 | definition of x | main.go:83:2:83:2 | x |
+| main.go:84:15:84:15 | x | main.go:83:2:83:2 | definition of x | main.go:83:2:83:2 | x |
+| main.go:94:2:94:8 | wrapper | main.go:92:22:92:28 | definition of wrapper | main.go:92:22:92:28 | wrapper |
+| main.go:97:9:97:9 | x | main.go:94:2:96:3 | capture variable x | main.go:93:2:93:2 | x |

--- a/ql/test/library-tests/semmle/go/dataflow/SSA/VarDefs.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/SSA/VarDefs.expected
@@ -1,34 +1,34 @@
-| main.go:13:6:13:6 | assignment to x | x | main.go:13:6:13:6 | zero value for x |
-| main.go:14:2:14:2 | assignment to y | y | main.go:14:7:14:8 | 23 |
-| main.go:17:3:17:3 | assignment to y | y | main.go:17:3:17:9 | ... += ... |
-| main.go:21:3:21:3 | assignment to x | x | main.go:21:7:21:7 | y |
-| main.go:26:10:26:10 | initialization of x | x | main.go:26:10:26:10 | argument corresponding to x |
-| main.go:27:2:27:2 | assignment to a | a | main.go:27:10:27:10 | x |
-| main.go:27:5:27:5 | assignment to b | b | main.go:27:13:27:13 | 0 |
-| main.go:29:3:29:3 | assignment to a | a | main.go:29:10:29:10 | b |
-| main.go:29:6:29:6 | assignment to b | b | main.go:29:13:29:13 | a |
-| main.go:34:11:34:11 | initialization of x | x | main.go:34:11:34:11 | argument corresponding to x |
-| main.go:39:2:39:2 | assignment to x | x | main.go:39:7:39:8 | 23 |
-| main.go:40:2:40:4 | assignment to ptr | ptr | main.go:40:9:40:10 | &... |
-| main.go:47:13:47:18 | initialization of result | result | main.go:47:13:47:18 | zero value for result |
-| main.go:48:2:48:7 | assignment to result | result | main.go:48:11:48:12 | 42 |
-| main.go:52:14:52:19 | initialization of result | result | main.go:52:14:52:19 | zero value for result |
-| main.go:57:6:57:6 | assignment to x | x | main.go:57:6:57:6 | zero value for x |
-| main.go:59:3:59:3 | assignment to x | x | main.go:59:7:59:7 | 2 |
-| main.go:63:2:63:2 | assignment to y | y | main.go:63:7:63:7 | 1 |
-| main.go:64:6:64:6 | assignment to i | i | main.go:64:11:64:11 | 0 |
-| main.go:64:16:64:18 | increment statement | i | main.go:64:16:64:18 | rhs of increment statement |
-| main.go:68:3:68:3 | assignment to y | y | main.go:68:7:68:7 | 2 |
-| main.go:72:2:72:2 | assignment to z | z | main.go:72:7:72:7 | 1 |
-| main.go:73:6:73:6 | assignment to i | i | main.go:73:11:73:11 | 0 |
-| main.go:73:16:73:18 | increment statement | i | main.go:73:16:73:18 | rhs of increment statement |
-| main.go:74:3:74:3 | assignment to z | z | main.go:74:7:74:7 | 2 |
-| main.go:82:18:82:18 | initialization of a | a | main.go:82:18:82:18 | zero value for a |
-| main.go:82:25:82:25 | initialization of b | b | main.go:82:25:82:25 | zero value for b |
-| main.go:83:2:83:2 | assignment to x | x | main.go:83:7:83:8 | 23 |
-| main.go:84:2:84:2 | assignment to x | x | main.go:84:9:84:12 | ...+... |
-| main.go:84:5:84:5 | assignment to a | a | main.go:84:15:84:15 | x |
-| main.go:90:15:90:16 | initialization of cb | cb | main.go:90:15:90:16 | argument corresponding to cb |
-| main.go:92:22:92:28 | initialization of wrapper | wrapper | main.go:92:22:92:28 | argument corresponding to wrapper |
-| main.go:93:2:93:2 | assignment to x | x | main.go:93:7:93:7 | 0 |
-| main.go:95:3:95:3 | assignment to x | x | main.go:95:7:95:7 | 1 |
+| main.go:13:6:13:6 | assignment to x | main.go:13:6:13:6 | x | main.go:13:6:13:6 | zero value for x |
+| main.go:14:2:14:2 | assignment to y | main.go:14:2:14:2 | y | main.go:14:7:14:8 | 23 |
+| main.go:17:3:17:3 | assignment to y | main.go:14:2:14:2 | y | main.go:17:3:17:9 | ... += ... |
+| main.go:21:3:21:3 | assignment to x | main.go:13:6:13:6 | x | main.go:21:7:21:7 | y |
+| main.go:26:10:26:10 | initialization of x | main.go:26:10:26:10 | x | main.go:26:10:26:10 | argument corresponding to x |
+| main.go:27:2:27:2 | assignment to a | main.go:27:2:27:2 | a | main.go:27:10:27:10 | x |
+| main.go:27:5:27:5 | assignment to b | main.go:27:5:27:5 | b | main.go:27:13:27:13 | 0 |
+| main.go:29:3:29:3 | assignment to a | main.go:27:2:27:2 | a | main.go:29:10:29:10 | b |
+| main.go:29:6:29:6 | assignment to b | main.go:27:5:27:5 | b | main.go:29:13:29:13 | a |
+| main.go:34:11:34:11 | initialization of x | main.go:34:11:34:11 | x | main.go:34:11:34:11 | argument corresponding to x |
+| main.go:39:2:39:2 | assignment to x | main.go:39:2:39:2 | x | main.go:39:7:39:8 | 23 |
+| main.go:40:2:40:4 | assignment to ptr | main.go:40:2:40:4 | ptr | main.go:40:9:40:10 | &... |
+| main.go:47:13:47:18 | initialization of result | main.go:47:13:47:18 | result | main.go:47:13:47:18 | zero value for result |
+| main.go:48:2:48:7 | assignment to result | main.go:47:13:47:18 | result | main.go:48:11:48:12 | 42 |
+| main.go:52:14:52:19 | initialization of result | main.go:52:14:52:19 | result | main.go:52:14:52:19 | zero value for result |
+| main.go:57:6:57:6 | assignment to x | main.go:57:6:57:6 | x | main.go:57:6:57:6 | zero value for x |
+| main.go:59:3:59:3 | assignment to x | main.go:57:6:57:6 | x | main.go:59:7:59:7 | 2 |
+| main.go:63:2:63:2 | assignment to y | main.go:63:2:63:2 | y | main.go:63:7:63:7 | 1 |
+| main.go:64:6:64:6 | assignment to i | main.go:64:6:64:6 | i | main.go:64:11:64:11 | 0 |
+| main.go:64:16:64:18 | increment statement | main.go:64:6:64:6 | i | main.go:64:16:64:18 | rhs of increment statement |
+| main.go:68:3:68:3 | assignment to y | main.go:63:2:63:2 | y | main.go:68:7:68:7 | 2 |
+| main.go:72:2:72:2 | assignment to z | main.go:72:2:72:2 | z | main.go:72:7:72:7 | 1 |
+| main.go:73:6:73:6 | assignment to i | main.go:73:6:73:6 | i | main.go:73:11:73:11 | 0 |
+| main.go:73:16:73:18 | increment statement | main.go:73:6:73:6 | i | main.go:73:16:73:18 | rhs of increment statement |
+| main.go:74:3:74:3 | assignment to z | main.go:72:2:72:2 | z | main.go:74:7:74:7 | 2 |
+| main.go:82:18:82:18 | initialization of a | main.go:82:18:82:18 | a | main.go:82:18:82:18 | zero value for a |
+| main.go:82:25:82:25 | initialization of b | main.go:82:25:82:25 | b | main.go:82:25:82:25 | zero value for b |
+| main.go:83:2:83:2 | assignment to x | main.go:83:2:83:2 | x | main.go:83:7:83:8 | 23 |
+| main.go:84:2:84:2 | assignment to x | main.go:83:2:83:2 | x | main.go:84:9:84:12 | ...+... |
+| main.go:84:5:84:5 | assignment to a | main.go:82:18:82:18 | a | main.go:84:15:84:15 | x |
+| main.go:90:15:90:16 | initialization of cb | main.go:90:15:90:16 | cb | main.go:90:15:90:16 | argument corresponding to cb |
+| main.go:92:22:92:28 | initialization of wrapper | main.go:92:22:92:28 | wrapper | main.go:92:22:92:28 | argument corresponding to wrapper |
+| main.go:93:2:93:2 | assignment to x | main.go:93:2:93:2 | x | main.go:93:7:93:7 | 0 |
+| main.go:95:3:95:3 | assignment to x | main.go:93:2:93:2 | x | main.go:95:7:95:7 | 1 |

--- a/ql/test/library-tests/semmle/go/dataflow/SSA/VarUses.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/SSA/VarUses.expected
@@ -1,31 +1,31 @@
-| main.go:15:12:15:12 | x | x |
-| main.go:15:15:15:15 | y | y |
-| main.go:17:3:17:3 | y | y |
-| main.go:19:12:19:12 | x | x |
-| main.go:19:15:19:15 | y | y |
-| main.go:21:7:21:7 | y | y |
-| main.go:23:12:23:12 | x | x |
-| main.go:23:15:23:15 | y | y |
-| main.go:27:10:27:10 | x | x |
-| main.go:29:10:29:10 | b | b |
-| main.go:29:13:29:13 | a | a |
-| main.go:31:9:31:9 | a | a |
-| main.go:31:12:31:12 | b | b |
-| main.go:35:3:35:3 | x | x |
-| main.go:40:10:40:10 | x | x |
-| main.go:42:8:42:10 | ptr | ptr |
-| main.go:44:12:44:12 | x | x |
-| main.go:47:13:47:18 | implicit read of result | result |
-| main.go:52:14:52:19 | implicit read of result | result |
-| main.go:61:12:61:12 | x | x |
-| main.go:64:16:64:16 | i | i |
-| main.go:70:12:70:12 | y | y |
-| main.go:73:16:73:16 | i | i |
-| main.go:79:12:79:12 | z | z |
-| main.go:82:18:82:18 | implicit read of a | a |
-| main.go:82:25:82:25 | implicit read of b | b |
-| main.go:84:9:84:9 | x | x |
-| main.go:84:15:84:15 | x | x |
-| main.go:94:2:94:8 | wrapper | wrapper |
-| main.go:94:2:94:10 | selection of s | s |
-| main.go:97:9:97:9 | x | x |
+| main.go:15:12:15:12 | x | main.go:13:6:13:6 | x |
+| main.go:15:15:15:15 | y | main.go:14:2:14:2 | y |
+| main.go:17:3:17:3 | y | main.go:14:2:14:2 | y |
+| main.go:19:12:19:12 | x | main.go:13:6:13:6 | x |
+| main.go:19:15:19:15 | y | main.go:14:2:14:2 | y |
+| main.go:21:7:21:7 | y | main.go:14:2:14:2 | y |
+| main.go:23:12:23:12 | x | main.go:13:6:13:6 | x |
+| main.go:23:15:23:15 | y | main.go:14:2:14:2 | y |
+| main.go:27:10:27:10 | x | main.go:26:10:26:10 | x |
+| main.go:29:10:29:10 | b | main.go:27:5:27:5 | b |
+| main.go:29:13:29:13 | a | main.go:27:2:27:2 | a |
+| main.go:31:9:31:9 | a | main.go:27:2:27:2 | a |
+| main.go:31:12:31:12 | b | main.go:27:5:27:5 | b |
+| main.go:35:3:35:3 | x | main.go:34:11:34:11 | x |
+| main.go:40:10:40:10 | x | main.go:39:2:39:2 | x |
+| main.go:42:8:42:10 | ptr | main.go:40:2:40:4 | ptr |
+| main.go:44:12:44:12 | x | main.go:39:2:39:2 | x |
+| main.go:47:13:47:18 | implicit read of result | main.go:47:13:47:18 | result |
+| main.go:52:14:52:19 | implicit read of result | main.go:52:14:52:19 | result |
+| main.go:61:12:61:12 | x | main.go:57:6:57:6 | x |
+| main.go:64:16:64:16 | i | main.go:64:6:64:6 | i |
+| main.go:70:12:70:12 | y | main.go:63:2:63:2 | y |
+| main.go:73:16:73:16 | i | main.go:73:6:73:6 | i |
+| main.go:79:12:79:12 | z | main.go:72:2:72:2 | z |
+| main.go:82:18:82:18 | implicit read of a | main.go:82:18:82:18 | a |
+| main.go:82:25:82:25 | implicit read of b | main.go:82:25:82:25 | b |
+| main.go:84:9:84:9 | x | main.go:83:2:83:2 | x |
+| main.go:84:15:84:15 | x | main.go:83:2:83:2 | x |
+| main.go:94:2:94:8 | wrapper | main.go:92:22:92:28 | wrapper |
+| main.go:94:2:94:10 | selection of s | main.go:92:38:92:38 | s |
+| main.go:97:9:97:9 | x | main.go:93:2:93:2 | x |


### PR DESCRIPTION
Five unrelated fixes, one per commit:

  - Remove `DeclaredEntity.getDecl()`, which is an unfortunate almost-clash with `Entity.getDeclaration()` but means something different.
  - Entities now have locations, so you can click on them in the IDE if they have a declaration. If they don't, the location is a dummy location that isn't clickable. (This commit unfortunately leads to many unwieldy `.expected` diffs.)
  - `Location.toString()` now agrees with the format qltest produces.
  - `Field` is now a subtype of `Variable` in QL, which it already was in the dbscheme.
  - There is now a utility predicate `Field.hasQualifiedName` analogous to `Method.hasQualifiedName`.

Dist-compare didn't show any differences in performance or results.