### PR TITLE
.gitattributes: Use -text instead of binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Force git not to modify line endings for go files
-*.go binary
+# Force git not to modify line endings for go files under the ql directory
+ql/**/*.go -text
 
 # Force git not to modify line endings for dbschemes
-*.dbscheme binary
+*.dbscheme -text


### PR DESCRIPTION
Also only add attributes to go files under the ql directory.

Thought I'd make this PR since it doesn't really make sense to wait for go.mod extraction to be merged (or really for this change to be a part of it...).