### PR TITLE
Add examples qlpack.yml to CodeQL manifest

### DIFF
--- a/.codeqlmanifest.json
+++ b/.codeqlmanifest.json
@@ -1,4 +1,5 @@
 { "provide": [ "ql/src/qlpack.yml",
+               "ql/examples/qlpack.yml",
                "ql/test/qlpack.yml",
                "upgrades/qlpack.yml",
                "ql/config/legacy-support/qlpack.yml",

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ ql/src/go.dbscheme.stats: ql/src/go.dbscheme build/stats/src.stamp extractor
 	odasa collectStats --dbscheme $< --db build/stats/database/db-go --outputFile $@
 
 test: all build/testdb/check-upgrade-path
-	codeql test run ql/test --search-path . --additional-packs ql
+	codeql test run ql/test --search-path .
 	cd extractor; go test -mod=vendor ./... | grep -vF "[no test files]"
 
 .PHONY: build/testdb/check-upgrade-path


### PR DESCRIPTION
As suggested by Pavel. I believe it removes the need for the `--additional-packs` argument to the test command, did you want that for any other reason?