### PR TITLE
Port recent data-flow improvements

### DIFF
--- a/ql/src/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -259,44 +259,47 @@ private ReturnPosition viableReturnPos(DataFlowCall call, ReturnKindExt kind) {
 
 /**
  * Holds if `node` is reachable from a source in the given configuration
- * ignoring call contexts.
+ * taking simple call contexts into consideration.
  */
-private predicate nodeCandFwd1(Node node, Configuration config) {
+private predicate nodeCandFwd1(Node node, boolean fromArg, Configuration config) {
   not fullBarrier(node, config) and
   (
-    config.isSource(node)
+    config.isSource(node) and
+    fromArg = false
     or
     exists(Node mid |
-      nodeCandFwd1(mid, config) and
+      nodeCandFwd1(mid, fromArg, config) and
       localFlowStep(mid, node, config)
     )
     or
     exists(Node mid |
-      nodeCandFwd1(mid, config) and
+      nodeCandFwd1(mid, fromArg, config) and
       additionalLocalFlowStep(mid, node, config)
     )
     or
     exists(Node mid |
       nodeCandFwd1(mid, config) and
-      jumpStep(mid, node, config)
+      jumpStep(mid, node, config) and
+      fromArg = false
     )
     or
     exists(Node mid |
       nodeCandFwd1(mid, config) and
-      additionalJumpStep(mid, node, config)
+      additionalJumpStep(mid, node, config) and
+      fromArg = false
     )
     or
     // store
     exists(Node mid |
       useFieldFlow(config) and
-      nodeCandFwd1(mid, config) and
+      nodeCandFwd1(mid, fromArg, config) and
       storeDirect(mid, _, node) and
       not outBarrier(mid, config)
     )
     or
     // read
     exists(Content f |
-      nodeCandFwd1Read(f, node, config) and
+      nodeCandFwd1Read(f, node, fromArg, config) and
       storeCandFwd1(f, config) and
       not inBarrier(node, config)
     )
@@ -304,30 +307,37 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     // flow into a callable
     exists(Node arg |
       nodeCandFwd1(arg, config) and
-      viableParamArg(_, node, arg)
+      viableParamArg(_, node, arg) and
+      fromArg = true
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
-      nodeCandFwd1ReturnPosition(pos, config) and
-      pos = viableReturnPos(call, kind) and
-      node = kind.getAnOutNode(call)
+    exists(DataFlowCall call |
+      nodeCandFwd1Out(call, node, false, config) and
+      fromArg = false
+      or
+      nodeCandFwd1OutFromArg(call, node, config) and
+      flowOutCandFwd1(call, fromArg, config)
     )
   )
 }
 
-pragma[noinline]
-private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+private predicate nodeCandFwd1(Node node, Configuration config) { nodeCandFwd1(node, _, config) }
+
+pragma[nomagic]
+private predicate nodeCandFwd1ReturnPosition(
+  ReturnPosition pos, boolean fromArg, Configuration config
+) {
   exists(ReturnNodeExt ret |
-    nodeCandFwd1(ret, config) and
+    nodeCandFwd1(ret, fromArg, config) and
     getReturnPosition(ret) = pos
   )
 }
 
 pragma[nomagic]
-private predicate nodeCandFwd1Read(Content f, Node node, Configuration config) {
+private predicate nodeCandFwd1Read(Content f, Node node, boolean fromArg, Configuration config) {
   exists(Node mid |
-    nodeCandFwd1(mid, config) and
+    nodeCandFwd1(mid, fromArg, config) and
     readDirect(mid, f, node)
   )
 }
@@ -335,7 +345,7 @@ private predicate nodeCandFwd1Read(Content f, Node node, Configuration config) {
 /**
  * Holds if `f` is the target of a store in the flow covered by `nodeCandFwd1`.
  */
-pragma[noinline]
+pragma[nomagic]
 private predicate storeCandFwd1(Content f, Configuration config) {
   exists(Node mid, Node node |
     not fullBarrier(node, config) and
@@ -345,71 +355,120 @@ private predicate storeCandFwd1(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
+private predicate nodeCandFwd1ReturnKind(
+  DataFlowCall call, ReturnKindExt kind, boolean fromArg, Configuration config
+) {
+  exists(ReturnPosition pos |
+    nodeCandFwd1ReturnPosition(pos, fromArg, config) and
+    pos = viableReturnPos(call, kind)
+  )
+}
+
+pragma[nomagic]
+private predicate nodeCandFwd1Out(
+  DataFlowCall call, Node node, boolean fromArg, Configuration config
+) {
+  exists(ReturnKindExt kind |
+    nodeCandFwd1ReturnKind(call, kind, fromArg, config) and
+    node = kind.getAnOutNode(call)
+  )
+}
+
+pragma[nomagic]
+private predicate nodeCandFwd1OutFromArg(DataFlowCall call, Node node, Configuration config) {
+  nodeCandFwd1Out(call, node, true, config)
+}
+
+/**
+ * Holds if an argument to `call` is reached in the flow covered by `nodeCandFwd1`.
+ */
+pragma[nomagic]
+private predicate flowOutCandFwd1(DataFlowCall call, boolean fromArg, Configuration config) {
+  exists(ArgumentNode arg |
+    nodeCandFwd1(arg, fromArg, config) and
+    viableParamArg(call, _, arg)
+  )
+}
+
 bindingset[result, b]
 private boolean unbindBool(boolean b) { result != b.booleanNot() }
 
 /**
  * Holds if `node` is part of a path from a source to a sink in the given
- * configuration ignoring call contexts.
+ * configuration taking simple call contexts into consideration.
  */
 pragma[nomagic]
-private predicate nodeCand1(Node node, Configuration config) {
+private predicate nodeCand1(Node node, boolean toReturn, Configuration config) {
+  nodeCand1_0(node, toReturn, config) and
+  nodeCandFwd1(node, config)
+}
+
+pragma[nomagic]
+private predicate nodeCand1_0(Node node, boolean toReturn, Configuration config) {
   nodeCandFwd1(node, config) and
-  config.isSink(node)
+  config.isSink(node) and
+  toReturn = false
   or
-  nodeCandFwd1(node, unbind(config)) and
-  (
-    exists(Node mid |
-      localFlowStep(node, mid, config) and
-      nodeCand1(mid, config)
-    )
+  exists(Node mid |
+    localFlowStep(node, mid, config) and
+    nodeCand1(mid, toReturn, config)
+  )
+  or
+  exists(Node mid |
+    additionalLocalFlowStep(node, mid, config) and
+    nodeCand1(mid, toReturn, config)
+  )
+  or
+  exists(Node mid |
+    jumpStep(node, mid, config) and
+    nodeCand1(mid, _, config) and
+    toReturn = false
+  )
+  or
+  exists(Node mid |
+    additionalJumpStep(node, mid, config) and
+    nodeCand1(mid, _, config) and
+    toReturn = false
+  )
+  or
+  // store
+  exists(Content f |
+    nodeCand1Store(f, node, toReturn, config) and
+    readCand1(f, config)
+  )
+  or
+  // read
+  exists(Node mid, Content f |
+    readDirect(node, f, mid) and
+    storeCandFwd1(f, unbind(config)) and
+    nodeCand1(mid, toReturn, config)
+  )
+  or
+  // flow into a callable
+  exists(DataFlowCall call |
+    nodeCand1Arg(call, node, false, config) and
+    toReturn = false
     or
-    exists(Node mid |
-      additionalLocalFlowStep(node, mid, config) and
-      nodeCand1(mid, config)
-    )
-    or
-    exists(Node mid |
-      jumpStep(node, mid, config) and
-      nodeCand1(mid, config)
-    )
-    or
-    exists(Node mid |
-      additionalJumpStep(node, mid, config) and
-      nodeCand1(mid, config)
-    )
-    or
-    // store
-    exists(Content f |
-      nodeCand1Store(f, node, config) and
-      readCand1(f, config)
-    )
-    or
-    // read
-    exists(Node mid, Content f |
-      readDirect(node, f, mid) and
-      storeCandFwd1(f, unbind(config)) and
-      nodeCand1(mid, config)
-    )
-    or
-    // flow into a callable
-    exists(Node param |
-      viableParamArg(_, param, node) and
-      nodeCand1(param, config)
-    )
-    or
-    // flow out of a callable
-    exists(ReturnPosition pos |
-      nodeCand1ReturnPosition(pos, config) and
-      getReturnPosition(node) = pos
-    )
+    nodeCand1ArgToReturn(call, node, config) and
+    flowInCand1(call, toReturn, config)
+  )
+  or
+  // flow out of a callable
+  exists(ReturnPosition pos |
+    nodeCand1ReturnPosition(pos, config) and
+    getReturnPosition(node) = pos and
+    toReturn = true
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
+private predicate nodeCand1(Node node, Configuration config) { nodeCand1(node, _, config) }
+
+pragma[nomagic]
 private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration config) {
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
-    nodeCand1(out, config) and
+    nodeCand1(out, _, config) and
     pos = viableReturnPos(call, kind) and
     out = kind.getAnOutNode(call)
   )
@@ -418,21 +477,21 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
 /**
  * Holds if `f` is the target of a read in the flow covered by `nodeCand1`.
  */
-pragma[noinline]
+pragma[nomagic]
 private predicate readCand1(Content f, Configuration config) {
   exists(Node mid, Node node |
     useFieldFlow(config) and
     nodeCandFwd1(node, unbind(config)) and
     readDirect(node, f, mid) and
     storeCandFwd1(f, unbind(config)) and
-    nodeCand1(mid, config)
+    nodeCand1(mid, _, config)
   )
 }
 
 pragma[nomagic]
-private predicate nodeCand1Store(Content f, Node node, Configuration config) {
+private predicate nodeCand1Store(Content f, Node node, boolean toReturn, Configuration config) {
   exists(Node mid |
-    nodeCand1(mid, config) and
+    nodeCand1(mid, toReturn, config) and
     storeCandFwd1(f, unbind(config)) and
     storeDirect(node, f, mid)
   )
@@ -444,11 +503,45 @@ private predicate nodeCand1Store(Content f, Node node, Configuration config) {
  */
 private predicate readStoreCand1(Content f, Configuration conf) {
   readCand1(f, conf) and
-  nodeCand1Store(f, _, conf)
+  nodeCand1Store(f, _, _, conf)
+}
+
+pragma[nomagic]
+private predicate viableParamArgCandFwd1(
+  DataFlowCall call, ParameterNode p, ArgumentNode arg, Configuration config
+) {
+  viableParamArg(call, p, arg) and
+  nodeCandFwd1(arg, config)
+}
+
+pragma[nomagic]
+private predicate nodeCand1Arg(
+  DataFlowCall call, ArgumentNode arg, boolean toReturn, Configuration config
+) {
+  exists(ParameterNode p |
+    nodeCand1(p, toReturn, config) and
+    viableParamArgCandFwd1(call, p, arg, config)
+  )
+}
+
+pragma[nomagic]
+private predicate nodeCand1ArgToReturn(DataFlowCall call, ArgumentNode arg, Configuration config) {
+  nodeCand1Arg(call, arg, true, config)
+}
+
+/**
+ * Holds if an output from `call` is reached in the flow covered by `nodeCand1`.
+ */
+pragma[nomagic]
+private predicate flowInCand1(DataFlowCall call, boolean toReturn, Configuration config) {
+  exists(Node out |
+    nodeCand1(out, toReturn, config) and
+    nodeCandFwd1OutFromArg(call, out, config)
+  )
 }
 
 private predicate throughFlowNodeCand(Node node, Configuration config) {
-  nodeCand1(node, config) and
+  nodeCand1(node, true, config) and
   not fullBarrier(node, config) and
   not inBarrier(node, config) and
   not outBarrier(node, config)

--- a/ql/src/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -2041,12 +2041,12 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
     result = getSuccMid()
     or
     // a final step to a sink via zero steps means we merge the last two steps to prevent trivial-looking edges
-    exists(PathNodeMid mid |
+    exists(PathNodeMid mid, PathNodeSink sink |
       mid = getSuccMid() and
-      mid.getNode() = result.getNode() and
+      mid.getNode() = sink.getNode() and
       mid.getAp() instanceof AccessPathNil and
-      result instanceof PathNodeSink and
-      result.getConfiguration() = unbind(mid.getConfiguration())
+      sink.getConfiguration() = unbind(mid.getConfiguration()) and
+      result = sink
     )
   }
 

--- a/ql/src/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -2257,13 +2257,12 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
-    midnode = mid.getNode() and
-    conf = mid.getConfiguration() and
-    cc = mid.getCallContext() and
-    sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
-    ap0 = mid.getAp()
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
+    LocalCallContext localCC
+  |
+    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
+    localCC = getLocalCallContext(cc, enclosing)
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
@@ -2295,6 +2294,20 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
+}
+
+pragma[nomagic]
+private predicate pathIntoLocalStep(
+  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
+  AccessPath ap0, Configuration conf
+) {
+  midnode = mid.getNode() and
+  cc = mid.getCallContext() and
+  conf = mid.getConfiguration() and
+  localFlowBigStep(midnode, _, _, conf, _) and
+  enclosing = midnode.getEnclosingCallable() and
+  sc = mid.getSummaryCtx() and
+  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/ql/src/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -7,7 +7,7 @@
  * on each other without introducing mutual recursion among those configurations.
  */
 
-private import DataFlowImplCommon::Public
+private import DataFlowImplCommon
 private import DataFlowImplSpecific::Private
 import DataFlowImplSpecific::Public
 
@@ -290,7 +290,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(Node mid |
       useFieldFlow(config) and
       nodeCandFwd1(mid, config) and
-      store(mid, _, node) and
+      storeDirect(mid, _, node) and
       not outBarrier(mid, config)
     )
     or
@@ -328,7 +328,7 @@ pragma[nomagic]
 private predicate nodeCandFwd1Read(Content f, Node node, Configuration config) {
   exists(Node mid |
     nodeCandFwd1(mid, config) and
-    read(mid, f, node)
+    readDirect(mid, f, node)
   )
 }
 
@@ -341,7 +341,7 @@ private predicate storeCandFwd1(Content f, Configuration config) {
     not fullBarrier(node, config) and
     useFieldFlow(config) and
     nodeCandFwd1(mid, config) and
-    store(mid, f, node)
+    storeDirect(mid, f, node)
   )
 }
 
@@ -387,7 +387,7 @@ private predicate nodeCand1(Node node, Configuration config) {
     or
     // read
     exists(Node mid, Content f |
-      read(node, f, mid) and
+      readDirect(node, f, mid) and
       storeCandFwd1(f, unbind(config)) and
       nodeCand1(mid, config)
     )
@@ -423,7 +423,7 @@ private predicate readCand1(Content f, Configuration config) {
   exists(Node mid, Node node |
     useFieldFlow(config) and
     nodeCandFwd1(node, unbind(config)) and
-    read(node, f, mid) and
+    readDirect(node, f, mid) and
     storeCandFwd1(f, unbind(config)) and
     nodeCand1(mid, config)
   )
@@ -434,7 +434,7 @@ private predicate nodeCand1Store(Content f, Node node, Configuration config) {
   exists(Node mid |
     nodeCand1(mid, config) and
     storeCandFwd1(f, unbind(config)) and
-    store(node, f, mid)
+    storeDirect(node, f, mid)
   )
 }
 
@@ -480,6 +480,16 @@ private predicate parameterThroughFlowCand(ParameterNode p, Configuration config
   )
 }
 
+private predicate store(Node n1, Content f, Node n2) {
+  storeDirect(n1, f, n2) or
+  argumentValueFlowsThrough(_, n1, TContentNone(), TContentSome(f), n2)
+}
+
+private predicate read(Node n1, Content f, Node n2) {
+  readDirect(n1, f, n2) or
+  argumentValueFlowsThrough(_, n1, TContentSome(f), TContentNone(), n2)
+}
+
 /**
  * Holds if `p` can flow to `node` in the same callable with `summary`
  * representing the flow path. The type of the tracked object is `t2`, and if
@@ -493,7 +503,7 @@ private predicate parameterFlow(
 ) {
   parameterThroughFlowCand(p, config) and
   p = node and
-  t1 = getErasedNodeType(node) and
+  t1 = getErasedNodeTypeBound(node) and
   t1 = t2 and
   summary = TSummaryVal()
   or
@@ -502,21 +512,15 @@ private predicate parameterFlow(
     exists(Node mid |
       parameterFlow(p, mid, t1, t2, summary, config) and
       localFlowStep(mid, node, config) and
-      compatibleTypes(t2, getErasedNodeType(node))
+      compatibleTypes(t2, getErasedNodeTypeBound(node))
     )
     or
     exists(Node mid, Summary midsum |
       parameterFlow(p, mid, _, _, midsum, config) and
       additionalLocalFlowStep(mid, node, config) and
-      t1 = getErasedNodeType(node) and
+      t1 = getErasedNodeTypeBound(node) and
       t1 = t2 and
       summary = midsum.additionalStep()
-    )
-    or
-    exists(Node mid |
-      parameterFlow(p, mid, t1, t2, summary, config) and
-      localStoreReadStep(mid, node) and
-      compatibleTypes(t2, getErasedNodeType(node))
     )
     or
     // read step
@@ -542,8 +546,8 @@ private predicate parameterFlow(
     // value flow through a callable
     exists(Node arg |
       parameterFlow(p, arg, t1, t2, summary, config) and
-      argumentValueFlowsThrough(arg, node, _) and
-      compatibleTypes(t2, getErasedNodeType(node))
+      argumentValueFlowsThrough(_, arg, TContentNone(), TContentNone(), node) and
+      compatibleTypes(t2, getErasedNodeTypeBound(node))
     )
     or
     // flow through a callable
@@ -580,9 +584,9 @@ private predicate argumentFlowsThrough0(
   DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, DataFlowType t1, DataFlowType t2,
   Summary summary, Configuration config
 ) {
-  exists(ParameterNode p, ReturnNodeExt ret |
+  exists(ParameterNode p |
     viableParamArgCand(call, p, arg, config) and
-    parameterFlowReturn(p, ret, kind, t1, t2, summary, config)
+    parameterFlowReturn(p, _, kind, t1, t2, summary, config)
   )
 }
 
@@ -598,11 +602,138 @@ private predicate argumentFlowsThrough(
 ) {
   nodeCand1(out, unbind(config)) and
   not inBarrier(out, config) and
-  compatibleTypes(t2, getErasedNodeType(out)) and
+  compatibleTypes(t2, getErasedNodeTypeBound(out)) and
   exists(DataFlowCall call, ReturnKindExt kind |
     argumentFlowsThrough0(call, arg, kind, t1, t2, summary, config) and
     out = kind.getAnOutNode(call)
   )
+}
+
+private newtype TNodeExt =
+  TNormalNode(Node node) { nodeCand1(node, _) } or
+  TReadStoreNode(DataFlowCall call, Node node1, Node node2, Content f1, Content f2) {
+    exists(Configuration config |
+      nodeCand1(node1, config) and
+      argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
+    )
+  }
+
+/**
+ * An extended data flow node. Either a normal node, or an intermediate node
+ * used to split up a read+store step through a call into first a read step
+ * followed by a store step.
+ *
+ * This is purely an internal implementation detail.
+ */
+abstract private class NodeExt extends TNodeExt {
+  /** Gets the underlying (normal) node, if any. */
+  abstract Node getNode();
+
+  abstract DataFlowType getErasedNodeTypeBound();
+
+  abstract DataFlowCallable getEnclosingCallable();
+
+  abstract predicate isCand1(Configuration config);
+
+  abstract string toString();
+
+  abstract predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  );
+}
+
+/** A `Node` at which a cast can occur such that the type should be checked. */
+abstract private class CastingNodeExt extends NodeExt { }
+
+private class NormalNodeExt extends NodeExt, TNormalNode {
+  override Node getNode() { this = TNormalNode(result) }
+
+  override DataFlowType getErasedNodeTypeBound() {
+    result = getErasedRepr(this.getNode().getTypeBound())
+  }
+
+  override DataFlowCallable getEnclosingCallable() {
+    result = this.getNode().getEnclosingCallable()
+  }
+
+  override predicate isCand1(Configuration config) { nodeCand1(this.getNode(), config) }
+
+  override string toString() { result = this.getNode().toString() }
+
+  override predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    this.getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
+
+private class NormalCastingNodeExt extends CastingNodeExt, NormalNodeExt {
+  NormalCastingNodeExt() { this.getNode() instanceof CastingNode }
+}
+
+private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
+  private DataFlowCall call;
+  private Node node1;
+  private Node node2;
+  private Content f1;
+  private Content f2;
+
+  ReadStoreNodeExt() { this = TReadStoreNode(call, node1, node2, f1, f2) }
+
+  override Node getNode() { none() }
+
+  override DataFlowType getErasedNodeTypeBound() { result = f1.getType() }
+
+  override DataFlowCallable getEnclosingCallable() { result = node1.getEnclosingCallable() }
+
+  override predicate isCand1(Configuration config) {
+    nodeCand1(node1, config) and nodeCand1(node2, config)
+  }
+
+  override string toString() {
+    result = "(inside) " + call.toString() + " [" + f1 + " -> " + f2 + "]"
+  }
+
+  override predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    call.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
+
+pragma[nomagic]
+private predicate readExt(NodeExt node1, Content f, NodeExt node2) {
+  read(node1.getNode(), f, node2.getNode())
+  or
+  node2 = TReadStoreNode(_, node1.getNode(), _, f, _)
+}
+
+pragma[nomagic]
+private predicate storeExt(NodeExt node1, Content f, NodeExt node2) {
+  store(node1.getNode(), f, node2.getNode())
+  or
+  node1 = TReadStoreNode(_, _, node2.getNode(), _, f)
+}
+
+private predicate jumpStepExt(NodeExt node1, NodeExt node2, Configuration config) {
+  jumpStep(node1.getNode(), node2.getNode(), config)
+}
+
+private predicate additionalJumpStepExt(NodeExt node1, NodeExt node2, Configuration config) {
+  additionalJumpStep(node1.getNode(), node2.getNode(), config)
+}
+
+private predicate argumentValueFlowsThrough(NodeExt node1, NodeExt node2) {
+  argumentValueFlowsThrough(_, node1.getNode(), TContentNone(), TContentNone(), node2.getNode())
+}
+
+private predicate argumentFlowsThrough(
+  NodeExt arg, NodeExt out, Summary summary, Configuration config
+) {
+  argumentFlowsThrough(arg.getNode(), out.getNode(), _, _, summary, config)
 }
 
 /**
@@ -610,12 +741,19 @@ private predicate argumentFlowsThrough(
  * through a callable.
  */
 pragma[noinline]
-private predicate localFlowStepOrFlowThroughCallable(Node node1, Node node2, Configuration config) {
-  nodeCand1(node1, config) and
-  localFlowStep(node1, node2, config)
-  or
-  nodeCand1(node1, config) and
-  argumentValueFlowsThrough(node1, node2, _)
+private predicate localFlowStepOrFlowThroughCallable(
+  NodeExt node1, NodeExt node2, Configuration config
+) {
+  exists(Node n1, Node n2 |
+    n1 = node1.getNode() and
+    n2 = node2.getNode()
+  |
+    nodeCand1(n1, config) and
+    localFlowStep(n1, n2, config)
+    or
+    nodeCand1(n1, config) and
+    argumentValueFlowsThrough(_, n1, TContentNone(), TContentNone(), n2)
+  )
 }
 
 /**
@@ -625,16 +763,21 @@ private predicate localFlowStepOrFlowThroughCallable(Node node1, Node node2, Con
  */
 pragma[noinline]
 private predicate additionalLocalFlowStepOrFlowThroughCallable(
-  Node node1, Node node2, Configuration config
+  NodeExt node1, NodeExt node2, Configuration config
 ) {
-  nodeCand1(node1, config) and
-  additionalLocalFlowStep(node1, node2, config)
-  or
-  argumentFlowsThrough(node1, node2, _, _, TSummaryTaint(), config)
+  exists(Node n1, Node n2 |
+    n1 = node1.getNode() and
+    n2 = node2.getNode()
+  |
+    nodeCand1(n1, config) and
+    additionalLocalFlowStep(n1, n2, config)
+    or
+    argumentFlowsThrough(n1, n2, _, _, TSummaryTaint(), config)
+  )
 }
 
 pragma[noinline]
-private ReturnPosition getReturnPosition1(Node node, Configuration config) {
+private ReturnPosition getReturnPosition1(ReturnNodeExt node, Configuration config) {
   result = getReturnPosition(node) and
   nodeCand1(node, config)
 }
@@ -658,7 +801,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
  * Holds if data can flow into a callable and that this step is part of a
  * path from a source to a sink.
  */
-private predicate flowIntoCallable(Node node1, Node node2, Configuration config) {
+private predicate flowIntoCallable(ArgumentNode node1, ParameterNode node2, Configuration config) {
   viableParamArgCand(_, node2, node1, config)
 }
 
@@ -688,15 +831,19 @@ private int join(Node n2, Configuration conf) {
  * specified by the configuration.
  */
 private predicate flowOutOfCallable(
-  Node node1, Node node2, boolean allowsFieldFlow, Configuration config
+  NodeExt node1, NodeExt node2, boolean allowsFieldFlow, Configuration config
 ) {
-  flowOutOfCallable(node1, node2, config) and
-  exists(int b, int j |
-    b = branch(node1, config) and
-    j = join(node2, config) and
-    if b.minimum(j) <= config.fieldFlowBranchLimit()
-    then allowsFieldFlow = true
-    else allowsFieldFlow = false
+  exists(Node n1, Node n2 |
+    n1 = node1.getNode() and
+    n2 = node2.getNode() and
+    flowOutOfCallable(n1, n2, config) and
+    exists(int b, int j |
+      b = branch(n1, config) and
+      j = join(n2, config) and
+      if b.minimum(j) <= config.fieldFlowBranchLimit()
+      then allowsFieldFlow = true
+      else allowsFieldFlow = false
+    )
   )
 }
 
@@ -706,15 +853,19 @@ private predicate flowOutOfCallable(
  * the branching is within the limit specified by the configuration.
  */
 private predicate flowIntoCallable(
-  Node node1, Node node2, boolean allowsFieldFlow, Configuration config
+  NodeExt node1, NodeExt node2, boolean allowsFieldFlow, Configuration config
 ) {
-  flowIntoCallable(node1, node2, config) and
-  exists(int b, int j |
-    b = branch(node1, config) and
-    j = join(node2, config) and
-    if b.minimum(j) <= config.fieldFlowBranchLimit()
-    then allowsFieldFlow = true
-    else allowsFieldFlow = false
+  exists(Node n1, Node n2 |
+    n1 = node1.getNode() and
+    n2 = node2.getNode() and
+    flowIntoCallable(n1, n2, config) and
+    exists(int b, int j |
+      b = branch(n1, config) and
+      j = join(n2, config) and
+      if b.minimum(j) <= config.fieldFlowBranchLimit()
+      then allowsFieldFlow = true
+      else allowsFieldFlow = false
+    )
   )
 }
 
@@ -722,50 +873,50 @@ private predicate flowIntoCallable(
  * Holds if `node` is part of a path from a source to a sink in the given
  * configuration taking simple call contexts into consideration.
  */
-private predicate nodeCandFwd2(Node node, boolean fromArg, boolean stored, Configuration config) {
-  nodeCand1(node, config) and
-  config.isSource(node) and
+private predicate nodeCandFwd2(NodeExt node, boolean fromArg, boolean stored, Configuration config) {
+  nodeCand1(node.getNode(), config) and
+  config.isSource(node.getNode()) and
   fromArg = false and
   stored = false
   or
-  nodeCand1(node, unbind(config)) and
+  node.isCand1(unbind(config)) and
   (
-    exists(Node mid |
+    exists(NodeExt mid |
       nodeCandFwd2(mid, fromArg, stored, config) and
       localFlowStepOrFlowThroughCallable(mid, node, config)
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       nodeCandFwd2(mid, fromArg, stored, config) and
       additionalLocalFlowStepOrFlowThroughCallable(mid, node, config) and
       stored = false
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       nodeCandFwd2(mid, _, stored, config) and
-      jumpStep(mid, node, config) and
+      jumpStepExt(mid, node, config) and
       fromArg = false
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       nodeCandFwd2(mid, _, stored, config) and
-      additionalJumpStep(mid, node, config) and
+      additionalJumpStepExt(mid, node, config) and
       fromArg = false and
       stored = false
     )
     or
     // store
-    exists(Node mid, Content f |
+    exists(NodeExt mid, Content f |
       nodeCandFwd2(mid, fromArg, _, config) and
-      store(mid, f, node) and
+      storeExt(mid, f, node) and
       readStoreCand1(f, unbind(config)) and
       stored = true
     )
     or
     // taint store
-    exists(Node mid, Content f |
+    exists(NodeExt mid, Content f |
       nodeCandFwd2(mid, fromArg, false, config) and
-      argumentFlowsThrough(mid, node, _, _, TSummaryTaintStore(f), config) and
+      argumentFlowsThrough(mid, node, TSummaryTaintStore(f), config) and
       readStoreCand1(f, unbind(config)) and
       stored = true
     )
@@ -784,14 +935,14 @@ private predicate nodeCandFwd2(Node node, boolean fromArg, boolean stored, Confi
       stored = false
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       nodeCandFwd2(mid, _, stored, config) and
       flowIntoCallable(mid, node, allowsFieldFlow, config) and
       fromArg = true and
       (stored = false or allowsFieldFlow = true)
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       nodeCandFwd2(mid, false, stored, config) and
       flowOutOfCallable(mid, node, allowsFieldFlow, config) and
       fromArg = false and
@@ -805,35 +956,37 @@ private predicate nodeCandFwd2(Node node, boolean fromArg, boolean stored, Confi
  */
 pragma[noinline]
 private predicate storeCandFwd2(Content f, Configuration config) {
-  exists(Node mid, Node node |
+  exists(NodeExt mid, NodeExt node |
     useFieldFlow(config) and
-    nodeCand1(node, unbind(config)) and
+    node.isCand1(unbind(config)) and
     nodeCandFwd2(mid, _, _, config) and
-    store(mid, f, node) and
+    storeExt(mid, f, node) and
     readStoreCand1(f, unbind(config))
   )
 }
 
 pragma[nomagic]
-private predicate nodeCandFwd2Read(Content f, Node node, boolean fromArg, Configuration config) {
-  exists(Node mid |
+private predicate nodeCandFwd2Read(Content f, NodeExt node, boolean fromArg, Configuration config) {
+  exists(NodeExt mid |
     nodeCandFwd2(mid, fromArg, true, config) and
-    read(mid, f, node) and
+    readExt(mid, f, node) and
     readStoreCand1(f, unbind(config))
   )
 }
 
 pragma[nomagic]
-private predicate nodeCandFwd2ReadTaint(Content f, Node node, boolean fromArg, Configuration config) {
-  exists(Node mid |
+private predicate nodeCandFwd2ReadTaint(
+  Content f, NodeExt node, boolean fromArg, Configuration config
+) {
+  exists(NodeExt mid |
     nodeCandFwd2(mid, fromArg, true, config) and
-    argumentFlowsThrough(mid, node, _, _, TSummaryReadTaint(f), config) and
+    argumentFlowsThrough(mid, node, TSummaryReadTaint(f), config) and
     readStoreCand1(f, unbind(config))
   )
 }
 
 private predicate readCandFwd2(Content f, Configuration config) {
-  exists(Node node |
+  exists(NodeExt node |
     nodeCandFwd2Read(f, node, _, config) or
     nodeCandFwd2ReadTaint(f, node, _, config)
   |
@@ -853,8 +1006,8 @@ private predicate summaryFwd2(Summary s, Configuration config) {
   exists(Content f | s = TSummaryTaintStore(f) | readStoreCandFwd2(f, config))
 }
 
-private predicate argumentFlowsThroughFwd2(Node n1, Node n2, Summary s, Configuration config) {
-  argumentFlowsThrough(n1, n2, _, _, s, config) and
+private predicate argumentFlowsThroughFwd2(NodeExt n1, NodeExt n2, Summary s, Configuration config) {
+  argumentFlowsThrough(n1, n2, s, config) and
   nodeCandFwd2(n1, _, _, config) and
   nodeCandFwd2(n2, _, _, unbind(config)) and
   summaryFwd2(s, unbind(config))
@@ -864,33 +1017,33 @@ private predicate argumentFlowsThroughFwd2(Node n1, Node n2, Summary s, Configur
  * Holds if `node` is part of a path from a source to a sink in the given
  * configuration taking simple call contexts into consideration.
  */
-private predicate nodeCand2(Node node, boolean toReturn, boolean stored, Configuration config) {
+private predicate nodeCand2(NodeExt node, boolean toReturn, boolean stored, Configuration config) {
   nodeCandFwd2(node, _, false, config) and
-  config.isSink(node) and
+  config.isSink(node.getNode()) and
   toReturn = false and
   stored = false
   or
   nodeCandFwd2(node, _, unbindBool(stored), unbind(config)) and
   (
-    exists(Node mid |
+    exists(NodeExt mid |
       localFlowStepOrFlowThroughCallable(node, mid, config) and
       nodeCand2(mid, toReturn, stored, config)
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       additionalLocalFlowStepOrFlowThroughCallable(node, mid, config) and
       nodeCand2(mid, toReturn, stored, config) and
       stored = false
     )
     or
-    exists(Node mid |
-      jumpStep(node, mid, config) and
+    exists(NodeExt mid |
+      jumpStepExt(node, mid, config) and
       nodeCand2(mid, _, stored, config) and
       toReturn = false
     )
     or
-    exists(Node mid |
-      additionalJumpStep(node, mid, config) and
+    exists(NodeExt mid |
+      additionalJumpStepExt(node, mid, config) and
       nodeCand2(mid, _, stored, config) and
       toReturn = false and
       stored = false
@@ -911,29 +1064,29 @@ private predicate nodeCand2(Node node, boolean toReturn, boolean stored, Configu
     )
     or
     // read
-    exists(Node mid, Content f |
-      read(node, f, mid) and
+    exists(NodeExt mid, Content f |
+      readExt(node, f, mid) and
       storeCandFwd2(f, unbind(config)) and
       nodeCand2(mid, toReturn, _, config) and
       stored = true
     )
     or
     // read taint
-    exists(Node mid, Content f |
+    exists(NodeExt mid, Content f |
       argumentFlowsThroughFwd2(node, mid, TSummaryReadTaint(f), config) and
       storeCandFwd2(f, unbind(config)) and
       nodeCand2(mid, toReturn, false, config) and
       stored = true
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       flowIntoCallable(node, mid, allowsFieldFlow, config) and
       nodeCand2(mid, false, stored, config) and
       toReturn = false and
       (stored = false or allowsFieldFlow = true)
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       flowOutOfCallable(node, mid, allowsFieldFlow, config) and
       nodeCand2(mid, _, stored, config) and
       toReturn = true and
@@ -947,26 +1100,28 @@ private predicate nodeCand2(Node node, boolean toReturn, boolean stored, Configu
  */
 pragma[noinline]
 private predicate readCand2(Content f, Configuration config) {
-  exists(Node mid, Node node |
+  exists(NodeExt mid, NodeExt node |
     useFieldFlow(config) and
     nodeCandFwd2(node, _, true, unbind(config)) and
-    read(node, f, mid) and
+    readExt(node, f, mid) and
     storeCandFwd2(f, unbind(config)) and
     nodeCand2(mid, _, _, config)
   )
 }
 
 pragma[nomagic]
-private predicate nodeCand2Store(Content f, Node node, boolean toReturn, Configuration config) {
-  exists(Node mid |
-    store(node, f, mid) and
+private predicate nodeCand2Store(Content f, NodeExt node, boolean toReturn, Configuration config) {
+  exists(NodeExt mid |
+    storeExt(node, f, mid) and
     nodeCand2(mid, toReturn, true, config)
   )
 }
 
 pragma[nomagic]
-private predicate nodeCand2TaintStore(Content f, Node node, boolean toReturn, Configuration config) {
-  exists(Node mid |
+private predicate nodeCand2TaintStore(
+  Content f, NodeExt node, boolean toReturn, Configuration config
+) {
+  exists(NodeExt mid |
     argumentFlowsThroughFwd2(node, mid, TSummaryTaintStore(f), config) and
     nodeCand2(mid, toReturn, true, config)
   )
@@ -974,7 +1129,7 @@ private predicate nodeCand2TaintStore(Content f, Node node, boolean toReturn, Co
 
 pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
-  exists(Node node |
+  exists(NodeExt node |
     nodeCand2Store(f, node, _, conf) or
     nodeCand2TaintStore(f, node, _, conf)
   |
@@ -992,7 +1147,7 @@ private predicate readStoreCand(Content f, Configuration conf) {
   readCand2(f, conf)
 }
 
-private predicate nodeCand(Node node, Configuration config) { nodeCand2(node, _, _, config) }
+private predicate nodeCand(NodeExt node, Configuration config) { nodeCand2(node, _, _, config) }
 
 private predicate summary2(Summary s, Configuration config) {
   s = TSummaryTaint()
@@ -1003,9 +1158,9 @@ private predicate summary2(Summary s, Configuration config) {
 }
 
 private predicate argumentFlowsThrough2(
-  Node n1, Node n2, DataFlowType t1, DataFlowType t2, Summary s, Configuration config
+  NodeExt n1, NodeExt n2, DataFlowType t1, DataFlowType t2, Summary s, Configuration config
 ) {
-  argumentFlowsThrough(n1, n2, t1, t2, s, config) and
+  argumentFlowsThrough(n1.getNode(), n2.getNode(), t1, t2, s, config) and
   nodeCand(n1, config) and
   nodeCand(n2, unbind(config)) and
   summary2(s, unbind(config))
@@ -1016,7 +1171,7 @@ private predicate argumentFlowsThrough2(
  * flow steps in a dataflow path.
  */
 private predicate localFlowEntry(Node node, Configuration config) {
-  nodeCand(node, config) and
+  nodeCand(TNormalNode(node), config) and
   (
     config.isSource(node) or
     jumpStep(_, node, config) or
@@ -1024,7 +1179,7 @@ private predicate localFlowEntry(Node node, Configuration config) {
     node instanceof ParameterNode or
     node instanceof OutNode or
     node instanceof PostUpdateNode or
-    read(_, _, node) or
+    readDirect(_, _, node) or
     node instanceof CastNode
   )
 }
@@ -1034,15 +1189,15 @@ private predicate localFlowEntry(Node node, Configuration config) {
  * flow steps in a dataflow path.
  */
 private predicate localFlowExit(Node node, Configuration config) {
-  exists(Node next | nodeCand(next, config) |
+  exists(Node next | nodeCand(TNormalNode(next), config) |
     jumpStep(node, next, config) or
     additionalJumpStep(node, next, config) or
     flowIntoCallable(node, next, config) or
     flowOutOfCallable(node, next, config) or
-    argumentFlowsThrough2(node, next, _, _, _, config) or
-    argumentValueFlowsThrough(node, next, _) or
-    store(node, _, next) or
-    read(node, _, next)
+    argumentFlowsThrough2(TNormalNode(node), TNormalNode(next), _, _, _, config) or
+    argumentValueFlowsThrough(_, node, TContentNone(), TContentNone(), next) or
+    storeDirect(node, _, next) or
+    readDirect(node, _, next)
   )
   or
   node instanceof CastNode
@@ -1072,13 +1227,13 @@ private predicate localFlowStepPlus(
     node1 != node2 and
     cc.relevantFor(node1.getEnclosingCallable()) and
     not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
-    nodeCand(node2, unbind(config))
+    nodeCand(TNormalNode(node2), unbind(config))
     or
     exists(Node mid |
       localFlowStepPlus(node1, mid, preservesValue, config, cc) and
       localFlowStep(mid, node2, config) and
       not mid instanceof CastNode and
-      nodeCand(node2, unbind(config))
+      nodeCand(TNormalNode(node2), unbind(config))
     )
     or
     exists(Node mid |
@@ -1086,7 +1241,7 @@ private predicate localFlowStepPlus(
       additionalLocalFlowStep(mid, node2, config) and
       not mid instanceof CastNode and
       preservesValue = false and
-      nodeCand(node2, unbind(config))
+      nodeCand(TNormalNode(node2), unbind(config))
     )
   )
 }
@@ -1101,6 +1256,13 @@ private predicate localFlowBigStep(
 ) {
   localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
+}
+
+pragma[nomagic]
+private predicate localFlowBigStepExt(
+  NodeExt node1, NodeExt node2, boolean preservesValue, Configuration config
+) {
+  localFlowBigStep(node1.getNode(), node2.getNode(), preservesValue, config, _)
 }
 
 private newtype TAccessPathFront =
@@ -1129,24 +1291,14 @@ private class AccessPathFront extends TAccessPathFront {
 private class AccessPathFrontNil extends AccessPathFront, TFrontNil { }
 
 /**
- * A `Node` at which a cast can occur such that the type should be checked.
- */
-private class CastingNode extends Node {
-  CastingNode() {
-    this instanceof ParameterNode or
-    this instanceof CastNode or
-    this instanceof OutNode or
-    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
-  }
-}
-
-/**
  * Holds if data can flow from a source to `node` with the given `apf`.
  */
-private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, Configuration config) {
+private predicate flowCandFwd(
+  NodeExt node, boolean fromArg, AccessPathFront apf, Configuration config
+) {
   flowCandFwd0(node, fromArg, apf, config) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeType(node), apf.getType())
+  if node instanceof CastingNodeExt
+  then compatibleTypes(node.getErasedNodeTypeBound(), apf.getType())
   else any()
 }
 
@@ -1155,92 +1307,91 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
  * (re-)computed. This is either a source or a node reached through an
  * additional step.
  */
-private class AccessPathFrontNilNode extends Node {
+private class AccessPathFrontNilNode extends NormalNodeExt {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
     (
-      any(Configuration c).isSource(this)
+      any(Configuration c).isSource(this.getNode())
       or
-      localFlowBigStep(_, this, false, _, _)
+      localFlowBigStepExt(_, this, false, _)
       or
-      additionalJumpStep(_, this, _)
+      additionalJumpStepExt(_, this, _)
     )
   }
 
-  pragma[noinline]
-  private DataFlowType getErasedReprType() { result = getErasedNodeType(this) }
-
   /** Gets the `nil` path front for this node. */
-  AccessPathFrontNil getApf() { result = TFrontNil(this.getErasedReprType()) }
+  AccessPathFrontNil getApf() { result = TFrontNil(this.getErasedNodeTypeBound()) }
 }
 
-private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, Configuration config) {
+private predicate flowCandFwd0(
+  NodeExt node, boolean fromArg, AccessPathFront apf, Configuration config
+) {
   nodeCand2(node, _, false, config) and
-  config.isSource(node) and
+  config.isSource(node.getNode()) and
   fromArg = false and
   apf = node.(AccessPathFrontNilNode).getApf()
   or
   nodeCand(node, unbind(config)) and
   (
-    exists(Node mid |
+    exists(NodeExt mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config, _)
+      localFlowBigStepExt(mid, node, true, config)
     )
     or
-    exists(Node mid, AccessPathFrontNil nil |
+    exists(NodeExt mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config, _) and
+      localFlowBigStepExt(mid, node, false, config) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       flowCandFwd(mid, _, apf, config) and
-      jumpStep(mid, node, config) and
+      jumpStepExt(mid, node, config) and
       fromArg = false
     )
     or
-    exists(Node mid, AccessPathFrontNil nil |
+    exists(NodeExt mid, AccessPathFrontNil nil |
       flowCandFwd(mid, _, nil, config) and
-      additionalJumpStep(mid, node, config) and
+      additionalJumpStepExt(mid, node, config) and
       fromArg = false and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       flowCandFwd(mid, _, apf, config) and
       flowIntoCallable(mid, node, allowsFieldFlow, config) and
       fromArg = true and
       (apf instanceof AccessPathFrontNil or allowsFieldFlow = true)
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       flowCandFwd(mid, false, apf, config) and
       flowOutOfCallable(mid, node, allowsFieldFlow, config) and
       fromArg = false and
       (apf instanceof AccessPathFrontNil or allowsFieldFlow = true)
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      argumentValueFlowsThrough(mid, node, _)
+      argumentValueFlowsThrough(mid, node)
     )
     or
-    exists(Node mid, AccessPathFrontNil nil, DataFlowType t |
+    exists(NodeExt mid, AccessPathFrontNil nil, DataFlowType t |
       flowCandFwd(mid, fromArg, nil, config) and
       argumentFlowsThrough2(mid, node, _, t, TSummaryTaint(), config) and
       apf = TFrontNil(t)
     )
   )
   or
-  exists(Node mid, Content f |
+  exists(NodeExt mid, Content f |
     flowCandFwd(mid, fromArg, _, config) and
-    store(mid, f, node) and
+    storeExt(mid, f, node) and
     nodeCand(node, unbind(config)) and
     readStoreCand(f, unbind(config)) and
     apf.headUsesContent(f)
   )
   or
-  exists(Node mid, AccessPathFrontNil nil, Content f |
+  exists(NodeExt mid, AccessPathFrontNil nil, Content f |
     flowCandFwd(mid, fromArg, nil, config) and
     argumentFlowsThrough2(mid, node, _, _, TSummaryTaintStore(f), config) and
     apf.headUsesContent(f)
@@ -1260,9 +1411,9 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
 
 pragma[noinline]
 private predicate consCandFwd(Content f, AccessPathFront apf, Configuration config) {
-  exists(Node mid, Node n |
+  exists(NodeExt mid, NodeExt n |
     flowCandFwd(mid, _, apf, config) and
-    store(mid, f, n) and
+    storeExt(mid, f, n) and
     nodeCand(n, unbind(config)) and
     readStoreCand(f, unbind(config)) and
     compatibleTypes(apf.getType(), f.getType())
@@ -1270,10 +1421,10 @@ private predicate consCandFwd(Content f, AccessPathFront apf, Configuration conf
 }
 
 pragma[nomagic]
-private predicate flowCandFwdRead(Content f, Node node, boolean fromArg, Configuration config) {
-  exists(Node mid, AccessPathFront apf |
+private predicate flowCandFwdRead(Content f, NodeExt node, boolean fromArg, Configuration config) {
+  exists(NodeExt mid, AccessPathFront apf |
     flowCandFwd(mid, fromArg, apf, config) and
-    read(mid, f, node) and
+    readExt(mid, f, node) and
     apf.headUsesContent(f) and
     nodeCand(node, unbind(config))
   )
@@ -1281,9 +1432,9 @@ private predicate flowCandFwdRead(Content f, Node node, boolean fromArg, Configu
 
 pragma[nomagic]
 private predicate flowCandFwdReadTaint(
-  Content f, Node node, boolean fromArg, DataFlowType t, Configuration config
+  Content f, NodeExt node, boolean fromArg, DataFlowType t, Configuration config
 ) {
-  exists(Node mid, AccessPathFront apf |
+  exists(NodeExt mid, AccessPathFront apf |
     flowCandFwd(mid, fromArg, apf, config) and
     argumentFlowsThrough2(mid, node, _, t, TSummaryReadTaint(f), config) and
     apf.headUsesContent(f)
@@ -1291,7 +1442,7 @@ private predicate flowCandFwdReadTaint(
 }
 
 pragma[noinline]
-private predicate flowCandFwdEmptyAp(Node node, Configuration config) {
+private predicate flowCandFwdEmptyAp(NodeExt node, Configuration config) {
   flowCandFwd(node, _, any(AccessPathFrontNil nil), config)
 }
 
@@ -1301,7 +1452,7 @@ private predicate consCandFwdEmptyAp(Content f, Configuration config) {
 }
 
 private predicate argumentFlowsThrough3(
-  Node n1, Node n2, DataFlowType t1, DataFlowType t2, Summary s, Configuration config
+  NodeExt n1, NodeExt n2, DataFlowType t1, DataFlowType t2, Summary s, Configuration config
 ) {
   argumentFlowsThrough2(n1, n2, t1, t2, s, config) and
   flowCandFwdEmptyAp(n1, config) and
@@ -1331,63 +1482,65 @@ private predicate argumentFlowsThrough3(
  * Holds if data can flow from a source to `node` with the given `apf` and
  * from there flow to a sink.
  */
-private predicate flowCand(Node node, boolean toReturn, AccessPathFront apf, Configuration config) {
+private predicate flowCand(NodeExt node, boolean toReturn, AccessPathFront apf, Configuration config) {
   flowCand0(node, toReturn, apf, config) and
   flowCandFwd(node, _, apf, config)
 }
 
-private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Configuration config) {
+private predicate flowCand0(
+  NodeExt node, boolean toReturn, AccessPathFront apf, Configuration config
+) {
   flowCandFwd(node, _, apf, config) and
-  config.isSink(node) and
+  config.isSink(node.getNode()) and
   toReturn = false and
   apf instanceof AccessPathFrontNil
   or
-  exists(Node mid |
-    localFlowBigStep(node, mid, true, config, _) and
+  exists(NodeExt mid |
+    localFlowBigStepExt(node, mid, true, config) and
     flowCand(mid, toReturn, apf, config)
   )
   or
-  exists(Node mid, AccessPathFrontNil nil |
+  exists(NodeExt mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config, _) and
+    localFlowBigStepExt(node, mid, false, config) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
   or
-  exists(Node mid |
-    jumpStep(node, mid, config) and
+  exists(NodeExt mid |
+    jumpStepExt(node, mid, config) and
     flowCand(mid, _, apf, config) and
     toReturn = false
   )
   or
-  exists(Node mid, AccessPathFrontNil nil |
+  exists(NodeExt mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    additionalJumpStep(node, mid, config) and
+    additionalJumpStepExt(node, mid, config) and
     flowCand(mid, _, nil, config) and
     toReturn = false and
     apf instanceof AccessPathFrontNil
   )
   or
-  exists(Node mid, boolean allowsFieldFlow |
+  exists(NodeExt mid, boolean allowsFieldFlow |
     flowIntoCallable(node, mid, allowsFieldFlow, config) and
     flowCand(mid, false, apf, config) and
     toReturn = false and
     (apf instanceof AccessPathFrontNil or allowsFieldFlow = true)
   )
   or
-  exists(Node mid, boolean allowsFieldFlow |
+  exists(NodeExt mid, boolean allowsFieldFlow |
     flowOutOfCallable(node, mid, allowsFieldFlow, config) and
     flowCand(mid, _, apf, config) and
     toReturn = true and
     (apf instanceof AccessPathFrontNil or allowsFieldFlow = true)
   )
   or
-  exists(Node mid |
-    argumentValueFlowsThrough(node, mid, _) and
+  exists(NodeExt mid |
+    argumentValueFlowsThrough(node, mid) and
     flowCand(mid, toReturn, apf, config)
   )
   or
-  exists(Node mid, AccessPathFrontNil nil |
+  exists(NodeExt mid, AccessPathFrontNil nil |
     argumentFlowsThrough3(node, mid, _, _, TSummaryTaint(), config) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil and
@@ -1400,7 +1553,7 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
     consCand(f, apf, config)
   )
   or
-  exists(Node mid, Content f, AccessPathFront apf0, AccessPathFrontNil nil |
+  exists(NodeExt mid, Content f, AccessPathFront apf0, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
     apf instanceof AccessPathFrontNil and
     argumentFlowsThrough3(node, mid, _, _, TSummaryTaintStore(f), config) and
@@ -1415,7 +1568,7 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
     apf.headUsesContent(f)
   )
   or
-  exists(Node mid, AccessPathFrontNil nil1, AccessPathFrontNil nil2, Content f |
+  exists(NodeExt mid, AccessPathFrontNil nil1, AccessPathFrontNil nil2, Content f |
     argumentFlowsThrough3(node, mid, _, _, TSummaryReadTaint(f), config) and
     flowCand(mid, toReturn, nil1, config) and
     consCandFwd(f, nil2, unbind(config)) and
@@ -1425,20 +1578,20 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
 
 pragma[nomagic]
 private predicate flowCandRead(
-  Node node, Content f, boolean toReturn, AccessPathFront apf0, Configuration config
+  NodeExt node, Content f, boolean toReturn, AccessPathFront apf0, Configuration config
 ) {
-  exists(Node mid |
-    read(node, f, mid) and
+  exists(NodeExt mid |
+    readExt(node, f, mid) and
     flowCand(mid, toReturn, apf0, config)
   )
 }
 
 pragma[nomagic]
 private predicate flowCandStore(
-  Node node, Content f, boolean toReturn, AccessPathFront apf0, Configuration config
+  NodeExt node, Content f, boolean toReturn, AccessPathFront apf0, Configuration config
 ) {
-  exists(Node mid |
-    store(node, f, mid) and
+  exists(NodeExt mid |
+    storeExt(node, f, mid) and
     flowCand(mid, toReturn, apf0, config)
   )
 }
@@ -1446,7 +1599,7 @@ private predicate flowCandStore(
 pragma[nomagic]
 private predicate consCand(Content f, AccessPathFront apf, Configuration config) {
   consCandFwd(f, apf, config) and
-  exists(Node n, AccessPathFront apf0 |
+  exists(NodeExt n, AccessPathFront apf0 |
     flowCandFwd(n, _, apf0, config) and
     apf0.headUsesContent(f) and
     flowCandRead(n, f, _, apf, config)
@@ -1456,7 +1609,9 @@ private predicate consCand(Content f, AccessPathFront apf, Configuration config)
 private newtype TAccessPath =
   TNil(DataFlowType t) or
   TConsNil(Content f, DataFlowType t) { consCand(f, TFrontNil(t), _) } or
-  TConsCons(Content f1, Content f2, int len) { consCand(f1, TFrontHead(f2), _) and len in [2 .. 5] }
+  TConsCons(Content f1, Content f2, int len) {
+    consCand(f1, TFrontHead(f2), _) and len in [2 .. accessPathLimit()]
+  }
 
 /**
  * Conceptually a list of `Content`s followed by a `Type`, but only the first two
@@ -1550,100 +1705,97 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   }
 }
 
-/** Holds if `ap0` corresponds to the cons of `f` and `ap`. */
-private predicate pop(AccessPath ap0, Content f, AccessPath ap) { ap0.pop(f, ap) }
+/** Gets the access path obtained by popping `f` from `ap`, if any. */
+private AccessPath pop(Content f, AccessPath ap) { ap.pop(f, result) }
 
 /** Holds if `ap0` corresponds to the cons of `f` and `ap` and `apf` is the front of `ap`. */
 pragma[noinline]
 private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, AccessPath ap) {
-  pop(ap0, f, ap) and apf = ap.getFront()
+  ap = pop(f, ap0) and apf = ap.getFront()
 }
 
-/** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
-private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
+/** Gets the access path obtained by pushing `f` onto `ap`. */
+private AccessPath push(Content f, AccessPath ap) { ap = pop(f, result) }
 
 /**
  * A node that requires an empty access path and should have its tracked type
  * (re-)computed. This is either a source or a node reached through an
  * additional step.
  */
-private class AccessPathNilNode extends Node {
+private class AccessPathNilNode extends NormalNodeExt {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 
-  pragma[noinline]
-  private DataFlowType getErasedReprType() { result = getErasedNodeType(this) }
-
   /** Gets the `nil` path for this node. */
-  AccessPathNil getAp() { result = TNil(this.getErasedReprType()) }
+  AccessPathNil getAp() { result = TNil(this.getErasedNodeTypeBound()) }
 }
 
 /**
  * Holds if data can flow from a source to `node` with the given `ap`.
  */
 private predicate flowFwd(
-  Node node, boolean fromArg, AccessPathFront apf, AccessPath ap, Configuration config
+  NodeExt node, boolean fromArg, AccessPathFront apf, AccessPath ap, Configuration config
 ) {
   flowFwd0(node, fromArg, apf, ap, config) and
   flowCand(node, _, apf, config)
 }
 
 private predicate flowFwd0(
-  Node node, boolean fromArg, AccessPathFront apf, AccessPath ap, Configuration config
+  NodeExt node, boolean fromArg, AccessPathFront apf, AccessPath ap, Configuration config
 ) {
   flowCand(node, _, _, config) and
-  config.isSource(node) and
+  config.isSource(node.getNode()) and
   fromArg = false and
   ap = node.(AccessPathNilNode).getAp() and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, unbind(config)) and
   (
-    exists(Node mid |
+    exists(NodeExt mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config, _)
+      localFlowBigStepExt(mid, node, true, config)
     )
     or
-    exists(Node mid, AccessPathNil nil |
+    exists(NodeExt mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config, _) and
+      localFlowBigStepExt(mid, node, false, config) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       flowFwd(mid, _, apf, ap, config) and
-      jumpStep(mid, node, config) and
+      jumpStepExt(mid, node, config) and
       fromArg = false
     )
     or
-    exists(Node mid, AccessPathNil nil |
+    exists(NodeExt mid, AccessPathNil nil |
       flowFwd(mid, _, _, nil, config) and
-      additionalJumpStep(mid, node, config) and
+      additionalJumpStepExt(mid, node, config) and
       fromArg = false and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       flowFwd(mid, _, apf, ap, config) and
       flowIntoCallable(mid, node, allowsFieldFlow, config) and
       fromArg = true and
       (ap instanceof AccessPathNil or allowsFieldFlow = true)
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       flowFwd(mid, false, apf, ap, config) and
       flowOutOfCallable(mid, node, allowsFieldFlow, config) and
       fromArg = false and
       (ap instanceof AccessPathNil or allowsFieldFlow = true)
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      argumentValueFlowsThrough(mid, node, _)
+      argumentValueFlowsThrough(mid, node)
     )
     or
-    exists(Node mid, AccessPathNil nil, DataFlowType t |
+    exists(NodeExt mid, AccessPathNil nil, DataFlowType t |
       flowFwd(mid, fromArg, _, nil, config) and
       argumentFlowsThrough3(mid, node, _, t, TSummaryTaint(), config) and
       ap = TNil(t) and
@@ -1653,7 +1805,7 @@ private predicate flowFwd0(
   or
   exists(Content f, AccessPath ap0 |
     flowFwdStore(node, f, ap0, apf, fromArg, config) and
-    push(ap0, f, ap)
+    ap = push(f, ap0)
   )
   or
   exists(Content f, AccessPath ap0 |
@@ -1661,7 +1813,7 @@ private predicate flowFwd0(
     popWithFront(ap0, f, apf, ap)
   )
   or
-  exists(Content f, Node mid, AccessPathFront apf0, DataFlowType t |
+  exists(Content f, NodeExt mid, AccessPathFront apf0, DataFlowType t |
     flowFwd(mid, fromArg, apf0, any(AccessPathConsNil consnil), config) and
     argumentFlowsThrough3(mid, node, _, t, TSummaryReadTaint(f), config) and
     apf0.headUsesContent(f) and
@@ -1673,14 +1825,15 @@ private predicate flowFwd0(
 
 pragma[nomagic]
 private predicate flowFwdStore(
-  Node node, Content f, AccessPath ap0, AccessPathFront apf, boolean fromArg, Configuration config
+  NodeExt node, Content f, AccessPath ap0, AccessPathFront apf, boolean fromArg,
+  Configuration config
 ) {
-  exists(Node mid, AccessPathFront apf0 |
+  exists(NodeExt mid, AccessPathFront apf0 |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, apf0, apf, config)
+    flowFwdStore1(mid, f, node, apf0, apf, config)
   )
   or
-  exists(Node mid, DataFlowType t |
+  exists(NodeExt mid, DataFlowType t |
     flowFwd(mid, fromArg, _, any(AccessPathNil nil), config) and
     argumentFlowsThrough3(mid, node, t, _, TSummaryTaintStore(f), config) and
     consCand(f, TFrontNil(t), unbind(config)) and
@@ -1690,22 +1843,31 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
-  Node mid, Content f, Node node, AccessPathFront apf0, AccessPathFront apf, Configuration config
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, AccessPathFront apf0, Configuration config
 ) {
-  store(mid, f, node) and
-  consCand(f, apf0, config) and
+  storeExt(mid, f, node) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
+  NodeExt mid, Content f, NodeExt node, AccessPathFront apf0, AccessPathFront apf,
+  Configuration config
+) {
+  flowFwdStore0(mid, f, node, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
 
 pragma[nomagic]
 private predicate flowFwdRead(
-  Node node, Content f, AccessPath ap0, boolean fromArg, Configuration config
+  NodeExt node, Content f, AccessPath ap0, boolean fromArg, Configuration config
 ) {
-  exists(Node mid, AccessPathFront apf0 |
+  exists(NodeExt mid, AccessPathFront apf0 |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    read(mid, f, node) and
+    readExt(mid, f, node) and
     apf0.headUsesContent(f) and
     flowCand(node, _, _, unbind(config))
   )
@@ -1715,197 +1877,191 @@ private predicate flowFwdRead(
  * Holds if data can flow from a source to `node` with the given `ap` and
  * from there flow to a sink.
  */
-private predicate flow(Node node, boolean toReturn, AccessPath ap, Configuration config) {
+private predicate flow(NodeExt node, boolean toReturn, AccessPath ap, Configuration config) {
   flow0(node, toReturn, ap, config) and
   flowFwd(node, _, _, ap, config)
 }
 
-private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuration config) {
+private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configuration config) {
   flowFwd(node, _, _, ap, config) and
-  config.isSink(node) and
+  config.isSink(node.getNode()) and
   toReturn = false and
   ap instanceof AccessPathNil
   or
-  exists(Node mid |
-    localFlowBigStep(node, mid, true, config, _) and
+  exists(NodeExt mid |
+    localFlowBigStepExt(node, mid, true, config) and
     flow(mid, toReturn, ap, config)
   )
   or
-  exists(Node mid, AccessPathNil nil |
+  exists(NodeExt mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config, _) and
+    localFlowBigStepExt(node, mid, false, config) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
   or
-  exists(Node mid |
-    jumpStep(node, mid, config) and
+  exists(NodeExt mid |
+    jumpStepExt(node, mid, config) and
     flow(mid, _, ap, config) and
     toReturn = false
   )
   or
-  exists(Node mid, AccessPathNil nil |
+  exists(NodeExt mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    additionalJumpStep(node, mid, config) and
+    additionalJumpStepExt(node, mid, config) and
     flow(mid, _, nil, config) and
     toReturn = false and
     ap instanceof AccessPathNil
   )
   or
-  exists(Node mid, boolean allowsFieldFlow |
+  exists(NodeExt mid, boolean allowsFieldFlow |
     flowIntoCallable(node, mid, allowsFieldFlow, config) and
     flow(mid, false, ap, config) and
     toReturn = false and
     (ap instanceof AccessPathNil or allowsFieldFlow = true)
   )
   or
-  exists(Node mid, boolean allowsFieldFlow |
+  exists(NodeExt mid, boolean allowsFieldFlow |
     flowOutOfCallable(node, mid, allowsFieldFlow, config) and
     flow(mid, _, ap, config) and
     toReturn = true and
     (ap instanceof AccessPathNil or allowsFieldFlow = true)
   )
   or
-  exists(Node mid |
-    argumentValueFlowsThrough(node, mid, _) and
+  exists(NodeExt mid |
+    argumentValueFlowsThrough(node, mid) and
     flow(mid, toReturn, ap, config)
   )
   or
-  exists(Node mid, AccessPathNil ap0 |
+  exists(NodeExt mid, AccessPathNil ap0 |
     argumentFlowsThrough3(node, mid, _, _, TSummaryTaint(), config) and
     flow(mid, toReturn, ap0, config) and
     ap instanceof AccessPathNil and
     flowFwd(node, _, _, ap, config)
   )
   or
-  exists(Content f, AccessPath ap0 |
-    flowStore(node, f, toReturn, ap0, config) and
-    pop(ap0, f, ap)
+  exists(NodeExt mid, AccessPath ap0 |
+    storeFwd(node, _, mid, ap, ap0, config) and
+    flow(mid, toReturn, ap0, config)
   )
   or
   exists(Content f, AccessPath ap0 |
     flowTaintStore(node, f, toReturn, ap0, config) and
-    pop(ap0, f, any(AccessPathNil nil)) and
+    pop(f, ap0) instanceof AccessPathNil and
     ap instanceof AccessPathNil and
     flowFwd(node, _, _, ap, config)
   )
   or
-  exists(Content f, AccessPath ap0 |
-    flowRead(node, f, toReturn, ap0, config) and
-    push(ap0, f, ap)
+  exists(NodeExt mid, AccessPath ap0 |
+    readFwd(node, mid, ap, ap0, config) and
+    flow(mid, toReturn, ap0, config)
   )
   or
-  exists(Node mid, Content f |
+  exists(NodeExt mid, Content f |
     argumentFlowsThrough3(node, mid, _, _, TSummaryReadTaint(f), config) and
     flow(mid, toReturn, any(AccessPathNil nil1), config) and
-    push(any(AccessPathNil nil2), f, ap) and
+    ap = push(f, any(AccessPathNil nil2)) and
     flowFwd(node, _, _, ap, config)
   )
 }
 
 pragma[nomagic]
-private predicate flowStore(
-  Node node, Content f, boolean toReturn, AccessPath ap0, Configuration config
+private predicate storeFwd(
+  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  exists(Node mid |
-    store(node, f, mid) and
-    flow(mid, toReturn, ap0, config)
-  )
+  storeExt(node1, f, node2) and
+  flowFwdStore(node2, f, ap, _, _, config) and
+  ap0 = push(f, ap)
 }
 
 pragma[nomagic]
 private predicate flowTaintStore(
-  Node node, Content f, boolean toReturn, AccessPath ap0, Configuration config
+  NodeExt node, Content f, boolean toReturn, AccessPath ap0, Configuration config
 ) {
-  exists(Node mid |
+  exists(NodeExt mid |
     argumentFlowsThrough3(node, mid, _, _, TSummaryTaintStore(f), config) and
     flow(mid, toReturn, ap0, config)
   )
 }
 
 pragma[nomagic]
-private predicate flowRead(
-  Node node, Content f, boolean toReturn, AccessPath ap0, Configuration config
+private predicate readFwd(
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  exists(Node mid |
-    read(node, f, mid) and
-    flow(mid, toReturn, ap0, config)
+  exists(Content f |
+    readExt(node1, f, node2) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
   )
 }
 
 bindingset[conf, result]
 private Configuration unbind(Configuration conf) { result >= conf and result <= conf }
 
-private predicate flow(Node n, Configuration config) { flow(n, _, _, config) }
+private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxNil(ParameterNode p) {
-    exists(Configuration conf, ReturnNodeExt ret |
-      flow(p, true, TNil(_), conf) and
-      parameterFlowReturn(p, ret, _, _, _,
-        any(Summary s | s = TSummaryTaint() or s = TSummaryTaintStore(_)), conf) and
-      flow(ret, unbind(conf))
-    )
-  } or
-  TSummaryCtxConsNil(ParameterNode p, Content f) {
-    exists(Configuration conf, ReturnNodeExt ret |
-      flow(p, true, TConsNil(f, _), conf) and
-      parameterFlowReturn(p, ret, _, _, _, TSummaryReadTaint(f), conf) and
-      flow(ret, unbind(conf))
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
+      exists(Summary summary |
+        parameterFlowReturn(p, ret, _, _, _, summary, config) and
+        flow(ret, unbind(config))
+      |
+        // taint through
+        summary = TSummaryTaint() and
+        ap instanceof AccessPathNil
+        or
+        // taint setter
+        summary = TSummaryTaintStore(_) and
+        ap instanceof AccessPathNil
+        or
+        // taint getter
+        summary = TSummaryReadTaint(ap.(AccessPathConsNil).getHead())
+      )
+      or
+      exists(ContentOption contentIn |
+        parameterValueFlowReturn(p, ret, _, contentIn, _) and
+        flow(ret, unbind(config))
+      |
+        // value through/setter
+        contentIn = TContentNone()
+        or
+        // value getter (+ setter)
+        contentIn = TContentSome(ap.getHead())
+      )
     )
   }
 
 /**
  * A context for generating flow summaries. This represents flow entry through
  * a specific parameter with an access path of a specific shape.
+ *
+ * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
-
-/** Gets the summary context for a given flow entry, if potentially necessary. */
-private SummaryCtx getSummaryCtx(ParameterNode p, AccessPath ap) {
-  result = TSummaryCtxNil(p) and flow(p, true, ap, _) and ap instanceof AccessPathNil
-  or
-  exists(Content f |
-    result = TSummaryCtxConsNil(p, f) and flow(p, true, ap, _) and ap = TConsNil(f, _)
-  )
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
 }
 
-/**
- * Holds if flow from a parameter specified by `sc` that flows to `ret` with a
- * resulting access path `ap` is compatible with a summary found by `parameterFlowReturn`.
- */
-private predicate summaryCompatible(
-  SummaryCtx sc, ReturnNodeExt ret, AccessPath ap, Configuration conf
-) {
-  exists(ParameterNode p |
-    sc = TSummaryCtxNil(p) and
-    flow(p, true, TNil(_), conf) and
-    parameterFlowReturn(p, ret, _, _, _, TSummaryTaint(), conf) and
-    flow(ret, true, ap, conf) and
-    ap instanceof AccessPathNil
-  )
-  or
-  exists(ParameterNode p, Content f |
-    sc = TSummaryCtxNil(p) and
-    flow(p, true, TNil(_), conf) and
-    parameterFlowReturn(p, ret, _, _, _, TSummaryTaintStore(f), conf) and
-    flow(ret, true, ap, conf) and
-    ap = TConsNil(f, _)
-  )
-  or
-  exists(ParameterNode p, Content f |
-    sc = TSummaryCtxConsNil(p, f) and
-    flow(p, true, TConsNil(f, _), conf) and
-    parameterFlowReturn(p, ret, _, _, _, TSummaryReadTaint(f), conf) and
-    flow(ret, true, ap, conf) and
-    ap instanceof AccessPathNil
-  )
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 }
 
 private newtype TPathNode =
@@ -1915,34 +2071,43 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = node.(AccessPathNilNode).getAp()
+    ap = any(AccessPathNilNode nil | nil.getNode() = node).getAp()
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
       pathStep(mid, node, cc, sc, ap) and
       config = mid.getConfiguration() and
-      flow(node, _, ap, unbind(config))
+      flow(TNormalNode(node), _, ap, unbind(config))
     )
   } or
   TPathNodeSink(Node node, Configuration config) {
-    // The AccessPath on a sink is empty.
     config.isSink(node) and
-    flow(node, config)
+    flow(node, unbind(config)) and
+    (
+      // A sink that is also a source ...
+      config.isSource(node)
+      or
+      // ... or a sink that can be reached from a source
+      exists(PathNodeMid mid |
+        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+        config = unbind(mid.getConfiguration())
+      )
+    )
   }
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
  * Only those `PathNode`s that are reachable from a source are generated.
  */
-abstract class PathNode extends TPathNode {
+class PathNode extends TPathNode {
   /** Gets a textual representation of this element. */
-  string toString() { result = getNode().toString() + ppAp() }
+  string toString() { none() }
 
   /**
    * Gets a textual representation of this element, including a textual
    * representation of the call context.
    */
-  string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
+  string toStringWithContext() { none() }
 
   /**
    * Holds if this element is at the specified location.
@@ -1954,24 +2119,23 @@ abstract class PathNode extends TPathNode {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    none()
   }
 
   /** Gets the underlying `Node`. */
-  abstract Node getNode();
+  Node getNode() { none() }
 
   /** Gets the associated configuration. */
-  abstract Configuration getConfiguration();
-
-  /** Gets a successor. */
-  deprecated final PathNode getSucc() { result = this.getASuccessor() }
+  Configuration getConfiguration() { none() }
 
   /** Gets a successor of this node, if any. */
-  abstract PathNode getASuccessor();
+  PathNode getASuccessor() { none() }
 
   /** Holds if this node is a source. */
-  abstract predicate isSource();
+  predicate isSource() { none() }
+}
 
+abstract private class PathNodeImpl extends PathNode {
   private string ppAp() {
     this instanceof PathNodeSink and result = ""
     or
@@ -1984,6 +2148,16 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     result = " <" + this.(PathNodeMid).getCallContext().toString() + ">"
+  }
+
+  override string toString() { result = this.getNode().toString() + ppAp() }
+
+  override string toStringWithContext() { result = this.getNode().toString() + ppAp() + ppCtx() }
+
+  override predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    this.getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -2012,7 +2186,7 @@ module PathGraph {
  * An intermediate flow graph node. This is a triple consisting of a `Node`,
  * a `CallContext`, and a `Configuration`.
  */
-private class PathNodeMid extends PathNode, TPathNodeMid {
+private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
   Node node;
   CallContext cc;
   SummaryCtx sc;
@@ -2036,7 +2210,7 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
     result.getConfiguration() = unbind(this.getConfiguration())
   }
 
-  override PathNode getASuccessor() {
+  override PathNodeImpl getASuccessor() {
     // an intermediate step to another intermediate node
     result = getSuccMid()
     or
@@ -2063,7 +2237,7 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
  * intermediate nodes in order to uniquely correspond to a given sink by
  * excluding the `CallContext`.
  */
-private class PathNodeSink extends PathNode, TPathNodeSink {
+private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   Node node;
   Configuration config;
 
@@ -2096,7 +2270,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     or
     localFlowBigStep(midnode, node, false, conf, localCC) and
     ap0 instanceof AccessPathNil and
-    ap = node.(AccessPathNilNode).getAp()
+    ap = any(AccessPathNilNode nil | nil.getNode() = node).getAp()
   )
   or
   jumpStep(mid.getNode(), node, mid.getConfiguration()) and
@@ -2108,11 +2282,12 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
+  ap = any(AccessPathNilNode nil | nil.getNode() = node).getAp()
   or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext() and sc = mid.getSummaryCtx()
+  exists(Content f, AccessPath ap0 | pathReadStep(mid, node, ap0, f, cc) and ap = pop(f, ap0)) and
+  sc = mid.getSummaryCtx()
   or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap)) and
+  exists(Content f, AccessPath ap0 | pathStoreStep(mid, node, ap0, f, cc) and ap = push(f, ap0)) and
   sc = mid.getSummaryCtx()
   or
   pathIntoCallable(mid, node, _, cc, sc, _) and ap = mid.getAp()
@@ -2120,40 +2295,53 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp() and sc = mid.getSummaryCtx()
 }
 
-pragma[noinline]
-private predicate contentReadStep(PathNodeMid mid, Node node, AccessPath ap) {
-  exists(Content f, AccessPath ap0 |
-    ap0 = mid.getAp() and
-    read(mid.getNode(), f, node) and
-    pop(ap0, f, ap)
-  )
+pragma[nomagic]
+private predicate readCand(Node node1, Content f, Node node2, Configuration config) {
+  readDirect(node1, f, node2) and
+  flow(node2, config)
 }
 
-pragma[noinline]
-private predicate contentStoreStep(
-  PathNodeMid mid, Node node, AccessPath ap0, Content f, CallContext cc
-) {
+pragma[nomagic]
+private predicate pathReadStep(PathNodeMid mid, Node node, AccessPath ap0, Content f, CallContext cc) {
   ap0 = mid.getAp() and
-  store(mid.getNode(), f, node) and
+  readCand(mid.getNode(), f, node, mid.getConfiguration()) and
   cc = mid.getCallContext()
 }
 
-private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallContext innercc) {
+pragma[nomagic]
+private predicate storeCand(Node node1, Content f, Node node2, Configuration config) {
+  storeDirect(node1, f, node2) and
+  flow(node2, config)
+}
+
+pragma[nomagic]
+private predicate pathStoreStep(
+  PathNodeMid mid, Node node, AccessPath ap0, Content f, CallContext cc
+) {
+  ap0 = mid.getAp() and
+  storeCand(mid.getNode(), f, node, mid.getConfiguration()) and
+  cc = mid.getCallContext()
+}
+
+private predicate pathOutOfCallable0(
+  PathNodeMid mid, ReturnPosition pos, CallContext innercc, AccessPath ap, Configuration config
+) {
   pos = getReturnPosition(mid.getNode()) and
   innercc = mid.getCallContext() and
-  not innercc instanceof CallContextCall
+  not innercc instanceof CallContextCall and
+  ap = mid.getAp() and
+  config = mid.getConfiguration()
 }
 
 pragma[nomagic]
 private predicate pathOutOfCallable1(
-  PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
+  PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc, AccessPath ap,
+  Configuration config
 ) {
   exists(ReturnPosition pos, DataFlowCallable c, CallContext innercc |
-    pathOutOfCallable0(mid, pos, innercc) and
+    pathOutOfCallable0(mid, pos, innercc, ap, config) and
     c = pos.getCallable() and
     kind = pos.getKind() and
     resolveReturn(innercc, c, call)
@@ -2162,14 +2350,24 @@ private predicate pathOutOfCallable1(
   )
 }
 
+pragma[noinline]
+private Node getAnOutNodeCand(
+  ReturnKindExt kind, DataFlowCall call, AccessPath ap, Configuration config
+) {
+  result = kind.getAnOutNode(call) and
+  flow(TNormalNode(result), _, ap, config)
+}
+
 /**
  * Holds if data may flow from `mid` to `out`. The last step of this path
  * is a return from a callable and is recorded by `cc`, if needed.
  */
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
-  exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = kind.getAnOutNode(call)
+  exists(ReturnKindExt kind, DataFlowCall call, AccessPath ap, Configuration config |
+    pathOutOfCallable1(mid, call, kind, cc, ap, config)
+  |
+    out = getAnOutNodeCand(kind, call, ap, config)
   )
 }
 
@@ -2189,9 +2387,11 @@ private predicate pathIntoArg(
 }
 
 pragma[noinline]
-private predicate parameterCand(DataFlowCallable callable, int i, Configuration config) {
+private predicate parameterCand(
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
+) {
   exists(ParameterNode p |
-    flow(p, config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2203,7 +2403,7 @@ private predicate pathIntoCallable0(
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
-  parameterCand(callable, any(int j | j <= i and j >= i), mid.getConfiguration())
+  parameterCand(callable, any(int j | j <= i and j >= i), ap, mid.getConfiguration())
 }
 
 /**
@@ -2219,9 +2419,10 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
-      sc = getSummaryCtx(p, ap)
+      sc = TSummaryCtxSome(p, ap)
       or
-      sc instanceof SummaryCtxNone and not exists(getSummaryCtx(p, ap))
+      not exists(TSummaryCtxSome(p, ap)) and
+      sc = TSummaryCtxNone()
     )
   |
     if recordDataFlowCallSite(call, callable)
@@ -2233,7 +2434,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, SummaryCtx sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2241,8 +2442,7 @@ private predicate paramFlowsThrough(
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp() and
-    summaryCompatible(sc, ret, ap, config)
+    ap = mid.getAp()
   )
 }
 
@@ -2250,8 +2450,8 @@ pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPath ap
 ) {
-  exists(ParameterNode p, CallContext innercc, SummaryCtx sc |
-    pathIntoCallable(mid, p, cc, innercc, sc, call) and
+  exists(CallContext innercc, SummaryCtx sc |
+    pathIntoCallable(mid, _, cc, innercc, sc, call) and
     paramFlowsThrough(kind, innercc, sc, ap, unbind(mid.getConfiguration()))
   )
 }
@@ -2264,24 +2464,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPath ap) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, ap) and
-    out = kind.getAnOutNode(call)
-  )
-}
-
-pragma[noinline]
-private predicate valuePathThroughCallable0(
-  DataFlowCall call, PathNodeMid mid, ReturnKind kind, CallContext cc
-) {
-  exists(ParameterNode p, CallContext innercc |
-    pathIntoCallable(mid, p, cc, innercc, _, call) and
-    parameterValueFlowsThrough(p, kind, innercc)
-  )
-}
-
-private predicate valuePathThroughCallable(PathNodeMid mid, OutNode out, CallContext cc) {
-  exists(DataFlowCall call, ReturnKind kind |
-    valuePathThroughCallable0(call, mid, kind, cc) and
-    out = getAnOutNode(call, kind)
+    out = getAnOutNodeCand(kind, call, ap, mid.getConfiguration())
   )
 }
 
@@ -2429,14 +2612,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2447,7 +2623,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeType(node)) and
+      ap = TPartialNil(getErasedNodeTypeBound(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2464,7 +2640,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeType(node), ap.getType())
+      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
       else any()
     )
   }
@@ -2474,13 +2650,13 @@ private module FlowExploration {
    */
   class PartialPathNode extends TPartialPathNode {
     /** Gets a textual representation of this element. */
-    string toString() { result = getNode().toString() + ppAp() }
+    string toString() { result = this.getNode().toString() + this.ppAp() }
 
     /**
      * Gets a textual representation of this element, including a textual
      * representation of the call context.
      */
-    string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
+    string toStringWithContext() { result = this.getNode().toString() + this.ppAp() + this.ppCtx() }
 
     /**
      * Holds if this element is at the specified location.
@@ -2492,17 +2668,17 @@ private module FlowExploration {
     predicate hasLocationInfo(
       string filepath, int startline, int startcolumn, int endline, int endcolumn
     ) {
-      getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+      this.getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
     }
 
     /** Gets the underlying `Node`. */
-    abstract Node getNode();
+    Node getNode() { none() }
 
     /** Gets the associated configuration. */
-    abstract Configuration getConfiguration();
+    Configuration getConfiguration() { none() }
 
     /** Gets a successor of this node, if any. */
-    abstract PartialPathNode getASuccessor();
+    PartialPathNode getASuccessor() { none() }
 
     /**
      * Gets the approximate distance to the nearest source measured in number
@@ -2553,12 +2729,10 @@ private module FlowExploration {
 
     override Configuration getConfiguration() { result = config }
 
-    private PartialPathNodePriv getSuccMid() {
+    override PartialPathNodePriv getASuccessor() {
       partialPathStep(this, result.getNode(), result.getCallContext(), result.getSummaryCtx1(),
         result.getSummaryCtx2(), result.getAp(), result.getConfiguration())
     }
-
-    override PartialPathNode getASuccessor() { result = getSuccMid() }
   }
 
   private predicate partialPathStep(
@@ -2579,7 +2753,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeType(node)) and
+      ap = TPartialNil(getErasedNodeTypeBound(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2595,7 +2769,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeType(node)) and
+    ap = TPartialNil(getErasedNodeTypeBound(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2620,10 +2794,6 @@ private module FlowExploration {
     partialPathThroughCallable(mid, node, cc, ap, config) and
     sc1 = mid.getSummaryCtx1() and
     sc2 = mid.getSummaryCtx2()
-    or
-    valuePartialPathThroughCallable(mid, node, cc, ap, config) and
-    sc1 = mid.getSummaryCtx1() and
-    sc2 = mid.getSummaryCtx2()
   }
 
   bindingset[result, i]
@@ -2634,7 +2804,7 @@ private module FlowExploration {
     PartialPathNodePriv mid, PartialAccessPath ap1, Content f, Node node, PartialAccessPath ap2
   ) {
     ap1 = mid.getAp() and
-    store(mid.getNode(), f, node) and
+    storeDirect(mid.getNode(), f, node) and
     ap2.getHead() = f and
     ap2.len() = unbindInt(ap1.len() + 1) and
     compatibleTypes(ap1.getType(), f.getType())
@@ -2656,7 +2826,7 @@ private module FlowExploration {
     Configuration config
   ) {
     ap = mid.getAp() and
-    read(mid.getNode(), f, node) and
+    readStep(mid.getNode(), f, node) and
     ap.getHead() = f and
     config = mid.getConfiguration() and
     cc = mid.getCallContext()
@@ -2729,11 +2899,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2753,8 +2920,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 
@@ -2775,26 +2941,6 @@ private module FlowExploration {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, ap, config) and
       out = kind.getAnOutNode(call)
-    )
-  }
-
-  pragma[noinline]
-  private predicate valuePartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodePriv mid, ReturnKind kind, CallContext cc,
-    PartialAccessPath ap, Configuration config
-  ) {
-    exists(ParameterNode p, CallContext innercc |
-      partialPathIntoCallable(mid, p, cc, innercc, _, _, call, ap, config) and
-      parameterValueFlowsThrough(p, kind, innercc)
-    )
-  }
-
-  private predicate valuePartialPathThroughCallable(
-    PartialPathNodePriv mid, OutNode out, CallContext cc, PartialAccessPath ap, Configuration config
-  ) {
-    exists(DataFlowCall call, ReturnKind kind |
-      valuePartialPathThroughCallable0(call, mid, kind, cc, ap, config) and
-      out = getAnOutNode(call, kind)
     )
   }
 }

--- a/ql/src/semmle/go/dataflow/internal/DataFlowImplCommon.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowImplCommon.qll
@@ -1,915 +1,855 @@
 private import DataFlowImplSpecific::Private
-import DataFlowImplSpecific::Public
+private import DataFlowImplSpecific::Public
+import Cached
 
-private ReturnNode getAReturnNodeOfKind(ReturnKind kind) { result.getKind() = kind }
+cached
+private module Cached {
+  /**
+   * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
+   * The instance parameter is considered to have index `-1`.
+   */
+  pragma[nomagic]
+  private predicate viableParam(DataFlowCall call, int i, ParameterNode p) {
+    p.isParameterOf(viableCallable(call), i)
+  }
 
-module Public {
-  import ImplCommon
-  import FlowThrough_v2
-}
+  /**
+   * Holds if `arg` is a possible argument to `p` in `call`, taking virtual
+   * dispatch into account.
+   */
+  cached
+  predicate viableParamArg(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+    exists(int i |
+      viableParam(call, i, p) and
+      arg.argumentOf(call, i) and
+      compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(p))
+    )
+  }
 
-private module ImplCommon {
-  import Cached
+  /** Provides predicates for calculating flow-through summaries. */
+  cached
+  private module FlowThrough {
+    /**
+     * The first flow-through approximation:
+     *
+     * - Input/output access paths are abstracted with a Boolean parameter
+     *   that indicates (non-)emptiness.
+     */
+    private module Cand {
+      /**
+       * Holds if `p` can flow to `node` in the same callable using only
+       * value-preserving steps.
+       *
+       * `read` indicates whether it is contents of `p` that can flow to `node`,
+       * and `stored` indicates whether it flows to contents of `node`.
+       */
+      pragma[nomagic]
+      private predicate parameterValueFlowCand(
+        ParameterNode p, Node node, boolean read, boolean stored
+      ) {
+        p = node and
+        read = false and
+        stored = false
+        or
+        // local flow
+        exists(Node mid |
+          parameterValueFlowCand(p, mid, read, stored) and
+          simpleLocalFlowStep(mid, node)
+        )
+        or
+        // read
+        exists(Node mid, boolean readMid, boolean storedMid |
+          parameterValueFlowCand(p, mid, readMid, storedMid) and
+          readStep(mid, _, node) and
+          stored = false
+        |
+          // value neither read nor stored prior to read
+          readMid = false and
+          storedMid = false and
+          read = true
+          or
+          // value (possibly read and then) stored prior to read (same content)
+          read = readMid and
+          storedMid = true
+        )
+        or
+        // store
+        exists(Node mid |
+          parameterValueFlowCand(p, mid, read, false) and
+          storeStep(mid, _, node) and
+          stored = true
+        )
+        or
+        // flow through: no prior read or store
+        exists(ArgumentNode arg |
+          parameterValueFlowArgCand(p, arg, false, false) and
+          argumentValueFlowsThroughCand(arg, node, read, stored)
+        )
+        or
+        // flow through: no read or store inside method
+        exists(ArgumentNode arg |
+          parameterValueFlowArgCand(p, arg, read, stored) and
+          argumentValueFlowsThroughCand(arg, node, false, false)
+        )
+        or
+        // flow through: possible prior read and prior store with compatible
+        // flow-through method
+        exists(ArgumentNode arg, boolean mid |
+          parameterValueFlowArgCand(p, arg, read, mid) and
+          argumentValueFlowsThroughCand(arg, node, mid, stored)
+        )
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowArgCand(
+        ParameterNode p, ArgumentNode arg, boolean read, boolean stored
+      ) {
+        parameterValueFlowCand(p, arg, read, stored)
+      }
+
+      pragma[nomagic]
+      predicate parameterValueFlowsToPreUpdateCand(ParameterNode p, PostUpdateNode n) {
+        parameterValueFlowCand(p, n.getPreUpdateNode(), false, false)
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowsToPostUpdateCand(
+        ParameterNode p, PostUpdateNode n, boolean read
+      ) {
+        parameterValueFlowCand(p, n, read, true)
+      }
+
+      /**
+       * Holds if `p` can flow to a return node of kind `kind` in the same
+       * callable using only value-preserving steps, not taking call contexts
+       * into account.
+       *
+       * `read` indicates whether it is contents of `p` that can flow to the return
+       * node, and `stored` indicates whether it flows to contents of the return
+       * node.
+       */
+      predicate parameterValueFlowReturnCand(
+        ParameterNode p, ReturnKindExt kind, boolean read, boolean stored
+      ) {
+        exists(ReturnNode ret |
+          parameterValueFlowCand(p, ret, read, stored) and
+          kind = TValueReturn(ret.getKind())
+        )
+        or
+        exists(ParameterNode p2, int pos2, PostUpdateNode n |
+          parameterValueFlowsToPostUpdateCand(p, n, read) and
+          parameterValueFlowsToPreUpdateCand(p2, n) and
+          p2.isParameterOf(_, pos2) and
+          kind = TParamUpdate(pos2) and
+          p != p2 and
+          stored = true
+        )
+      }
+
+      pragma[nomagic]
+      private predicate argumentValueFlowsThroughCand0(
+        DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, boolean read, boolean stored
+      ) {
+        exists(ParameterNode param | viableParamArg(call, param, arg) |
+          parameterValueFlowReturnCand(param, kind, read, stored)
+        )
+      }
+
+      /**
+       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
+       * not taking call contexts into account.
+       *
+       * `read` indicates whether it is contents of `arg` that can flow to `out`, and
+       * `stored` indicates whether it flows to contents of `out`.
+       */
+      predicate argumentValueFlowsThroughCand(
+        ArgumentNode arg, Node out, boolean read, boolean stored
+      ) {
+        exists(DataFlowCall call, ReturnKindExt kind |
+          argumentValueFlowsThroughCand0(call, arg, kind, read, stored) and
+          out = kind.getAnOutNode(call)
+        )
+      }
+
+      predicate cand(ParameterNode p, Node n) {
+        parameterValueFlowCand(p, n, _, _) and
+        (
+          parameterValueFlowReturnCand(p, _, _, _)
+          or
+          parameterValueFlowsToPreUpdateCand(p, _)
+        )
+      }
+    }
+
+    private module LocalFlowBigStep {
+      private predicate localFlowEntry(Node n) {
+        Cand::cand(_, n) and
+        (
+          n instanceof ParameterNode or
+          n instanceof OutNode or
+          n instanceof PostUpdateNode or
+          readStep(_, _, n) or
+          n instanceof CastNode
+        )
+      }
+
+      private predicate localFlowExit(Node n) {
+        Cand::cand(_, n) and
+        (
+          n instanceof ArgumentNode
+          or
+          n instanceof ReturnNode
+          or
+          Cand::parameterValueFlowsToPreUpdateCand(_, n)
+          or
+          storeStep(n, _, _)
+          or
+          readStep(n, _, _)
+          or
+          n instanceof CastNode
+          or
+          n =
+            any(PostUpdateNode pun | Cand::parameterValueFlowsToPreUpdateCand(_, pun))
+                .getPreUpdateNode()
+        )
+      }
+
+      pragma[nomagic]
+      private predicate localFlowStepPlus(Node node1, Node node2) {
+        localFlowEntry(node1) and
+        simpleLocalFlowStep(node1, node2) and
+        node1 != node2
+        or
+        exists(Node mid |
+          localFlowStepPlus(node1, mid) and
+          simpleLocalFlowStep(mid, node2) and
+          not mid instanceof CastNode
+        )
+      }
+
+      pragma[nomagic]
+      predicate localFlowBigStep(Node node1, Node node2) {
+        localFlowStepPlus(node1, node2) and
+        localFlowExit(node2)
+      }
+    }
+
+    /**
+     * The final flow-through calculation:
+     *
+     * - Input/output access paths are abstracted with a `ContentOption` parameter
+     *   that represents the head of the access path. `TContentNone()` means that
+     *   the access path is unrestricted.
+     * - Types are checked using the `compatibleTypes()` relation.
+     */
+    cached
+    module Final {
+      /**
+       * Holds if `p` can flow to `node` in the same callable using only
+       * value-preserving steps, not taking call contexts into account.
+       *
+       * `contentIn` describes the content of `p` that can flow to `node`
+       * (if any), and `contentOut` describes the content of `node` that
+       * it flows to (if any).
+       */
+      private predicate parameterValueFlow(
+        ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow0(p, node, contentIn, contentOut) and
+        if node instanceof CastingNode
+        then
+          // normal flow through
+          contentIn = TContentNone() and
+          contentOut = TContentNone() and
+          compatibleTypes(getErasedNodeTypeBound(p), getErasedNodeTypeBound(node))
+          or
+          // getter
+          exists(Content fIn |
+            contentIn.getContent() = fIn and
+            contentOut = TContentNone() and
+            compatibleTypes(fIn.getType(), getErasedNodeTypeBound(node))
+          )
+          or
+          // (getter+)setter
+          exists(Content fOut |
+            contentOut.getContent() = fOut and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
+          )
+        else any()
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlow0(
+        ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
+      ) {
+        p = node and
+        Cand::cand(p, _) and
+        contentIn = TContentNone() and
+        contentOut = TContentNone()
+        or
+        // local flow
+        exists(Node mid |
+          parameterValueFlow(p, mid, contentIn, contentOut) and
+          LocalFlowBigStep::localFlowBigStep(mid, node)
+        )
+        or
+        // read
+        exists(Node mid, Content f, ContentOption contentInMid, ContentOption contentOutMid |
+          parameterValueFlow(p, mid, contentInMid, contentOutMid) and
+          readStep(mid, f, node)
+        |
+          // value neither read nor stored prior to read
+          contentInMid = TContentNone() and
+          contentOutMid = TContentNone() and
+          contentIn.getContent() = f and
+          contentOut = TContentNone() and
+          Cand::parameterValueFlowReturnCand(p, _, true, _) and
+          compatibleTypes(getErasedNodeTypeBound(p), f.getContainerType())
+          or
+          // value (possibly read and then) stored prior to read (same content)
+          contentIn = contentInMid and
+          contentOutMid.getContent() = f and
+          contentOut = TContentNone()
+        )
+        or
+        // store
+        exists(Node mid, Content f |
+          parameterValueFlow(p, mid, contentIn, TContentNone()) and
+          storeStep(mid, f, node) and
+          contentOut.getContent() = f
+        |
+          contentIn = TContentNone() and
+          compatibleTypes(getErasedNodeTypeBound(p), f.getType())
+          or
+          compatibleTypes(contentIn.getContent().getType(), f.getType())
+        )
+        or
+        // flow through: no prior read or store
+        exists(ArgumentNode arg |
+          parameterValueFlowArg(p, arg, TContentNone(), TContentNone()) and
+          argumentValueFlowsThrough(_, arg, contentIn, contentOut, node)
+        )
+        or
+        // flow through: no read or store inside method
+        exists(ArgumentNode arg |
+          parameterValueFlowArg(p, arg, contentIn, contentOut) and
+          argumentValueFlowsThrough(_, arg, TContentNone(), TContentNone(), node)
+        )
+        or
+        // flow through: possible prior read and prior store with compatible
+        // flow-through method
+        exists(ArgumentNode arg, ContentOption contentMid |
+          parameterValueFlowArg(p, arg, contentIn, contentMid) and
+          argumentValueFlowsThrough(_, arg, contentMid, contentOut, node)
+        )
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowArg(
+        ParameterNode p, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow(p, arg, contentIn, contentOut) and
+        Cand::argumentValueFlowsThroughCand(arg, _, _, _)
+      }
+
+      pragma[nomagic]
+      private predicate argumentValueFlowsThrough0(
+        DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, ContentOption contentIn,
+        ContentOption contentOut
+      ) {
+        exists(ParameterNode param | viableParamArg(call, param, arg) |
+          parameterValueFlowReturn(param, _, kind, contentIn, contentOut)
+        )
+      }
+
+      /**
+       * Holds if `arg` flows to `out` through `call` using only value-preserving steps,
+       * not taking call contexts into account.
+       *
+       * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
+       * `contentOut` describes the content of `out` that it flows to (if any).
+       */
+      cached
+      predicate argumentValueFlowsThrough(
+        DataFlowCall call, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut,
+        Node out
+      ) {
+        exists(ReturnKindExt kind |
+          argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
+          out = kind.getAnOutNode(call)
+        |
+          // normal flow through
+          contentIn = TContentNone() and
+          contentOut = TContentNone() and
+          compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
+          or
+          // getter
+          exists(Content fIn |
+            contentIn.getContent() = fIn and
+            contentOut = TContentNone() and
+            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType()) and
+            compatibleTypes(fIn.getType(), getErasedNodeTypeBound(out))
+          )
+          or
+          // setter
+          exists(Content fOut |
+            contentIn = TContentNone() and
+            contentOut.getContent() = fOut and
+            compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(out))
+          )
+          or
+          // getter+setter
+          exists(Content fIn, Content fOut |
+            contentIn.getContent() = fIn and
+            contentOut.getContent() = fOut and
+            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(out))
+          )
+        )
+      }
+
+      /**
+       * Holds if `p` can flow to the pre-update node associated with post-update
+       * node `n`, in the same callable, using only value-preserving steps.
+       */
+      cached
+      predicate parameterValueFlowsToPreUpdate(ParameterNode p, PostUpdateNode n) {
+        parameterValueFlow(p, n.getPreUpdateNode(), TContentNone(), TContentNone())
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowsToPostUpdate(
+        ParameterNode p, PostUpdateNode n, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow(p, n, contentIn, contentOut) and
+        contentOut.hasContent()
+      }
+
+      /**
+       * Holds if `p` can flow to a return node of kind `kind` in the same
+       * callable using only value-preserving steps.
+       *
+       * `contentIn` describes the content of `p` that can flow to the return
+       * node (if any), and `contentOut` describes the content of the return
+       * node that it flows to (if any).
+       */
+      cached
+      predicate parameterValueFlowReturn(
+        ParameterNode p, Node ret, ReturnKindExt kind, ContentOption contentIn,
+        ContentOption contentOut
+      ) {
+        ret =
+          any(ReturnNode n |
+            parameterValueFlow(p, n, contentIn, contentOut) and
+            kind = TValueReturn(n.getKind())
+          )
+        or
+        ret =
+          any(PostUpdateNode n |
+            exists(ParameterNode p2, int pos2 |
+              parameterValueFlowsToPostUpdate(p, n, contentIn, contentOut) and
+              parameterValueFlowsToPreUpdate(p2, n) and
+              p2.isParameterOf(_, pos2) and
+              kind = TParamUpdate(pos2) and
+              p != p2
+            )
+          )
+      }
+    }
+
+    import Final
+  }
+
+  /**
+   * Holds if data can flow from `node1` to `node2` via a direct assignment to
+   * `f`.
+   *
+   * This includes reverse steps through reads when the result of the read has
+   * been stored into, in order to handle cases like `x.f1.f2 = y`.
+   */
+  cached
+  predicate storeDirect(Node node1, Content f, Node node2) {
+    storeStep(node1, f, node2) and readStep(_, f, _)
+    or
+    exists(Node n1, Node n2 |
+      n1 = node1.(PostUpdateNode).getPreUpdateNode() and
+      n2 = node2.(PostUpdateNode).getPreUpdateNode()
+    |
+      argumentValueFlowsThrough(_, n2, TContentSome(f), TContentNone(), n1)
+      or
+      readStep(n2, f, n1)
+    )
+  }
+
+  import FlowThrough
+
+  /**
+   * Holds if the call context `call` either improves virtual dispatch in
+   * `callable` or if it allows us to prune unreachable nodes in `callable`.
+   */
+  cached
+  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+    reducedViableImplInCallContext(_, callable, call)
+    or
+    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+  }
 
   cached
-  private module Cached {
-    /**
-     * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
-     * The instance parameter is considered to have index `-1`.
-     */
-    pragma[nomagic]
-    private predicate viableParam(DataFlowCall call, int i, ParameterNode p) {
-      p.isParameterOf(viableCallable(call), i)
-    }
+  newtype TCallContext =
+    TAnyCallContext() or
+    TSpecificCall(DataFlowCall call) { recordDataFlowCallSite(call, _) } or
+    TSomeCall() or
+    TReturn(DataFlowCallable c, DataFlowCall call) { reducedViableImplInReturn(c, call) }
 
-    /**
-     * Holds if `arg` is a possible argument to `p` in `call`, taking virtual
-     * dispatch into account.
-     */
-    cached
-    predicate viableParamArg(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-      exists(int i |
-        viableParam(call, i, p) and
-        arg.argumentOf(call, i)
+  cached
+  newtype TReturnPosition =
+    TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) {
+      exists(ReturnNodeExt ret |
+        c = returnNodeGetEnclosingCallable(ret) and
+        kind = ret.getKind()
       )
     }
 
-    /*
-     * The `FlowThrough_*` modules take a `step` relation as input and provide
-     * an `argumentValueFlowsThrough` relation as output.
-     *
-     * `FlowThrough_v1` includes just `simpleLocalFlowStep`, which is then used
-     * to detect getters and setters.
-     * `FlowThrough_v2` then includes a little bit of local field flow on top
-     * of `simpleLocalFlowStep`.
-     */
-
-    private module FlowThrough_v1 {
-      private predicate step = simpleLocalFlowStep/2;
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, not taking call contexts into account.
-       */
-      private predicate parameterValueFlowCand(ParameterNode p, Node node) {
-        p = node
-        or
-        exists(Node mid |
-          parameterValueFlowCand(p, mid) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlowCand(p, arg) and
-          argumentValueFlowsThroughCand(arg, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, not taking call contexts
-       * into account.
-       */
-      private predicate parameterValueFlowsThroughCand(ParameterNode p, ReturnKind kind) {
-        parameterValueFlowCand(p, getAReturnNodeOfKind(kind))
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThroughCand0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind
-      ) {
-        exists(ParameterNode param | viableParamArg(call, param, arg) |
-          parameterValueFlowsThroughCand(param, kind)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * not taking call contexts into account.
-       */
-      private predicate argumentValueFlowsThroughCand(ArgumentNode arg, OutNode out) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThroughCand0(call, arg, kind)
-        |
-          out = getAnOutNode(call, kind) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-
-      /**
-       * Holds if `arg` is the `i`th argument of `call` inside the callable
-       * `enclosing`, and `arg` may flow through `call`.
-       */
-      pragma[noinline]
-      private predicate argumentOf(
-        DataFlowCall call, int i, ArgumentNode arg, DataFlowCallable enclosing
-      ) {
-        arg.argumentOf(call, i) and
-        argumentValueFlowsThroughCand(arg, _) and
-        enclosing = arg.getEnclosingCallable()
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg0(
-        int i, ArgumentNode arg, CallContext outercc, DataFlowCall call
-      ) {
-        exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
-          (
-            outercc = TAnyCallContext()
-            or
-            outercc = TSomeCall()
-            or
-            exists(DataFlowCall other | outercc = TSpecificCall(other) |
-              recordDataFlowCallSite(other, c)
-            )
-          ) and
-          not isUnreachableInCall(arg, outercc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg1(
-        ParameterNode p, DataFlowCallable callable, int i, ArgumentNode arg, CallContext outercc,
-        DataFlowCall call
-      ) {
-        viableParamArg0(i, arg, outercc, call) and
-        callable = resolveCall(call, outercc) and
-        p.isParameterOf(callable, any(int j | j <= i and j >= i))
-      }
-
-      /**
-       * Holds if `arg` is a possible argument to `p`, in the call `call`, and
-       * `arg` may flow through `call`. The possible contexts before and after
-       * entering the callable are `outercc` and `innercc`, respectively.
-       */
-      private predicate viableParamArg(
-        DataFlowCall call, ParameterNode p, ArgumentNode arg, CallContext outercc,
-        CallContextCall innercc
-      ) {
-        exists(int i, DataFlowCallable callable |
-          viableParamArg1(p, callable, i, arg, outercc, call)
-        |
-          if recordDataFlowCallSite(call, callable)
-          then innercc = TSpecificCall(call)
-          else innercc = TSomeCall()
-        )
-      }
-
-      private CallContextCall getAValidCallContextForParameter(ParameterNode p) {
-        result = TSomeCall()
-        or
-        exists(DataFlowCall call, DataFlowCallable callable |
-          result = TSpecificCall(call) and
-          p.isParameterOf(callable, _) and
-          recordDataFlowCallSite(call, callable)
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlow(ParameterNode p, Node node, CallContextCall cc) {
-        p = node and
-        parameterValueFlowsThroughCand(p, _) and
-        cc = getAValidCallContextForParameter(p)
-        or
-        exists(Node mid |
-          parameterValueFlow(p, mid, cc) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlow(p, arg, cc) and
-          argumentValueFlowsThrough(arg, node, cc) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlowsThrough(
-        ParameterNode p, ReturnKind kind, CallContextCall cc
-      ) {
-        parameterValueFlow(p, getAReturnNodeOfKind(kind), cc)
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThrough0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind, CallContext cc
-      ) {
-        exists(ParameterNode param, CallContext innercc |
-          viableParamArg(call, param, arg, cc, innercc) and
-          parameterValueFlowsThrough(param, kind, innercc)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * in call context cc.
-       */
-      predicate argumentValueFlowsThrough(ArgumentNode arg, OutNode out, CallContext cc) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThrough0(call, arg, kind, cc)
-        |
-          out = getAnOutNode(call, kind) and
-          not isUnreachableInCall(out, cc.(CallContextSpecificCall).getCall()) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-    }
-
-    /**
-     * Holds if `p` can flow to the pre-update node of `n` in the same callable
-     * using only value-preserving steps.
-     */
-    cached
-    predicate parameterValueFlowsToUpdate(ParameterNode p, PostUpdateNode n) {
-      parameterValueFlowNoCtx(p, n.getPreUpdateNode())
-    }
-
-    /**
-     * Holds if data can flow from `node1` to `node2` in one local step or a step
-     * through a value-preserving method.
-     */
-    private predicate localValueStep(Node node1, Node node2) {
-      simpleLocalFlowStep(node1, node2) or
-      FlowThrough_v1::argumentValueFlowsThrough(node1, node2, _)
-    }
-
-    /**
-     * Holds if `p` can flow to `node` in the same callable allowing local flow
-     * steps and value flow through methods. Call contexts are only accounted
-     * for in the nested calls.
-     */
-    private predicate parameterValueFlowNoCtx(ParameterNode p, Node node) {
-      p = node
-      or
-      exists(Node mid |
-        parameterValueFlowNoCtx(p, mid) and
-        localValueStep(mid, node) and
-        compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-      )
-    }
-
-    /*
-     * Calculation of `predicate store(Node node1, Content f, Node node2)`:
-     * There are four cases:
-     * - The base case: A direct local assignment given by `storeStep`.
-     * - A call to a method or constructor with two arguments, `arg1` and `arg2`,
-     *   such that the call has the side-effect `arg2.f = arg1`.
-     * - A call to a method that returns an object in which an argument has been
-     *   stored.
-     * - A reverse step through a read when the result of the read has been
-     *   stored into. This handles cases like `x.f1.f2 = y`.
-     * `storeViaSideEffect` covers the first two cases, and `storeReturn` covers
-     * the third case.
-     */
-
-    /**
-     * Holds if data can flow from `node1` to `node2` via a direct assignment to
-     * `f` or via a call that acts as a setter.
-     */
-    cached
-    predicate store(Node node1, Content f, Node node2) {
-      storeViaSideEffect(node1, f, node2) or
-      storeReturn(node1, f, node2) or
-      read(node2.(PostUpdateNode).getPreUpdateNode(), f, node1.(PostUpdateNode).getPreUpdateNode())
-    }
-
-    private predicate storeViaSideEffect(Node node1, Content f, PostUpdateNode node2) {
-      storeStep(node1, f, node2) and readStep(_, f, _)
-      or
-      exists(DataFlowCall call, int i1, int i2 |
-        setterCall(call, i1, i2, f) and
-        node1.(ArgumentNode).argumentOf(call, i1) and
-        node2.getPreUpdateNode().(ArgumentNode).argumentOf(call, i2) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getContainerType())
-      )
-    }
-
-    pragma[nomagic]
-    private predicate setterInParam(ParameterNode p1, Content f, ParameterNode p2) {
-      exists(Node n1, PostUpdateNode n2 |
-        parameterValueFlowNoCtx(p1, n1) and
-        storeViaSideEffect(n1, f, n2) and
-        parameterValueFlowNoCtx(p2, n2.getPreUpdateNode()) and
-        p1 != p2
-      )
-    }
-
-    pragma[nomagic]
-    private predicate setterCall(DataFlowCall call, int i1, int i2, Content f) {
-      exists(DataFlowCallable callable, ParameterNode p1, ParameterNode p2 |
-        setterInParam(p1, f, p2) and
-        callable = viableCallable(call) and
-        p1.isParameterOf(callable, i1) and
-        p2.isParameterOf(callable, i2)
-      )
-    }
-
-    pragma[noinline]
-    private predicate storeReturn0(DataFlowCall call, ReturnKind kind, ArgumentNode arg, Content f) {
-      exists(ParameterNode p |
-        viableParamArg(call, p, arg) and
-        setterReturn(p, f, kind)
-      )
-    }
-
-    private predicate storeReturn(Node node1, Content f, Node node2) {
-      exists(DataFlowCall call, ReturnKind kind |
-        storeReturn0(call, kind, node1, f) and
-        node2 = getAnOutNode(call, kind) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getContainerType())
-      )
-    }
-
-    private predicate setterReturn(ParameterNode p, Content f, ReturnKind kind) {
-      exists(Node n1, Node n2 |
-        parameterValueFlowNoCtx(p, n1) and
-        store(n1, f, n2) and
-        localValueStep*(n2, getAReturnNodeOfKind(kind))
-      )
-    }
-
-    pragma[noinline]
-    private predicate read0(DataFlowCall call, ReturnKind kind, ArgumentNode arg, Content f) {
-      exists(ParameterNode p |
-        viableParamArg(call, p, arg) and
-        getter(p, f, kind)
-      )
-    }
-
-    /**
-     * Holds if data can flow from `node1` to `node2` via a direct read of `f` or
-     * via a getter.
-     */
-    cached
-    predicate read(Node node1, Content f, Node node2) {
-      readStep(node1, f, node2)
-      or
-      exists(DataFlowCall call, ReturnKind kind |
-        read0(call, kind, node1, f) and
-        node2 = getAnOutNode(call, kind) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getContainerType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getType())
-      )
-    }
-
-    private predicate getter(ParameterNode p, Content f, ReturnKind kind) {
-      exists(Node n1, Node n2 |
-        parameterValueFlowNoCtx(p, n1) and
-        read(n1, f, n2) and
-        localValueStep*(n2, getAReturnNodeOfKind(kind))
-      )
-    }
-
-    cached
-    predicate localStoreReadStep(Node node1, Node node2) {
-      exists(Node mid1, Node mid2, Content f |
-        store(node1, f, mid1) and
-        localValueStep*(mid1, mid2) and
-        read(mid2, f, node2) and
-        compatibleTypes(getErasedNodeTypeBound(node1), getErasedNodeTypeBound(node2))
-      )
-    }
-
-    cached
-    module FlowThrough_v2 {
-      private predicate step(Node node1, Node node2) {
-        simpleLocalFlowStep(node1, node2) or
-        localStoreReadStep(node1, node2)
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, not taking call contexts into account.
-       */
-      private predicate parameterValueFlowCand(ParameterNode p, Node node) {
-        p = node
-        or
-        exists(Node mid |
-          parameterValueFlowCand(p, mid) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlowCand(p, arg) and
-          argumentValueFlowsThroughCand(arg, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, not taking call contexts
-       * into account.
-       */
-      private predicate parameterValueFlowsThroughCand(ParameterNode p, ReturnKind kind) {
-        parameterValueFlowCand(p, getAReturnNodeOfKind(kind))
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThroughCand0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind
-      ) {
-        exists(ParameterNode param | viableParamArg(call, param, arg) |
-          parameterValueFlowsThroughCand(param, kind)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * not taking call contexts into account.
-       */
-      private predicate argumentValueFlowsThroughCand(ArgumentNode arg, OutNode out) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThroughCand0(call, arg, kind)
-        |
-          out = getAnOutNode(call, kind) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-
-      /**
-       * Holds if `arg` is the `i`th argument of `call` inside the callable
-       * `enclosing`, and `arg` may flow through `call`.
-       */
-      pragma[noinline]
-      private predicate argumentOf(
-        DataFlowCall call, int i, ArgumentNode arg, DataFlowCallable enclosing
-      ) {
-        arg.argumentOf(call, i) and
-        argumentValueFlowsThroughCand(arg, _) and
-        enclosing = arg.getEnclosingCallable()
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg0(
-        int i, ArgumentNode arg, CallContext outercc, DataFlowCall call
-      ) {
-        exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
-          (
-            outercc = TAnyCallContext()
-            or
-            outercc = TSomeCall()
-            or
-            exists(DataFlowCall other | outercc = TSpecificCall(other) |
-              recordDataFlowCallSite(other, c)
-            )
-          ) and
-          not isUnreachableInCall(arg, outercc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg1(
-        ParameterNode p, DataFlowCallable callable, int i, ArgumentNode arg, CallContext outercc,
-        DataFlowCall call
-      ) {
-        viableParamArg0(i, arg, outercc, call) and
-        callable = resolveCall(call, outercc) and
-        p.isParameterOf(callable, any(int j | j <= i and j >= i))
-      }
-
-      /**
-       * Holds if `arg` is a possible argument to `p`, in the call `call`, and
-       * `arg` may flow through `call`. The possible contexts before and after
-       * entering the callable are `outercc` and `innercc`, respectively.
-       */
-      private predicate viableParamArg(
-        DataFlowCall call, ParameterNode p, ArgumentNode arg, CallContext outercc,
-        CallContextCall innercc
-      ) {
-        exists(int i, DataFlowCallable callable |
-          viableParamArg1(p, callable, i, arg, outercc, call)
-        |
-          if recordDataFlowCallSite(call, callable)
-          then innercc = TSpecificCall(call)
-          else innercc = TSomeCall()
-        )
-      }
-
-      private CallContextCall getAValidCallContextForParameter(ParameterNode p) {
-        result = TSomeCall()
-        or
-        exists(DataFlowCall call, DataFlowCallable callable |
-          result = TSpecificCall(call) and
-          p.isParameterOf(callable, _) and
-          recordDataFlowCallSite(call, callable)
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlow(ParameterNode p, Node node, CallContextCall cc) {
-        p = node and
-        parameterValueFlowsThroughCand(p, _) and
-        cc = getAValidCallContextForParameter(p)
-        or
-        exists(Node mid |
-          parameterValueFlow(p, mid, cc) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlow(p, arg, cc) and
-          argumentValueFlowsThrough(arg, node, cc) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, in call context `cc`.
-       */
-      cached
-      predicate parameterValueFlowsThrough(ParameterNode p, ReturnKind kind, CallContextCall cc) {
-        parameterValueFlow(p, getAReturnNodeOfKind(kind), cc)
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThrough0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind, CallContext cc
-      ) {
-        exists(ParameterNode param, CallContext innercc |
-          viableParamArg(call, param, arg, cc, innercc) and
-          parameterValueFlowsThrough(param, kind, innercc)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * in call context cc.
-       */
-      cached
-      predicate argumentValueFlowsThrough(ArgumentNode arg, OutNode out, CallContext cc) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThrough0(call, arg, kind, cc)
-        |
-          out = getAnOutNode(call, kind) and
-          not isUnreachableInCall(out, cc.(CallContextSpecificCall).getCall()) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-    }
-
-    /**
-     * Holds if the call context `call` either improves virtual dispatch in
-     * `callable` or if it allows us to prune unreachable nodes in `callable`.
-     */
-    cached
-    predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
-      reducedViableImplInCallContext(_, callable, call)
-      or
-      exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
-    }
-
-    cached
-    newtype TCallContext =
-      TAnyCallContext() or
-      TSpecificCall(DataFlowCall call) { recordDataFlowCallSite(call, _) } or
-      TSomeCall() or
-      TReturn(DataFlowCallable c, DataFlowCall call) { reducedViableImplInReturn(c, call) }
-
-    cached
-    newtype TReturnPosition =
-      TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) { returnPosition(_, c, kind) }
-
-    cached
-    newtype TLocalFlowCallContext =
-      TAnyLocalCall() or
-      TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
-  }
-
-  pragma[noinline]
-  private predicate returnPosition(ReturnNodeExt ret, DataFlowCallable c, ReturnKindExt kind) {
-    c = returnNodeGetEnclosingCallable(ret) and
-    kind = ret.getKind()
-  }
-
-  /**
-   * A call context to restrict the targets of virtual dispatch, prune local flow,
-   * and match the call sites of flow into a method with flow out of a method.
-   *
-   * There are four cases:
-   * - `TAnyCallContext()` : No restrictions on method flow.
-   * - `TSpecificCall(DataFlowCall call)` : Flow entered through the
-   *    given `call`. This call improves the set of viable
-   *    dispatch targets for at least one method call in the current callable
-   *    or helps prune unreachable nodes in the current callable.
-   * - `TSomeCall()` : Flow entered through a parameter. The
-   *    originating call does not improve the set of dispatch targets for any
-   *    method call in the current callable and was therefore not recorded.
-   * - `TReturn(Callable c, DataFlowCall call)` : Flow reached `call` from `c` and
-   *    this dispatch target of `call` implies a reduced set of dispatch origins
-   *    to which data may flow if it should reach a `return` statement.
-   */
-  abstract class CallContext extends TCallContext {
-    abstract string toString();
-
-    /** Holds if this call context is relevant for `callable`. */
-    abstract predicate relevantFor(DataFlowCallable callable);
-  }
-
-  class CallContextAny extends CallContext, TAnyCallContext {
-    override string toString() { result = "CcAny" }
-
-    override predicate relevantFor(DataFlowCallable callable) { any() }
-  }
-
-  abstract class CallContextCall extends CallContext { }
-
-  class CallContextSpecificCall extends CallContextCall, TSpecificCall {
-    override string toString() {
-      exists(DataFlowCall call | this = TSpecificCall(call) | result = "CcCall(" + call + ")")
-    }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      recordDataFlowCallSite(getCall(), callable)
-    }
-
-    DataFlowCall getCall() { this = TSpecificCall(result) }
-  }
-
-  class CallContextSomeCall extends CallContextCall, TSomeCall {
-    override string toString() { result = "CcSomeCall" }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      exists(ParameterNode p | p.getEnclosingCallable() = callable)
-    }
-  }
-
-  class CallContextReturn extends CallContext, TReturn {
-    override string toString() {
-      exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
-    }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      exists(DataFlowCall call | this = TReturn(_, call) and call.getEnclosingCallable() = callable)
-    }
-  }
-
-  /**
-   * A call context that is relevant for pruning local flow.
-   */
-  abstract class LocalCallContext extends TLocalFlowCallContext {
-    abstract string toString();
-
-    /** Holds if this call context is relevant for `callable`. */
-    abstract predicate relevantFor(DataFlowCallable callable);
-  }
-
-  class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
-    override string toString() { result = "LocalCcAny" }
-
-    override predicate relevantFor(DataFlowCallable callable) { any() }
-  }
-
-  class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
-    LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
-
-    DataFlowCall call;
-
-    DataFlowCall getCall() { result = call }
-
-    override string toString() { result = "LocalCcCall(" + call + ")" }
-
-    override predicate relevantFor(DataFlowCallable callable) { relevantLocalCCtx(call, callable) }
-  }
-
-  private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
-    exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
-  }
-
-  /**
-   * Gets the local call context given the call context and the callable that
-   * the contexts apply to.
-   */
-  LocalCallContext getLocalCallContext(CallContext ctx, DataFlowCallable callable) {
-    ctx.relevantFor(callable) and
-    if relevantLocalCCtx(ctx.(CallContextSpecificCall).getCall(), callable)
-    then result.(LocalCallContextSpecificCall).getCall() = ctx.(CallContextSpecificCall).getCall()
-    else result instanceof LocalCallContextAny
-  }
-
-  /**
-   * A node from which flow can return to the caller. This is either a regular
-   * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
-   */
-  class ReturnNodeExt extends Node {
-    ReturnNodeExt() {
-      this instanceof ReturnNode or
-      parameterValueFlowsToUpdate(_, this)
-    }
-
-    /** Gets the kind of this returned value. */
-    ReturnKindExt getKind() {
-      result = TValueReturn(this.(ReturnNode).getKind())
-      or
-      exists(ParameterNode p, int pos |
-        parameterValueFlowsToUpdate(p, this) and
-        p.isParameterOf(_, pos) and
-        result = TParamUpdate(pos)
-      )
-    }
-  }
-
-  private newtype TReturnKindExt =
+  cached
+  newtype TLocalFlowCallContext =
+    TAnyLocalCall() or
+    TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
+
+  cached
+  newtype TReturnKindExt =
     TValueReturn(ReturnKind kind) or
-    TParamUpdate(int pos) {
-      exists(ParameterNode p | parameterValueFlowsToUpdate(p, _) and p.isParameterOf(_, pos))
-    }
-
-  /**
-   * An extended return kind. A return kind describes how data can be returned
-   * from a callable. This can either be through a returned value or an updated
-   * parameter.
-   */
-  abstract class ReturnKindExt extends TReturnKindExt {
-    /** Gets a textual representation of this return kind. */
-    abstract string toString();
-
-    /** Gets a node corresponding to data flow out of `call`. */
-    abstract Node getAnOutNode(DataFlowCall call);
-  }
-
-  class ValueReturnKind extends ReturnKindExt, TValueReturn {
-    private ReturnKind kind;
-
-    ValueReturnKind() { this = TValueReturn(kind) }
-
-    ReturnKind getKind() { result = kind }
-
-    override string toString() { result = kind.toString() }
-
-    override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
-  }
-
-  class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
-    private int pos;
-
-    ParamUpdateReturnKind() { this = TParamUpdate(pos) }
-
-    int getPosition() { result = pos }
-
-    override string toString() { result = "param update " + pos }
-
-    override Node getAnOutNode(DataFlowCall call) {
-      exists(ArgumentNode arg |
-        result.(PostUpdateNode).getPreUpdateNode() = arg and
-        arg.argumentOf(call, this.getPosition())
-      )
-    }
-  }
-
-  /** A callable tagged with a relevant return kind. */
-  class ReturnPosition extends TReturnPosition0 {
-    private DataFlowCallable c;
-    private ReturnKindExt kind;
-
-    ReturnPosition() { this = TReturnPosition0(c, kind) }
-
-    /** Gets the callable. */
-    DataFlowCallable getCallable() { result = c }
-
-    /** Gets the return kind. */
-    ReturnKindExt getKind() { result = kind }
-
-    /** Gets a textual representation of this return position. */
-    string toString() { result = "[" + kind + "] " + c }
-  }
-
-  pragma[noinline]
-  DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
-    result = ret.getEnclosingCallable()
-  }
-
-  pragma[noinline]
-  ReturnPosition getReturnPosition(ReturnNodeExt ret) {
-    exists(DataFlowCallable c, ReturnKindExt k | returnPosition(ret, c, k) |
-      result = TReturnPosition0(c, k)
-    )
-  }
-
-  bindingset[cc, callable]
-  predicate resolveReturn(CallContext cc, DataFlowCallable callable, DataFlowCall call) {
-    cc instanceof CallContextAny and callable = viableCallable(call)
-    or
-    exists(DataFlowCallable c0, DataFlowCall call0 |
-      call0.getEnclosingCallable() = callable and
-      cc = TReturn(c0, call0) and
-      c0 = prunedViableImplInCallContextReverse(call0, call)
-    )
-  }
-
-  bindingset[call, cc]
-  DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
-    exists(DataFlowCall ctx | cc = TSpecificCall(ctx) |
-      if reducedViableImplInCallContext(call, _, ctx)
-      then result = prunedViableImplInCallContext(call, ctx)
-      else result = viableCallable(call)
-    )
-    or
-    result = viableCallable(call) and cc instanceof CallContextSomeCall
-    or
-    result = viableCallable(call) and cc instanceof CallContextAny
-    or
-    result = viableCallable(call) and cc instanceof CallContextReturn
-  }
-
-  newtype TSummary =
-    TSummaryVal() or
-    TSummaryTaint() or
-    TSummaryReadVal(Content f) or
-    TSummaryReadTaint(Content f) or
-    TSummaryTaintStore(Content f)
-
-  /**
-   * A summary of flow through a callable. This can either be value-preserving
-   * if no additional steps are used, taint-flow if at least one additional step
-   * is used, or any one of those combined with a store or a read. Summaries
-   * recorded at a return node are restricted to include at least one additional
-   * step, as the value-based summaries are calculated independent of the
-   * configuration.
-   */
-  class Summary extends TSummary {
-    string toString() {
-      result = "Val" and this = TSummaryVal()
-      or
-      result = "Taint" and this = TSummaryTaint()
-      or
-      exists(Content f |
-        result = "ReadVal " + f.toString() and this = TSummaryReadVal(f)
-        or
-        result = "ReadTaint " + f.toString() and this = TSummaryReadTaint(f)
-        or
-        result = "TaintStore " + f.toString() and this = TSummaryTaintStore(f)
-      )
-    }
-
-    /** Gets the summary that results from extending this with an additional step. */
-    Summary additionalStep() {
-      this = TSummaryVal() and result = TSummaryTaint()
-      or
-      this = TSummaryTaint() and result = TSummaryTaint()
-      or
-      exists(Content f | this = TSummaryReadVal(f) and result = TSummaryReadTaint(f))
-      or
-      exists(Content f | this = TSummaryReadTaint(f) and result = TSummaryReadTaint(f))
-    }
-
-    /** Gets the summary that results from extending this with a read. */
-    Summary readStep(Content f) { this = TSummaryVal() and result = TSummaryReadVal(f) }
-
-    /** Gets the summary that results from extending this with a store. */
-    Summary storeStep(Content f) { this = TSummaryTaint() and result = TSummaryTaintStore(f) }
-
-    /** Gets the summary that results from extending this with `step`. */
-    bindingset[this, step]
-    Summary compose(Summary step) {
-      this = TSummaryVal() and result = step
-      or
-      this = TSummaryTaint() and
-      (step = TSummaryTaint() or step = TSummaryTaintStore(_)) and
-      result = step
-      or
-      exists(Content f |
-        this = TSummaryReadVal(f) and step = TSummaryTaint() and result = TSummaryReadTaint(f)
-      )
-      or
-      this = TSummaryReadTaint(_) and step = TSummaryTaint() and result = this
-    }
-
-    /** Holds if this summary does not include any taint steps. */
-    predicate isPartial() {
-      this = TSummaryVal() or
-      this = TSummaryReadVal(_)
-    }
-  }
-
-  pragma[noinline]
-  DataFlowType getErasedNodeType(Node n) { result = getErasedRepr(n.getType()) }
-
-  pragma[noinline]
-  DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
+    TParamUpdate(int pos) { exists(ParameterNode p | p.isParameterOf(_, pos)) }
 }
+
+/**
+ * A `Node` at which a cast can occur such that the type should be checked.
+ */
+class CastingNode extends Node {
+  CastingNode() {
+    this instanceof ParameterNode or
+    this instanceof CastNode or
+    this instanceof OutNode or
+    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+  }
+}
+
+newtype TContentOption =
+  TContentNone() or
+  TContentSome(Content f)
+
+class ContentOption extends TContentOption {
+  Content getContent() { this = TContentSome(result) }
+
+  predicate hasContent() { exists(this.getContent()) }
+
+  string toString() {
+    result = this.getContent().toString()
+    or
+    not this.hasContent() and
+    result = "<none>"
+  }
+}
+
+/**
+ * A call context to restrict the targets of virtual dispatch, prune local flow,
+ * and match the call sites of flow into a method with flow out of a method.
+ *
+ * There are four cases:
+ * - `TAnyCallContext()` : No restrictions on method flow.
+ * - `TSpecificCall(DataFlowCall call)` : Flow entered through the
+ *    given `call`. This call improves the set of viable
+ *    dispatch targets for at least one method call in the current callable
+ *    or helps prune unreachable nodes in the current callable.
+ * - `TSomeCall()` : Flow entered through a parameter. The
+ *    originating call does not improve the set of dispatch targets for any
+ *    method call in the current callable and was therefore not recorded.
+ * - `TReturn(Callable c, DataFlowCall call)` : Flow reached `call` from `c` and
+ *    this dispatch target of `call` implies a reduced set of dispatch origins
+ *    to which data may flow if it should reach a `return` statement.
+ */
+abstract class CallContext extends TCallContext {
+  abstract string toString();
+
+  /** Holds if this call context is relevant for `callable`. */
+  abstract predicate relevantFor(DataFlowCallable callable);
+}
+
+class CallContextAny extends CallContext, TAnyCallContext {
+  override string toString() { result = "CcAny" }
+
+  override predicate relevantFor(DataFlowCallable callable) { any() }
+}
+
+abstract class CallContextCall extends CallContext { }
+
+class CallContextSpecificCall extends CallContextCall, TSpecificCall {
+  override string toString() {
+    exists(DataFlowCall call | this = TSpecificCall(call) | result = "CcCall(" + call + ")")
+  }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    recordDataFlowCallSite(getCall(), callable)
+  }
+
+  DataFlowCall getCall() { this = TSpecificCall(result) }
+}
+
+class CallContextSomeCall extends CallContextCall, TSomeCall {
+  override string toString() { result = "CcSomeCall" }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    exists(ParameterNode p | p.getEnclosingCallable() = callable)
+  }
+}
+
+class CallContextReturn extends CallContext, TReturn {
+  override string toString() {
+    exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
+  }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    exists(DataFlowCall call | this = TReturn(_, call) and call.getEnclosingCallable() = callable)
+  }
+}
+
+/**
+ * A call context that is relevant for pruning local flow.
+ */
+abstract class LocalCallContext extends TLocalFlowCallContext {
+  abstract string toString();
+
+  /** Holds if this call context is relevant for `callable`. */
+  abstract predicate relevantFor(DataFlowCallable callable);
+}
+
+class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
+  override string toString() { result = "LocalCcAny" }
+
+  override predicate relevantFor(DataFlowCallable callable) { any() }
+}
+
+class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
+  LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
+
+  DataFlowCall call;
+
+  DataFlowCall getCall() { result = call }
+
+  override string toString() { result = "LocalCcCall(" + call + ")" }
+
+  override predicate relevantFor(DataFlowCallable callable) { relevantLocalCCtx(call, callable) }
+}
+
+private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
+  exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
+}
+
+/**
+ * Gets the local call context given the call context and the callable that
+ * the contexts apply to.
+ */
+LocalCallContext getLocalCallContext(CallContext ctx, DataFlowCallable callable) {
+  ctx.relevantFor(callable) and
+  if relevantLocalCCtx(ctx.(CallContextSpecificCall).getCall(), callable)
+  then result.(LocalCallContextSpecificCall).getCall() = ctx.(CallContextSpecificCall).getCall()
+  else result instanceof LocalCallContextAny
+}
+
+/**
+ * A node from which flow can return to the caller. This is either a regular
+ * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
+ */
+class ReturnNodeExt extends Node {
+  ReturnNodeExt() {
+    this instanceof ReturnNode or
+    parameterValueFlowsToPreUpdate(_, this)
+  }
+
+  /** Gets the kind of this returned value. */
+  ReturnKindExt getKind() {
+    result = TValueReturn(this.(ReturnNode).getKind())
+    or
+    exists(ParameterNode p, int pos |
+      parameterValueFlowsToPreUpdate(p, this) and
+      p.isParameterOf(_, pos) and
+      result = TParamUpdate(pos)
+    )
+  }
+}
+
+/**
+ * An extended return kind. A return kind describes how data can be returned
+ * from a callable. This can either be through a returned value or an updated
+ * parameter.
+ */
+abstract class ReturnKindExt extends TReturnKindExt {
+  /** Gets a textual representation of this return kind. */
+  abstract string toString();
+
+  /** Gets a node corresponding to data flow out of `call`. */
+  abstract Node getAnOutNode(DataFlowCall call);
+}
+
+class ValueReturnKind extends ReturnKindExt, TValueReturn {
+  private ReturnKind kind;
+
+  ValueReturnKind() { this = TValueReturn(kind) }
+
+  ReturnKind getKind() { result = kind }
+
+  override string toString() { result = kind.toString() }
+
+  override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
+}
+
+class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
+  private int pos;
+
+  ParamUpdateReturnKind() { this = TParamUpdate(pos) }
+
+  int getPosition() { result = pos }
+
+  override string toString() { result = "param update " + pos }
+
+  override PostUpdateNode getAnOutNode(DataFlowCall call) {
+    exists(ArgumentNode arg |
+      result.getPreUpdateNode() = arg and
+      arg.argumentOf(call, this.getPosition())
+    )
+  }
+}
+
+/** A callable tagged with a relevant return kind. */
+class ReturnPosition extends TReturnPosition0 {
+  private DataFlowCallable c;
+  private ReturnKindExt kind;
+
+  ReturnPosition() { this = TReturnPosition0(c, kind) }
+
+  /** Gets the callable. */
+  DataFlowCallable getCallable() { result = c }
+
+  /** Gets the return kind. */
+  ReturnKindExt getKind() { result = kind }
+
+  /** Gets a textual representation of this return position. */
+  string toString() { result = "[" + kind + "] " + c }
+}
+
+pragma[noinline]
+private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
+  result = ret.getEnclosingCallable()
+}
+
+pragma[noinline]
+private ReturnPosition getReturnPosition0(ReturnNodeExt ret, ReturnKindExt kind) {
+  result.getCallable() = returnNodeGetEnclosingCallable(ret) and
+  kind = result.getKind()
+}
+
+pragma[noinline]
+ReturnPosition getReturnPosition(ReturnNodeExt ret) {
+  result = getReturnPosition0(ret, ret.getKind())
+}
+
+bindingset[cc, callable]
+predicate resolveReturn(CallContext cc, DataFlowCallable callable, DataFlowCall call) {
+  cc instanceof CallContextAny and callable = viableCallable(call)
+  or
+  exists(DataFlowCallable c0, DataFlowCall call0 |
+    call0.getEnclosingCallable() = callable and
+    cc = TReturn(c0, call0) and
+    c0 = prunedViableImplInCallContextReverse(call0, call)
+  )
+}
+
+bindingset[call, cc]
+DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
+  exists(DataFlowCall ctx | cc = TSpecificCall(ctx) |
+    if reducedViableImplInCallContext(call, _, ctx)
+    then result = prunedViableImplInCallContext(call, ctx)
+    else result = viableCallable(call)
+  )
+  or
+  result = viableCallable(call) and cc instanceof CallContextSomeCall
+  or
+  result = viableCallable(call) and cc instanceof CallContextAny
+  or
+  result = viableCallable(call) and cc instanceof CallContextReturn
+}
+
+newtype TSummary =
+  TSummaryVal() or
+  TSummaryTaint() or
+  TSummaryReadVal(Content f) or
+  TSummaryReadTaint(Content f) or
+  TSummaryTaintStore(Content f)
+
+/**
+ * A summary of flow through a callable. This can either be value-preserving
+ * if no additional steps are used, taint-flow if at least one additional step
+ * is used, or any one of those combined with a store or a read. Summaries
+ * recorded at a return node are restricted to include at least one additional
+ * step, as the value-based summaries are calculated independent of the
+ * configuration.
+ */
+class Summary extends TSummary {
+  string toString() {
+    result = "Val" and this = TSummaryVal()
+    or
+    result = "Taint" and this = TSummaryTaint()
+    or
+    exists(Content f |
+      result = "ReadVal " + f.toString() and this = TSummaryReadVal(f)
+      or
+      result = "ReadTaint " + f.toString() and this = TSummaryReadTaint(f)
+      or
+      result = "TaintStore " + f.toString() and this = TSummaryTaintStore(f)
+    )
+  }
+
+  /** Gets the summary that results from extending this with an additional step. */
+  Summary additionalStep() {
+    this = TSummaryVal() and result = TSummaryTaint()
+    or
+    this = TSummaryTaint() and result = TSummaryTaint()
+    or
+    exists(Content f | this = TSummaryReadVal(f) and result = TSummaryReadTaint(f))
+    or
+    exists(Content f | this = TSummaryReadTaint(f) and result = TSummaryReadTaint(f))
+  }
+
+  /** Gets the summary that results from extending this with a read. */
+  Summary readStep(Content f) { this = TSummaryVal() and result = TSummaryReadVal(f) }
+
+  /** Gets the summary that results from extending this with a store. */
+  Summary storeStep(Content f) { this = TSummaryTaint() and result = TSummaryTaintStore(f) }
+
+  /** Gets the summary that results from extending this with `step`. */
+  bindingset[this, step]
+  Summary compose(Summary step) {
+    this = TSummaryVal() and result = step
+    or
+    this = TSummaryTaint() and
+    (step = TSummaryTaint() or step = TSummaryTaintStore(_)) and
+    result = step
+    or
+    exists(Content f |
+      this = TSummaryReadVal(f) and step = TSummaryTaint() and result = TSummaryReadTaint(f)
+    )
+    or
+    this = TSummaryReadTaint(_) and step = TSummaryTaint() and result = this
+  }
+
+  /** Holds if this summary does not include any taint steps. */
+  predicate isPartial() {
+    this = TSummaryVal() or
+    this = TSummaryReadVal(_)
+  }
+}
+
+pragma[noinline]
+DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
+
+predicate readDirect = readStep/3;

--- a/ql/src/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -1,6 +1,6 @@
 private import go
 private import DataFlowUtil
-private import DataFlowImplCommon::Public
+private import DataFlowImplCommon
 
 private newtype TReturnKind =
   TSingleReturn() or
@@ -270,3 +270,5 @@ predicate isUnreachableInCall(Node n, DataFlowCall call) {
     guard.dominates(n.getBasicBlock())
   )
 }
+
+int accessPathLimit() { result = 5 }

--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -283,11 +283,10 @@ class CallNode extends ExprNode {
     exists(DataFlow::Node calleeSource | calleeSource = getACalleeSource() |
       result = calleeSource.asExpr()
       or
-      exists(Method m, InterfaceType declaredRecv, Type actualRecv |
-        calleeSource = m.getARead() and
-        declaredRecv = m.getReceiverType().(NamedType).getBaseType() and
-        actualRecv.implements(declaredRecv) and
-        result = actualRecv.getMethod(m.getName()).(DeclaredFunction).getFuncDecl()
+      exists(Method declared, Method actual |
+        calleeSource = declared.getARead() and
+        actual.implements(declared) and
+        result = actual.(DeclaredFunction).getFuncDecl()
       )
     )
   }

--- a/ql/test/library-tests/semmle/go/dataflow/CallGraph/main.go
+++ b/ql/test/library-tests/semmle/go/dataflow/CallGraph/main.go
@@ -33,3 +33,7 @@ func test(x *s1, y s2, z s3, b mybool, i I) {
 	id := func(x int) int { return x } // name: id
 	id(1)                              // callee: id
 }
+
+func test2(v interface{}) {
+	v.(interface{ m(int) }).m(0)       // callee: s3.m
+}


### PR DESCRIPTION
This ports over the changes from https://github.com/Semmle/ql/pull/2769, https://github.com/Semmle/ql/pull/2631, https://github.com/Semmle/ql/pull/2872, and https://github.com/Semmle/ql/pull/2822.

The last commit fixes the performance regression on `aws-sdk-go` we observed on the latest LGTM distribution upgrade. It was caused by https://git.semmle.com/Semmle/go/pull/239 but went undetected since `aws-sdk-go` wasn't part of our default benchmark suite; I've added it now. To verify that the fix doesn't break the call graph I ran a query over all Go projects on LGTM.com to compare the new and the old implementation (https://lgtm.com/query/6747287448283805953/), which found that the new implementation gives additional call-graph edges of the kind shown in the test, but doesn't lose any existing ones.

Performance looks [reasonable](https://git.semmle.com/max/dist-compare-reports/blob/master/go/update-data-flow/report.md), with a bit of a slowdown overall, but nothing I would be concerned about. (Obviously `aws-sdk-go` got a lot faster.)

Us usual, no need to review the first four commits since they simply port over changes that have already been reviewed.