### PR TITLE
OpenUrlRedirect: Expand safe URL flow configuration

### DIFF
--- a/change-notes/1.24/analysis-go.md
+++ b/change-notes/1.24/analysis-go.md
@@ -21,11 +21,12 @@ The CodeQL library for Go now contains a folder of simple "cookbook" queries tha
 
 ## Changes to existing queries
 
-| **Query**                                           | **Expected impact**          | **Change**                                                |
-|-----------------------------------------------------|------------------------------|-----------------------------------------------------------|
-| Database query built from user-controlled sources (`go/sql-injection`) | More results | The library models used by the query have been improved, allowing it to flag more potentially problematic cases. |
-| Identical operands (`go/redundant-operation`) | Fewer false positives | The query no longer flags cases where the operands have the same value but are syntactically distinct, since this is usually intentional. |
-| Incomplete regular expression for hostnames (`go/incomplete-hostname-regexp`) | More results | The query now flags unescaped dots before the TLD in a hostname regex. |
-| Reflected cross-site scripting (`go/reflected-xss`) | Fewer results | Untrusted input flowing into an HTTP header definition or into an `fmt.Fprintf` call with a constant prefix is no longer flagged, since it is in both cases often harmless. |
-| Useless assignment to field (`go/useless-assignment-to-field`) | Fewer false positives | The query now conservatively handles fields promoted through embedded pointer types. |
-| Bitwise exclusive-or used like exponentiation (`go/mistyped-exponentiation`) | Fewer false positives | The query now identifies when the value of an xor is assigned to a mask object, and excludes such results. |
+| **Query**                                                                     | **Expected impact**   | **Change**                                                                                                                                                                  |
+|-------------------------------------------------------------------------------|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Database query built from user-controlled sources (`go/sql-injection`)        | More results          | The library models used by the query have been improved, allowing it to flag more potentially problematic cases.                                                            |
+| Identical operands (`go/redundant-operation`)                                 | Fewer false positives | The query no longer flags cases where the operands have the same value but are syntactically distinct, since this is usually intentional.                                   |
+| Incomplete regular expression for hostnames (`go/incomplete-hostname-regexp`) | More results          | The query now flags unescaped dots before the TLD in a hostname regex.                                                                                                      |
+| Reflected cross-site scripting (`go/reflected-xss`)                           | Fewer results         | Untrusted input flowing into an HTTP header definition or into an `fmt.Fprintf` call with a constant prefix is no longer flagged, since it is in both cases often harmless. |
+| Useless assignment to field (`go/useless-assignment-to-field`)                | Fewer false positives | The query now conservatively handles fields promoted through embedded pointer types.                                                                                        |
+| Bitwise exclusive-or used like exponentiation (`go/mistyped-exponentiation`)  | Fewer false positives | The query now identifies when the value of an xor is assigned to a mask object, and excludes such results.                                                                  |
+| Open URL redirect (`go/unvalidated-url-redirection`)                          | Fewer false positives | The query now identifies some sources that are not attacker-controlled, and excludes results with such sources.                                                             |

--- a/ql/src/semmle/go/frameworks/HTTP.qll
+++ b/ql/src/semmle/go/frameworks/HTTP.qll
@@ -15,12 +15,20 @@ private module StdlibHttp {
     }
   }
 
-  private class HeaderGetCall extends UntrustedFlowSource::Range, DataFlow::MethodCallNode {
-    HeaderGetCall() { this.getTarget().hasQualifiedName("net/http", "Header", "Get") }
+  private class HeaderGet extends TaintTracking::FunctionModel, Method {
+    HeaderGet() { this.hasQualifiedName("net/http", "Header", "Get") }
+
+    override predicate hasTaintFlow(FunctionInput inp, FunctionOutput outp) {
+      inp.isReceiver() and outp.isResult()
+    }
   }
 
-  private class HeaderValuesCall extends UntrustedFlowSource::Range, DataFlow::MethodCallNode {
-    HeaderValuesCall() { this.getTarget().hasQualifiedName("net/http", "Header", "Values") }
+  private class HeaderValues extends TaintTracking::FunctionModel, Method {
+    HeaderValues() { this.hasQualifiedName("net/http", "Header", "Values") }
+
+    override predicate hasTaintFlow(FunctionInput inp, FunctionOutput outp) {
+      inp.isReceiver() and outp.isResult()
+    }
   }
 
   private class StdlibResponseWriter extends HTTP::ResponseWriter::Range {

--- a/ql/src/semmle/go/frameworks/Stdlib.qll
+++ b/ql/src/semmle/go/frameworks/Stdlib.qll
@@ -114,9 +114,7 @@ module IoUtil {
    * from its first argument to its first result.
    */
   private class ReadAll extends TaintTracking::FunctionModel {
-    ReadAll() {
-      hasQualifiedName("io/ioutil", "ReadAll")
-    }
+    ReadAll() { hasQualifiedName("io/ioutil", "ReadAll") }
 
     override predicate hasTaintFlow(FunctionInput inp, FunctionOutput outp) {
       inp.isParameter(0) and outp.isResult(0)
@@ -201,7 +199,7 @@ module OS {
 /** Provides models of commonly used functions in the `path` package. */
 module Path {
   /** A path-manipulating function in the `path` package. */
-  private class PathManipulatingFunction extends TaintTracking::FunctionModel {
+  class PathManipulatingFunction extends TaintTracking::FunctionModel {
     PathManipulatingFunction() {
       exists(string fn | hasQualifiedName("path", fn) |
         fn = "Base" or

--- a/ql/src/semmle/go/security/OpenUrlRedirect.qll
+++ b/ql/src/semmle/go/security/OpenUrlRedirect.qll
@@ -30,15 +30,6 @@ module OpenUrlRedirect {
     override predicate isBarrier(DataFlow::Node node) { node instanceof Barrier }
 
     override predicate isAdditionalFlowStep(DataFlow::Node pred, DataFlow::Node succ) {
-      // A write to URL.Host
-      exists(Write write, Field f, DataFlow::SsaNode var |
-        write.writesField(var.getAUse(), f, pred) and
-        succ = var.getAUse() and
-        write.getASuccessor+() = succ.asInstruction() and
-        f.getName() = "Host" and
-        var.getType().hasQualifiedName("net/url", "URL")
-      )
-      or
       // taint steps that do not include flow through fields
       TaintTracking::localTaintStep(pred, succ) and not TaintTracking::fieldReadStep(pred, succ)
       or

--- a/ql/src/semmle/go/security/OpenUrlRedirect.qll
+++ b/ql/src/semmle/go/security/OpenUrlRedirect.qll
@@ -82,17 +82,17 @@ module OpenUrlRedirect {
         (frn.getFieldName() = "Host" or frn.getFieldName() = "Path")
       )
       or
-      exists(Write w, Field f, SsaWithFields v | f.hasQualifiedName("net/url", "URL", "Path") |
+      // propagate to a URL when its host is assigned to
+      exists(Write w, Field f, SsaWithFields v | f.hasQualifiedName("net/url", "URL", "Host") |
         w.writesField(v.getAUse(), f, pred) and succ = v.getAUse()
       )
     }
 
     override predicate isBarrierOut(DataFlow::Node node) {
-      exists(Write w, Field f | f.hasQualifiedName("net/url", "URL", "Path") |
+      // block propagation of this safe value when its host is overwritten
+      exists(Write w, Field f | f.hasQualifiedName("net/url", "URL", "Host") |
         w.writesField(node.getASuccessor(), f, _)
       )
     }
-
-    override int explorationLimit() { result = 30 }
   }
 }

--- a/ql/src/semmle/go/security/OpenUrlRedirectCustomizations.qll
+++ b/ql/src/semmle/go/security/OpenUrlRedirectCustomizations.qll
@@ -33,20 +33,10 @@ module OpenUrlRedirect {
   abstract class BarrierGuard extends DataFlow::BarrierGuard { }
 
   /**
-   * A method on a `net/url.URL` that is considered safe to redirect to.
+   * A method on a `net/url.URL` that is considered unsafe to redirect to.
    */
-  class SafeUrlMethod extends TaintTracking::FunctionModel, Method {
-    SafeUrlMethod() {
-      this instanceof StringMethod
-      or
-      exists(string m | this.hasQualifiedName("net/url", "URL", m) |
-        m = "Hostname" or m = "Port" or m = "RequestURI"
-      )
-    }
-
-    override predicate hasTaintFlow(DataFlow::FunctionInput inp, DataFlow::FunctionOutput outp) {
-      inp.isReceiver() and outp.isResult()
-    }
+  class UnsafeUrlMethod extends URL::UrlGetter {
+    UnsafeUrlMethod() { this.getName() = "Query" }
   }
 
   /**

--- a/ql/src/semmle/go/security/OpenUrlRedirectCustomizations.qll
+++ b/ql/src/semmle/go/security/OpenUrlRedirectCustomizations.qll
@@ -39,11 +39,25 @@ module OpenUrlRedirect {
     SafeUrlMethod() {
       this instanceof StringMethod
       or
-      exists(string m | this.hasQualifiedName("net/url", "URL", m) | m = "Hostname" or m = "Port")
+      exists(string m | this.hasQualifiedName("net/url", "URL", m) |
+        m = "Hostname" or m = "Port" or m = "RequestURI"
+      )
     }
 
     override predicate hasTaintFlow(DataFlow::FunctionInput inp, DataFlow::FunctionOutput outp) {
       inp.isReceiver() and outp.isResult()
+    }
+  }
+
+  /**
+   * A function that trims the right hand side of a string, considered to preserve the safeness
+   * of taint flow from the full request URL.
+   */
+  class StringRightTrimmer extends Strings::Trimmer {
+    StringRightTrimmer() {
+      this.hasQualifiedName("strings", "TrimSuffix") or
+      this.hasQualifiedName("strings", "TrimRight") or
+      this.hasQualifiedName("strings", "TrimRightFunc")
     }
   }
 

--- a/ql/src/semmle/go/security/OpenUrlRedirectCustomizations.qll
+++ b/ql/src/semmle/go/security/OpenUrlRedirectCustomizations.qll
@@ -54,7 +54,16 @@ module OpenUrlRedirect {
   /**
    * A source of third-party user input, considered as a flow source for URL redirects.
    */
-  class UntrustedFlowAsSource extends Source, UntrustedFlowSource { }
+  class UntrustedFlowAsSource extends Source, UntrustedFlowSource {
+    UntrustedFlowAsSource() {
+      // exclude request headers, as they are generally not attacker-controllable for open redirect
+      // exploits
+      not this
+          .(DataFlow::FieldReadNode)
+          .getField()
+          .hasQualifiedName("net/http", "Request", "Header")
+    }
+  }
 
   /**
    * An HTTP redirect, considered as a sink for `Configuration`.

--- a/ql/test/library-tests/semmle/go/frameworks/HTTP/UntrustedFlowSources.expected
+++ b/ql/test/library-tests/semmle/go/frameworks/HTTP/UntrustedFlowSources.expected
@@ -11,7 +11,5 @@
 | main.go:50:2:50:11 | selection of Header |
 | server.go:8:6:8:13 | selection of Header |
 | server.go:9:6:9:13 | selection of Header |
-| server.go:9:6:9:38 | call to Values |
 | server.go:10:6:10:13 | selection of Header |
-| server.go:10:6:10:35 | call to Get |
 | server.go:13:6:13:11 | selection of Body |

--- a/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
+++ b/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
@@ -6,7 +6,7 @@ edges
 | issue48.go:42:24:42:30 | selection of URL : pointer type | issue48.go:42:17:42:50 | type conversion : slice type |
 | main.go:10:11:10:16 | selection of Form : Values | main.go:10:11:10:28 | index expression |
 | main.go:14:63:14:67 | selection of URL : pointer type | main.go:14:11:14:84 | call to Sprintf |
-| main.go:15:63:15:84 | call to Get : string | main.go:15:11:15:85 | call to Sprintf |
+| main.go:15:63:15:70 | selection of Header : Header | main.go:15:11:15:85 | call to Sprintf |
 | main.go:27:17:30:2 | &... [pointer, Category] | main.go:33:3:33:13 | RequestData [pointer, Category] |
 | main.go:27:18:30:2 | composite literal [Category] : slice type | main.go:27:17:30:2 | &... [pointer, Category] |
 | main.go:29:13:29:19 | selection of URL : pointer type | main.go:29:13:29:39 | index expression : slice type |
@@ -56,7 +56,7 @@ nodes
 | main.go:14:11:14:84 | call to Sprintf | semmle.label | call to Sprintf |
 | main.go:14:63:14:67 | selection of URL : pointer type | semmle.label | selection of URL : pointer type |
 | main.go:15:11:15:85 | call to Sprintf | semmle.label | call to Sprintf |
-| main.go:15:63:15:84 | call to Get : string | semmle.label | call to Get : string |
+| main.go:15:63:15:70 | selection of Header : Header | semmle.label | selection of Header : Header |
 | main.go:27:17:30:2 | &... [pointer, Category] | semmle.label | &... [pointer, Category] |
 | main.go:27:18:30:2 | composite literal [Category] : slice type | semmle.label | composite literal [Category] : slice type |
 | main.go:29:13:29:19 | selection of URL : pointer type | semmle.label | selection of URL : pointer type |
@@ -99,7 +99,7 @@ nodes
 | issue48.go:46:11:46:12 | q5 | issue48.go:42:24:42:30 | selection of URL : pointer type | issue48.go:46:11:46:12 | q5 | This query depends on $@. | issue48.go:42:24:42:30 | selection of URL | a user-provided value |
 | main.go:10:11:10:28 | index expression | main.go:10:11:10:16 | selection of Form : Values | main.go:10:11:10:28 | index expression | This query depends on $@. | main.go:10:11:10:16 | selection of Form | a user-provided value |
 | main.go:14:11:14:84 | call to Sprintf | main.go:14:63:14:67 | selection of URL : pointer type | main.go:14:11:14:84 | call to Sprintf | This query depends on $@. | main.go:14:63:14:67 | selection of URL | a user-provided value |
-| main.go:15:11:15:85 | call to Sprintf | main.go:15:63:15:84 | call to Get : string | main.go:15:11:15:85 | call to Sprintf | This query depends on $@. | main.go:15:63:15:84 | call to Get | a user-provided value |
+| main.go:15:11:15:85 | call to Sprintf | main.go:15:63:15:70 | selection of Header : Header | main.go:15:11:15:85 | call to Sprintf | This query depends on $@. | main.go:15:63:15:70 | selection of Header | a user-provided value |
 | main.go:34:11:34:11 | q | main.go:29:13:29:19 | selection of URL : pointer type | main.go:34:11:34:11 | q | This query depends on $@. | main.go:29:13:29:19 | selection of URL | a user-provided value |
 | main.go:43:11:43:11 | q | main.go:39:25:39:31 | selection of URL : pointer type | main.go:43:11:43:11 | q | This query depends on $@. | main.go:39:25:39:31 | selection of URL | a user-provided value |
 | main.go:52:11:52:11 | q | main.go:48:28:48:34 | selection of URL : pointer type | main.go:52:11:52:11 | q | This query depends on $@. | main.go:48:28:48:34 | selection of URL | a user-provided value |

--- a/ql/test/query-tests/Security/CWE-601/OpenUrlRedirect/OpenUrlRedirect.expected
+++ b/ql/test/query-tests/Security/CWE-601/OpenUrlRedirect/OpenUrlRedirect.expected
@@ -9,6 +9,12 @@ edges
 | stdlib.go:112:24:112:28 | selection of URL : pointer type | stdlib.go:112:24:112:37 | call to String |
 | stdlib.go:112:24:112:28 | selection of URL : pointer type | stdlib.go:112:24:112:37 | call to String |
 | stdlib.go:133:13:133:18 | selection of Form : Values | stdlib.go:139:23:139:28 | target |
+| stdlib.go:146:11:146:15 | selection of URL : pointer type | stdlib.go:146:11:146:15 | selection of URL : pointer type |
+| stdlib.go:146:11:146:15 | selection of URL : pointer type | stdlib.go:146:11:146:15 | selection of URL : pointer type |
+| stdlib.go:146:11:146:15 | selection of URL : pointer type | stdlib.go:149:24:149:35 | call to String |
+| stdlib.go:146:11:146:15 | selection of URL : pointer type | stdlib.go:149:24:149:35 | call to String |
+| stdlib.go:160:35:160:39 | selection of URL : pointer type | stdlib.go:160:24:160:52 | ...+... |
+| stdlib.go:160:35:160:39 | selection of URL : pointer type | stdlib.go:160:24:160:52 | ...+... |
 nodes
 | OpenUrlRedirect.go:10:23:10:28 | selection of Form : Values | semmle.label | selection of Form : Values |
 | OpenUrlRedirect.go:10:23:10:42 | call to Get | semmle.label | call to Get |
@@ -30,6 +36,14 @@ nodes
 | stdlib.go:112:24:112:37 | call to String | semmle.label | call to String |
 | stdlib.go:133:13:133:18 | selection of Form : Values | semmle.label | selection of Form : Values |
 | stdlib.go:139:23:139:28 | target | semmle.label | target |
+| stdlib.go:146:11:146:15 | selection of URL : pointer type | semmle.label | selection of URL : pointer type |
+| stdlib.go:146:11:146:15 | selection of URL : pointer type | semmle.label | selection of URL : pointer type |
+| stdlib.go:149:24:149:35 | call to String | semmle.label | call to String |
+| stdlib.go:149:24:149:35 | call to String | semmle.label | call to String |
+| stdlib.go:160:24:160:52 | ...+... | semmle.label | ...+... |
+| stdlib.go:160:24:160:52 | ...+... | semmle.label | ...+... |
+| stdlib.go:160:35:160:39 | selection of URL : pointer type | semmle.label | selection of URL : pointer type |
+| stdlib.go:160:35:160:39 | selection of URL : pointer type | semmle.label | selection of URL : pointer type |
 #select
 | OpenUrlRedirect.go:10:23:10:42 | call to Get | OpenUrlRedirect.go:10:23:10:28 | selection of Form : Values | OpenUrlRedirect.go:10:23:10:42 | call to Get | Untrusted URL redirection due to $@. | OpenUrlRedirect.go:10:23:10:28 | selection of Form | user-provided value |
 | stdlib.go:14:30:14:35 | target | stdlib.go:12:13:12:18 | selection of Form : Values | stdlib.go:14:30:14:35 | target | Untrusted URL redirection due to $@. | stdlib.go:12:13:12:18 | selection of Form | user-provided value |

--- a/ql/test/query-tests/Security/CWE-601/OpenUrlRedirect/stdlib.go
+++ b/ql/test/query-tests/Security/CWE-601/OpenUrlRedirect/stdlib.go
@@ -139,5 +139,29 @@ func serveStdlib() {
 		http.Redirect(w, r, target, 302)
 	})
 
+	http.HandleFunc("/ex8", func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+
+		// GOOD: Only safe parts of the URL are used
+		url := *r.URL
+		if url.Scheme == "http" {
+			url.Scheme = "https"
+			http.Redirect(w, r, url.String(), 302)
+		} else {
+			// ...
+		}
+	})
+
+	http.HandleFunc("/ex8", func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+
+		// GOOD: Only safe parts of the URL are used
+		if r.URL.Scheme == "http" {
+			http.Redirect(w, r, "https://"+r.URL.RequestURI(), 302)
+		} else {
+			// ...
+		}
+	})
+
 	http.ListenAndServe(":80", nil)
 }


### PR DESCRIPTION
Tested this on LGTM.com and it fixes all but two of the obvious false positives.

The last two are [these](https://lgtm.com/projects/g/caddyserver/caddy/snapshot/89b6c8ef3926b30ed1b8dca64f8ebd3301c9321f/files/caddyhttp/staticfiles/fileserver.go?sort=name&dir=ASC&mode=heatmap#xf26e02affcbaab40:1) [results](https://lgtm.com/projects/g/caddyserver/caddy/snapshot/89b6c8ef3926b30ed1b8dca64f8ebd3301c9321f/files/caddyhttp/staticfiles/fileserver.go?sort=name&dir=ASC&mode=heatmap#xc9a7505ef87e05cd:1) on `caddyserver/caddy`, for which the source, which I'd expect to be on line 102 of `fileserver.go`, is strangely not found. I'll probably do some digging into this eventually, but I thought I'd leave it here for now since it seems like this may be a bit more involved.