### PR TITLE
Sharpen the sources for `StringBreak`.

### DIFF
--- a/ql/src/semmle/go/security/StringBreakCustomizations.qll
+++ b/ql/src/semmle/go/security/StringBreakCustomizations.qll
@@ -49,7 +49,8 @@ module StringBreak {
   class JsonMarshalAsSource extends Source {
     JsonMarshalAsSource() {
       exists(Function jsonMarshal | jsonMarshal.hasQualifiedName("encoding/json", "Marshal") |
-        this = jsonMarshal.getACall()
+        // we are only interested in the first result (the second result is an error)
+        this = DataFlow::extractTupleElement(jsonMarshal.getACall(), 0)
       )
     }
   }

--- a/ql/test/query-tests/Security/CWE-089/StringBreak.expected
+++ b/ql/test/query-tests/Security/CWE-089/StringBreak.expected
@@ -1,7 +1,7 @@
 edges
-| StringBreak.go:10:20:10:40 | call to Marshal : tuple type | StringBreak.go:14:47:14:57 | versionJSON |
+| StringBreak.go:10:2:10:40 | ... := ...[0] : slice type | StringBreak.go:14:47:14:57 | versionJSON |
 nodes
-| StringBreak.go:10:20:10:40 | call to Marshal : tuple type | semmle.label | call to Marshal : tuple type |
+| StringBreak.go:10:2:10:40 | ... := ...[0] : slice type | semmle.label | ... := ...[0] : slice type |
 | StringBreak.go:14:47:14:57 | versionJSON | semmle.label | versionJSON |
 #select
-| StringBreak.go:14:47:14:57 | versionJSON | StringBreak.go:10:20:10:40 | call to Marshal : tuple type | StringBreak.go:14:47:14:57 | versionJSON | If this $@ contains a single quote, it could break out of the enclosing quotes. | StringBreak.go:10:20:10:40 | call to Marshal | JSON value |
+| StringBreak.go:14:47:14:57 | versionJSON | StringBreak.go:10:2:10:40 | ... := ...[0] : slice type | StringBreak.go:14:47:14:57 | versionJSON | If this $@ contains a single quote, it could break out of the enclosing quotes. | StringBreak.go:10:2:10:40 | ... := ...[0] | JSON value |

--- a/ql/test/query-tests/Security/CWE-089/tst.go
+++ b/ql/test/query-tests/Security/CWE-089/tst.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func marshal(version interface{}) string {
+	versionJSON, err := json.Marshal(version)
+	if err != nil {
+		return fmt.Sprintf("error: '%v'", err) // OK
+	}
+	return versionJSON
+}


### PR DESCRIPTION
`json.Marshal` returns two results, we only want to consider the first one as a source.

I have verified that we still flag the CVE I initially wrote this query for.