### PR TITLE
MistypedExponentiation: Add a heuristic to reduce FPs

### DIFF
--- a/change-notes/1.24/analysis-go.md
+++ b/change-notes/1.24/analysis-go.md
@@ -27,3 +27,4 @@ The CodeQL library for Go now contains a folder of simple "cookbook" queries tha
 | Incomplete regular expression for hostnames (`go/incomplete-hostname-regexp`) | More results | The query now flags unescaped dots before the TLD in a hostname regex. |
 | Reflected cross-site scripting (`go/reflected-xss`) | Fewer results | Untrusted input flowing into an HTTP header definition or into an `fmt.Fprintf` call with a constant prefix is no longer flagged, since it is in both cases often harmless. |
 | Useless assignment to field (`go/useless-assignment-to-field`) | Fewer false positives | The query now conservatively handles fields promoted through embedded pointer types. |
+| Bitwise exclusive-or used like exponentiation (`go/mistyped-exponentiation`) | Fewer false positives | The query now identifies when the value of an xor is assigned to a mask object, and excludes such results. |

--- a/ql/src/InconsistentCode/MistypedExponentiation.ql
+++ b/ql/src/InconsistentCode/MistypedExponentiation.ql
@@ -34,8 +34,12 @@ where
     )
   ) and
   // exclude the right hand side of assignments to variables that have "mask" in their name
-  not exists(Assignment assign | assign.getRhs() = xe.getParent*() |
-    assign.getLhs().getAChild*().(Ident).getName().regexpMatch(".*(^m|M)ask($|\\p{Lu}).*")
+  not exists(Assignment assign, Ident id | assign.getRhs() = xe.getParent*() |
+    id.getName().regexpMatch("(?i).*mask.*") and
+    (
+      assign.getLhs() = id or
+      assign.getLhs().(SelectorExpr).getSelector() = id
+    )
   )
 select xe,
   "This expression uses the bitwise exclusive-or operator when exponentiation was likely meant."

--- a/ql/src/InconsistentCode/MistypedExponentiation.ql
+++ b/ql/src/InconsistentCode/MistypedExponentiation.ql
@@ -32,6 +32,10 @@ where
     exists(Ident id | id = xe.getRightOperand() |
       id.getName().regexpMatch("(?i)_*((exp(onent)?)|pow(er)?)")
     )
+  ) and
+  // exclude the right hand side of assignments to variables that have "mask" in their name
+  not exists(Assignment assign | assign.getRhs() = xe.getParent*() |
+    assign.getLhs().getAChild*().(Ident).getName().regexpMatch(".*(^m|M)ask($|\\p{Lu}).*")
   )
 select xe,
   "This expression uses the bitwise exclusive-or operator when exponentiation was likely meant."

--- a/ql/test/query-tests/InconsistentCode/MistypedExponentiation/main.go
+++ b/ql/test/query-tests/InconsistentCode/MistypedExponentiation/main.go
@@ -20,6 +20,8 @@ func main() {
 	fmt.Println(253 ^ expectingResponse) // OK
 	fmt.Println(2 ^ power)               // Not OK
 
+	mask := (((1 << 10) - 1) ^ 7) // OK
+
 	// This is not ok, but isn't detected because the multiplication binds tighter
 	// than the xor operator and so the query doesn't see a constant on the left
 	// hand side of ^.


### PR DESCRIPTION
Fixes two FPs on LGTM.com.