### PR TITLE
Gzip TRAP files

### DIFF
--- a/extractor/trap/labels.go
+++ b/extractor/trap/labels.go
@@ -55,7 +55,7 @@ func (l *Labeler) GlobalID(key string) Label {
 	label, exists := l.keyLabels[key]
 	if !exists {
 		id := l.nextID()
-		fmt.Fprintf(l.tw.w, "%s=@\"%s\"\n", id, escapeString(key))
+		fmt.Fprintf(l.tw.zip, "%s=@\"%s\"\n", id, escapeString(key))
 		label = Label{id}
 		l.keyLabels[key] = label
 	}
@@ -83,7 +83,7 @@ func (l *Labeler) LocalID(nd interface{}) Label {
 // FreshID creates a fresh label and returns it
 func (l *Labeler) FreshID() Label {
 	id := l.nextID()
-	fmt.Fprintf(l.tw.w, "%s=*\n", id)
+	fmt.Fprintf(l.tw.zip, "%s=*\n", id)
 	return Label{id}
 }
 


### PR DESCRIPTION
This reduces the total size of TRAP files, in many cases dramatically so (kubernetes: 13G -> 2G, cockroach: 6.5G -> 1.2G, aws-sdk-go: 2.9G -> 557M), at the cost of slowing down extraction in some cases (kubernetes: 606s -> 727s, but cockroach: 376s -> 368s, aws-sdk-go: 223s -> 183s). More data is [here](https://docs.google.com/spreadsheets/d/1Z-vqhVwn_iFIO0_1z49WPwf2KlLP3qWiyFnR5X4g7Io) (internal link); note that the timings are probably less reliable than usual since they were taken on my laptop.

In spite of the potential slowdown I think this is worth it, since TRAP size looks like a blocker for code scanning.

[Evaluation](https://git.semmle.com/max/dist-compare-reports/blob/master/go/trap.gz/report.md) (also internal link) is uneventful.