### PR TITLE
Makefile: make testdb target phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,8 @@ build/testdb/check-upgrade-path : build/testdb/go.dbscheme ql/src/go.dbscheme
 	codeql dataset upgrade build/testdb --search-path upgrades
 	diff -q build/testdb/go.dbscheme ql/src/go.dbscheme
 
+.PHONY: build/testdb/go.dbscheme
 build/testdb/go.dbscheme: upgrades/initial/go.dbscheme
+	rm -rf build/testdb
 	echo >build/empty.trap
 	codeql dataset import -S upgrades/initial/go.dbscheme build/testdb build/empty.trap


### PR DESCRIPTION
This fixes `make test` sometimes failing because of remaining state in `build/testdb`.