### PR TITLE
extractor: Use -mod=vendor when a vendor directory exists

### DIFF
--- a/change-notes/1.24/extractor-go.md
+++ b/change-notes/1.24/extractor-go.md
@@ -6,3 +6,4 @@
 
 * The autobuilder now runs Makefiles or custom build scripts present in the codebase to install dependencies.
 * The extractor now supports extracting go.mod files, enabling queries on dependencies and their versions.
+* The extractor now attempts to automatically detect when a dependencies have been vendored and use `-mod=vendor` appropriately.

--- a/change-notes/1.24/extractor-go.md
+++ b/change-notes/1.24/extractor-go.md
@@ -6,4 +6,4 @@
 
 * The autobuilder now runs Makefiles or custom build scripts present in the codebase to install dependencies.
 * The extractor now supports extracting go.mod files, enabling queries on dependencies and their versions.
-* The extractor now attempts to automatically detect when a dependencies have been vendored and use `-mod=vendor` appropriately.
+* The autobuilder now attempts to automatically detect when dependencies have been vendored and use `-mod=vendor` appropriately.


### PR DESCRIPTION
I'm also going to run a test for disabling the dependency installation step if the file exists, as in theory that should help with performance.

If I were to add another environment variable to customize that behavior should I use the `LGTM` or `CODEQL` prefix?