### PR TITLE
Propagate data flow through receivers

### DIFF
--- a/ql/src/semmle/go/Decls.qll
+++ b/ql/src/semmle/go/Decls.qll
@@ -110,25 +110,23 @@ class FuncDef extends @funcdef, StmtParent, ExprParent {
 
   /** Gets a result variable of this function. */
   ResultVariable getAResultVar() {
-    result.getDeclaration() = getTypeExpr().getAResultDecl().getANameExpr()
+    result.getFunction() = this
   }
 
   /**
    * Gets the `i`th parameter of this function.
+   *
+   * The receiver variable, if any, is considered to be the -1st parameter.
    */
   Parameter getParameter(int i) {
-    result = rank[i + 1](Parameter parm, int j, int k |
-        parm.getDeclaration() = getTypeExpr().getParameterDecl(j).getNameExpr(k)
-      |
-        parm order by j, k
-      )
+    result.isParameterOf(this, i)
   }
 
   /**
    * Gets a parameter of this function.
    */
   Parameter getAParameter() {
-    result.getDeclaration() = getTypeExpr().getAParameterDecl().getNameExpr(_)
+    result.getFunction() = this
   }
 
   /**

--- a/ql/src/semmle/go/controlflow/IR.qll
+++ b/ql/src/semmle/go/controlflow/IR.qll
@@ -1021,7 +1021,7 @@ module IR {
    * An instruction initializing a parameter to the corresponding argument.
    */
   class InitParameterInstruction extends WriteInstruction, MkParameterInit {
-    ParameterOrReceiver parm;
+    Parameter parm;
 
     InitParameterInstruction() { this = MkParameterInit(parm) }
 
@@ -1042,7 +1042,7 @@ module IR {
    * An instruction reading the value of a function argument.
    */
   class ReadArgumentInstruction extends Instruction, MkArgumentNode {
-    ParameterOrReceiver parm;
+    Parameter parm;
 
     ReadArgumentInstruction() { this = MkArgumentNode(parm) }
 

--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -350,20 +350,6 @@ class MethodCallNode extends CallNode {
   override MethodDecl getACallee() { result = super.getACallee() }
 }
 
-/** A representation of a receiver initialization. */
-class ReceiverNode extends SsaNode {
-  override SsaExplicitDefinition ssa;
-  ReceiverVariable recv;
-
-  ReceiverNode() { ssa.getInstruction() = IR::initRecvInstruction(recv) }
-
-  /** Gets the receiver variable this node initializes. */
-  ReceiverVariable asReceiverVariable() { result = recv }
-
-  /** Holds if this node initializes the receiver of `fd`. */
-  predicate isReceiverOf(FuncDef fd) { recv = fd.(MethodDecl).getReceiver() }
-}
-
 /** A representation of a parameter initialization. */
 class ParameterNode extends SsaNode {
   override SsaExplicitDefinition ssa;
@@ -375,7 +361,16 @@ class ParameterNode extends SsaNode {
   override Parameter asParameter() { result = parm }
 
   /** Holds if this node initializes the `i`th parameter of `fd`. */
-  predicate isParameterOf(FuncDef fd, int i) { parm = fd.getParameter(i) }
+  predicate isParameterOf(FuncDef fd, int i) { parm.isParameterOf(fd, i) }
+}
+
+/** A representation of a receiver initialization. */
+class ReceiverNode extends ParameterNode {
+  override ReceiverVariable parm;
+
+  ReceiverVariable asReceiverVariable() { result = parm }
+
+  predicate isReceiverOf(MethodDecl m) { parm.isReceiverOf(m) }
 }
 
 /**

--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -430,10 +430,17 @@ class ArgumentNode extends Node {
    * Holds if this argument occurs at the given position in the given call.
    *
    * The receiver argument is considered to have index `-1`.
+   *
+   * Note that we currently do not track receiver arguments into calls to interface methods.
    */
   predicate argumentOf(CallExpr call, int pos) {
     call = c.asExpr() and
-    pos = i
+    pos = i and
+    (
+      i != -1
+      or
+      exists(c.(MethodCallNode).getTarget().getBody())
+    )
   }
 
   /**

--- a/ql/test/library-tests/semmle/go/dataflow/InterProceduralDataFlow/Test.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/InterProceduralDataFlow/Test.expected
@@ -16,3 +16,4 @@
 | main.go:53:16:53:24 | "source3" | main.go:10:14:10:14 | x |
 | pointers.go:6:13:6:21 | "source6" | main.go:10:14:10:14 | x |
 | pointers.go:6:13:6:21 | "source6" | pointers.go:15:11:15:12 | star expression |
+| receivers.go:11:12:11:29 | type conversion | receivers.go:6:10:6:13 | recv |

--- a/ql/test/library-tests/semmle/go/dataflow/InterProceduralDataFlow/receivers.go
+++ b/ql/test/library-tests/semmle/go/dataflow/InterProceduralDataFlow/receivers.go
@@ -1,0 +1,13 @@
+package main
+
+type mystring string
+
+func (recv mystring) sink() mystring {
+	sink := recv
+	return sink
+}
+
+func test20() {
+	source := mystring("source")
+	source.sink()
+}


### PR DESCRIPTION
The data-flow library now treats the receiver as just another parameter... almost. It turns out that propagating flow through receivers can become very imprecise in the presence of virtual calls to megamorphic methods like `Error` and `String`. As a quick workaround, we disable receiver flow for virtual calls (as suggested by @sauyon). Ideally we'd handle this in a more principled fashion, for example by more precisely resolving virtual calls, but I've seen cases where it's not at all clear how one would do that.

Evaluation looks [very good](https://git.semmle.com/max/dist-compare-reports/blob/master/go/receiver-flow/report.md) (internal link), in fact it looks so good that I wouldn't set too much store by the reported performance improvements, and rather read it as confirmation that there aren't any performance or result regressions.