### PR TITLE
Remove a mistaken uniqueness annotation.

### DIFF
--- a/extractor/dbscheme/tables.go
+++ b/extractor/dbscheme/tables.go
@@ -788,7 +788,7 @@ var FieldStructsTable = NewTable("fieldstructs",
 
 // MethodHostsTable maps interface methods to the named type they belong to
 var MethodHostsTable = NewTable("methodhosts",
-	EntityColumn(ObjectType, "method").Unique(),
+	EntityColumn(ObjectType, "method"),
 	EntityColumn(NamedType, "host"),
 )
 

--- a/ql/src/go.dbscheme
+++ b/ql/src/go.dbscheme
@@ -89,7 +89,7 @@ methodreceivers(unique int method: @object ref, int receiver: @object ref);
 
 fieldstructs(unique int field: @object ref, int struct: @structtype ref);
 
-methodhosts(unique int method: @object ref, int host: @namedtype ref);
+methodhosts(int method: @object ref, int host: @namedtype ref);
 
 defs(int ident: @ident ref, int object: @object ref);
 

--- a/ql/src/semmle/go/Scopes.qll
+++ b/ql/src/semmle/go/Scopes.qll
@@ -391,7 +391,13 @@ class Function extends ValueEntity, @functionobject {
   Parameter getAParameter() { result = getParameter(_) }
 }
 
-/** A method, that is, a function with a receiver variable. */
+/**
+ * A method, that is, a function with a receiver variable, or a function declared in an interface.
+ *
+ * Note that method identity is determined by receiver type identity: if two methods have the same
+ * name and their receiver types are identical in the sense of the Go language specification
+ * (https://golang.org/ref/spec#Type_identity), then the two methods are identical as well.
+ */
 class Method extends Function {
   Variable receiver;
 

--- a/upgrades/ffced433fce33521f90c1b6c66b611902cdceac2/go.dbscheme
+++ b/upgrades/ffced433fce33521f90c1b6c66b611902cdceac2/go.dbscheme
@@ -89,7 +89,7 @@ methodreceivers(unique int method: @object ref, int receiver: @object ref);
 
 fieldstructs(unique int field: @object ref, int struct: @structtype ref);
 
-methodhosts(unique int method: @object ref, int host: @namedtype ref);
+methodhosts(int method: @object ref, int host: @namedtype ref);
 
 defs(int ident: @ident ref, int object: @object ref);
 


### PR DESCRIPTION
This fixes an oversight in #41: methods can be associated with more than one named type, so the first column of `methodhosts` isn't unique. (Thanks to @sauyon for noticing and diagnosing the root cause!)

Since the upgrade to the dbscheme is still the last one, I chose to fix it in-place instead of adding another upgrade script.

Initial sanity checking looks good, but I'm running a full dist-compare to make sure.