### PR TITLE
Use bufio and don't sync FS

### DIFF
--- a/extractor/trap/trapwriter.go
+++ b/extractor/trap/trapwriter.go
@@ -1,6 +1,7 @@
 package trap
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"go/types"
@@ -15,7 +16,8 @@ import (
 
 // A Writer provides methods for writing data to a TRAP file
 type Writer struct {
-	w            *os.File
+	w            *bufio.Writer
+	file         *os.File
 	Labeler      *Labeler
 	path         string
 	trapFilePath string
@@ -40,6 +42,7 @@ func NewWriter(path string, pkg *packages.Package) (*Writer, error) {
 		return nil, err
 	}
 	tw := &Writer{
+		bufio.NewWriter(tmpFile),
 		tmpFile,
 		nil,
 		path,
@@ -67,15 +70,15 @@ func trapFolder() (string, error) {
 
 // Close the underlying file writer
 func (tw *Writer) Close() error {
-	err := tw.w.Sync()
+	err := tw.w.Flush()
 	if err != nil {
 		return err
 	}
-	err = tw.w.Close()
+	err = tw.file.Close()
 	if err != nil {
 		return err
 	}
-	return os.Rename(tw.w.Name(), tw.trapFilePath)
+	return os.Rename(tw.file.Name(), tw.trapFilePath)
 }
 
 // ForEachObject iterates over all objects labeled by this labeler, and invokes


### PR DESCRIPTION
Found via profiling that the vast majority of the time taken during extraction was `write` syscalls.

This empirically makes things much faster on Kubernetes, n=1:

Before:
1481.40s user 996.60s system 282% cpu 14:36.62 total
After:
606.63s user 12.59s system 338% cpu 3:02.91 total

Was there a reason we were running `Sync` before? My understanding is that it's not  necessary unless we want trap files to be uncorrupted if the system crashes.

I've kicked off an evaluation.