### PR TITLE
CWE-643 XPathInjection on Go

### DIFF
--- a/ql/src/experimental/Security/CWE-643/XPathInjection.go
+++ b/ql/src/experimental/Security/CWE-643/XPathInjection.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+  "net/http"
+  "github.com/moovweb/gokogiri"
+)
+
+func processRequest(r *http.Request, doc *XmlDocument) {
+  r.parseForm()
+  username := r.Form.Get("username")
+  password := r.Form.Get("password")
+  
+  root := doc.Root()
+  // BAD: User input used directly in an XPath expression
+  doc, _ := root.SearchWithVariables("//users/user[login/text()='" + username + "' and password/text() = '" + password + "']/home_dir/text()")
+
+  // GOOD: Uses parameters to avoid including user input directly in XPath expression
+  doc, _ := root.SearchWithVariables("//users/user[login/text()=$username and password/text() = $password]/home_dir/text()")
+}

--- a/ql/src/experimental/Security/CWE-643/XPathInjection.go
+++ b/ql/src/experimental/Security/CWE-643/XPathInjection.go
@@ -1,19 +1,32 @@
 package main
 
 import (
-  "net/http"
-  "github.com/moovweb/gokogiri"
+	"fmt"
+	"net/http"
+
+	"github.com/ChrisTrenkamp/goxpath"
+	"github.com/ChrisTrenkamp/goxpath/tree"
 )
 
-func processRequest(r *http.Request, doc *XmlDocument) {
-  r.parseForm()
-  username := r.Form.Get("username")
-  password := r.Form.Get("password")
-  
-  root := doc.Root()
-  // BAD: User input used directly in an XPath expression
-  doc, _ := root.SearchWithVariables("//users/user[login/text()='" + username + "' and password/text() = '" + password + "']/home_dir/text()")
+func main() {}
 
-  // GOOD: Uses parameters to avoid including user input directly in XPath expression
-  doc, _ := root.SearchWithVariables("//users/user[login/text()=$username and password/text() = $password]/home_dir/text()")
+func processRequest(r *http.Request, doc tree.Node) {
+	r.ParseForm()
+	username := r.Form.Get("username")
+	password := r.Form.Get("password")
+
+	// BAD: User input used directly in an XPath expression
+	xPath := goxpath.MustParse("//users/user[login/text()='" + username + "' and password/text() = '" + password + "']/home_dir/text()")
+	unsafeRes, _ := xPath.ExecBool(doc)
+	fmt.Println(unsafeRes)
+
+	// GOOD: Value of parameters is defined here instead of directly in the query
+	opt := func(o *goxpath.Opts) {
+		o.Vars["username"] = tree.String(username)
+		o.Vars["password"] = tree.String(password)
+	}
+	// GOOD: Uses parameters to avoid including user input directly in XPath expression
+	xPath = goxpath.MustParse("//users/user[login/text()=$username and password/text() = $password]/home_dir/text()")
+	safeRes, _ := xPath.ExecBool(doc, opt)
+	fmt.Println(safeRes)
 }

--- a/ql/src/experimental/Security/CWE-643/XPathInjection.qhelp
+++ b/ql/src/experimental/Security/CWE-643/XPathInjection.qhelp
@@ -1,0 +1,45 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>
+If an XPath expression is built using string concatenation, and the components of the concatenation
+include user input, a user is likely to be able to create a malicious XPath expression.
+</p>
+</overview>
+
+<recommendation>
+<p>
+If user input must be included in an XPath expression, pre-compile the query and use variable
+references to include the user input.
+</p>
+<p>
+For exmaple, when using the <code>github.com/moovweb/gokogiri</code> API, this can be done by creating a custom subtype of
+<code>xpath.VariableScope</code>, and implementing
+<code>ResolveVariable(string, string)</code> to return the user provided data. This
+custom scope can be specified when calling <code>SearchWithVariables(), EvalXPath() or EvalXPathAsBoolean()</code>.
+</p>
+
+</recommendation>
+
+<example>
+<p>
+In the first example, the code accepts a user name specified by the user, and uses this
+unvalidated and unsanitized value in an XPath expression. This is vulnerable to the user providing
+special characters or string sequences that change the meaning of the XPath expression to search
+for different values.
+</p>
+
+<p>
+In the second example, the XPath expression is a hard-coded string that specifies some variables,
+which are safely replaced at runtime using a custom <code>xpath.VariableScope</code>.
+</p>
+<sample src="XPathInjection.go" />
+</example>
+
+<references>
+<li>OWASP: <a href="https://www.owasp.org/index.php?title=Testing_for_XPath_Injection_(OTG-INPVAL-010)">Testing for XPath Injection</a>.</li>
+<li>OWASP: <a href="https://www.owasp.org/index.php/XPATH_Injection">XPath Injection</a>.</li>
+</references>
+</qhelp>

--- a/ql/src/experimental/Security/CWE-643/XPathInjection.qhelp
+++ b/ql/src/experimental/Security/CWE-643/XPathInjection.qhelp
@@ -15,10 +15,9 @@ If user input must be included in an XPath expression, pre-compile the query and
 references to include the user input.
 </p>
 <p>
-For example, when using the <code>github.com/moovweb/gokogiri</code> API, this can be done by creating a custom subtype of
-<code>xpath.VariableScope</code>, and implementing
-<code>ResolveVariable(string, string)</code> to return the user provided data. This
-custom scope can be specified when calling <code>SearchWithVariables()</code>, <code>EvalXPath()</code>, or <code>EvalXPathAsBoolean()</code>.
+For example, when using the <code>github.com/ChrisTrenkamp/goxpath</code> API, this can be done by creating a function that takes an <code>*goxpath.Opts</code> structure.
+In this structure you can then set the values of the variable references.
+This function can then be specified when calling <code>Exec()</code>, <code>Exec{Bool|Num|Node}()</code>, <code>ParseExec()</code> or <code>MustExec()</code>.
 </p>
 
 </recommendation>
@@ -33,7 +32,7 @@ for different values.
 
 <p>
 In the second example, the XPath expression is a hard-coded string that specifies some variables,
-which are safely replaced at runtime using a custom <code>xpath.VariableScope</code>.
+which are safely resolved at runtime using the <code>goxpath.Opts</code> structure.
 </p>
 <sample src="XPathInjection.go" />
 </example>

--- a/ql/src/experimental/Security/CWE-643/XPathInjection.qhelp
+++ b/ql/src/experimental/Security/CWE-643/XPathInjection.qhelp
@@ -15,10 +15,10 @@ If user input must be included in an XPath expression, pre-compile the query and
 references to include the user input.
 </p>
 <p>
-For exmaple, when using the <code>github.com/moovweb/gokogiri</code> API, this can be done by creating a custom subtype of
+For example, when using the <code>github.com/moovweb/gokogiri</code> API, this can be done by creating a custom subtype of
 <code>xpath.VariableScope</code>, and implementing
 <code>ResolveVariable(string, string)</code> to return the user provided data. This
-custom scope can be specified when calling <code>SearchWithVariables(), EvalXPath() or EvalXPathAsBoolean()</code>.
+custom scope can be specified when calling <code>SearchWithVariables()</code>, <code>EvalXPath()</code>, or <code>EvalXPathAsBoolean()</code>.
 </p>
 
 </recommendation>

--- a/ql/src/experimental/Security/CWE-643/XPathInjection.ql
+++ b/ql/src/experimental/Security/CWE-643/XPathInjection.ql
@@ -139,5 +139,5 @@ class GokogiriSink extends XPathInjectionSink {
 
 from DataFlow::PathNode source, DataFlow::PathNode sink, XPathInjectionConfiguration c
 where c.hasFlowPath(source, sink)
-select sink.getNode(), source, sink, "$@ flows to here and is used in an XPath expression.",
-  source.getNode(), "User-provided value"
+select sink.getNode(), source, sink, "$@ flows here and is used in an XPath expression.",
+  source.getNode(), "A user-provided value"

--- a/ql/src/experimental/Security/CWE-643/XPathInjection.ql
+++ b/ql/src/experimental/Security/CWE-643/XPathInjection.ql
@@ -25,8 +25,9 @@ class XPathInjectionConfiguration extends TaintTracking::Configuration {
   override predicate isSink(DataFlow::Node sink) { sink instanceof XPathInjectionSink }
 
   override predicate isSanitizer(DataFlow::Node node) {
-    not node.asExpr().getType() instanceof StringType or
-    not node.asExpr().getType() instanceof ByteSliceType
+  exists(Type t | t = node.getType().getUnderlyingType() |
+    not t instanceof StringType or not t instanceof ByteSliceType
+  )
   }
 }
 

--- a/ql/src/experimental/Security/CWE-643/XPathInjection.ql
+++ b/ql/src/experimental/Security/CWE-643/XPathInjection.ql
@@ -1,0 +1,143 @@
+/**
+ * @name XPath injection
+ * @description Building an XPath expression from user-controlled sources is vulnerable to insertion of
+ *              malicious code by the user.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id go/xml/xpath-injection
+ * @tags security
+ *       external/cwe/cwe-643
+ */
+
+import go
+import semmle.go.dataflow.TaintTracking
+import DataFlow::PathGraph
+
+class XPathInjectionConfiguration extends TaintTracking::Configuration {
+  XPathInjectionConfiguration() { this = "XPathInjectionConfiguration" }
+
+  override predicate isSource(DataFlow::Node source) { 
+    source instanceof UntrustedFlowSource
+  }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof XPathInjectionSink }
+}
+
+abstract class XPathInjectionSink extends DataFlow::Node { }
+
+Function getAMatchingFunction(string package, int argumentNumber, CallExpr call, Expr argument) {
+  result.getPackage().getName() = package and
+  call.getTarget() = result and
+  call.getArgument(argumentNumber) = argument
+}
+
+// https://github.com/antchfx/xpath
+class XPathSink extends XPathInjectionSink {
+  XPathSink() {
+    exists(CallExpr call |
+      getAMatchingFunction("xpath", 0, call, this.asExpr()).getName().matches("Compile")
+      or 
+      getAMatchingFunction("xpath", 0, call, this.asExpr()).getName().matches("MustCompile")
+      or 
+      getAMatchingFunction("xpath", 1, call, this.asExpr()).getName().matches("Select")
+    )
+  }
+}
+
+// https://github.com/antchfx/htmlquery
+class HtmlQuerySink extends XPathInjectionSink {
+  HtmlQuerySink() {
+    exists(CallExpr call |
+      getAMatchingFunction("htmlquery", 1, call, this.asExpr()).getName().matches("Find%")
+      or 
+      getAMatchingFunction("htmlquery", 1, call, this.asExpr()).getName().matches("Query%")
+      or 
+      getAMatchingFunction("htmlquery", 0, call, this.asExpr()).getName().matches("getQuery")
+    )
+  }
+}
+
+// https://github.com/antchfx/xmlquery
+class XmlQuerySink extends XPathInjectionSink {
+  XmlQuerySink() {
+    exists(CallExpr call |
+      getAMatchingFunction("xmlquery", 1, call, this.asExpr()).getName().matches("Find%")
+      or 
+      getAMatchingFunction("xmlquery", 1, call, this.asExpr()).getName().matches("Query%")
+      or 
+      getAMatchingFunction("xmlquery", 0, call, this.asExpr()).getName().matches("getQuery")
+      or 
+      getAMatchingFunction("xmlquery", 0, call, this.asExpr()).getName().matches("Select%")
+    )
+  }
+}
+
+// https://github.com/antchfx/jsonquery
+class JsonQuerySink extends XPathInjectionSink {
+  JsonQuerySink() {
+    exists(CallExpr call |
+      getAMatchingFunction("jsonquery", 1, call, this.asExpr()).getName().matches("Find%")
+      or 
+      getAMatchingFunction("jsonquery", 1, call, this.asExpr()).getName().matches("Query%")
+      or 
+      getAMatchingFunction("jsonquery", 0, call, this.asExpr()).getName().matches("getQuery")
+    )
+  }
+}
+
+// https://github.com/go-xmlpath/xmlpath
+class XmlPathSink extends XPathInjectionSink {
+  XmlPathSink() {
+    exists(CallExpr call |
+      getAMatchingFunction("xmlpath", 0, call, this.asExpr()).getName().matches("Compile%")
+      or 
+      getAMatchingFunction("xmlpath", 0, call, this.asExpr()).getName().matches("MustCompile")
+    )
+  }
+}
+
+// https://github.com/ChrisTrenkamp/goxpath
+class GoXPathSink extends XPathInjectionSink {
+  GoXPathSink() {
+    exists(CallExpr call |
+      getAMatchingFunction("goxpath", 0, call, this.asExpr()).getName().matches("Parse")
+      or 
+      getAMatchingFunction("goxpath", 0, call, this.asExpr()).getName().matches("MustParse")
+      or 
+      getAMatchingFunction("goxpath", 0, call, this.asExpr()).getName().matches("ParseExec")
+    )
+  }
+}
+
+// https://github.com/santhosh-tekuri/xpathparser
+class XPathParserSink extends XPathInjectionSink {
+  XPathParserSink() {
+    exists(CallExpr call |
+      getAMatchingFunction("xpathparser", 0, call, this.asExpr()).getName().matches("Parse")
+      or 
+      getAMatchingFunction("xpathparser", 0, call, this.asExpr()).getName().matches("MustParse")
+    )
+  }
+}
+
+// https://github.com/moovweb/gokogiri
+class GokogiriSink extends XPathInjectionSink {
+  GokogiriSink() {
+    exists(CallExpr call |
+      getAMatchingFunction("xpath", 0, call, this.asExpr()).getName().matches("Compile")
+      or 
+      // TODO: The following cases will have false positives in case a *xpath.Expression is supplied
+      // I don't know how to fix this, since I'm new to the Go QL flavour.
+      // https://github.com/moovweb/gokogiri/blob/a1a828153468a7518b184e698f6265904108d957/xml/node.go#L613
+      getAMatchingFunction("xml", 0, call, this.asExpr()).getName().matches("Search%")
+      or
+      getAMatchingFunction("xml", 0, call, this.asExpr()).getName().matches("EvalXPath%")    
+    )
+  }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, XPathInjectionConfiguration c
+where c.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "$@ flows to here and is used in an XPath expression.",
+  source.getNode(), "User-provided value"


### PR DESCRIPTION
An XPath injection query is available for C#, JavaScript, Java but not for Go.
This pull request consist of an XPath Injection query to detect cases in which user input is used unsafely included in an XPath query.

I'm pretty much new to the Go language, so I hope my example code works.
I'm also new to the Go QL flavour so I've added a TODO which I'm currently not sure how to solve.

Query help is inspired/ported from the C# query help.

Code will be autoformatted soon.