### PR TITLE
Add Qldoc for the last few remaining predicates.

### DIFF
--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -368,8 +368,10 @@ class ParameterNode extends SsaNode {
 class ReceiverNode extends ParameterNode {
   override ReceiverVariable parm;
 
+  /** Gets the receiver variable this node initializes. */
   ReceiverVariable asReceiverVariable() { result = parm }
 
+  /** Holds if this node initializes the receiver variable of `m`. */
   predicate isReceiverOf(MethodDecl m) { parm.isReceiverOf(m) }
 }
 

--- a/ql/src/semmle/go/dataflow/internal/TaintTrackingUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/TaintTrackingUtil.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides Go-specific definitions for use in the taint-tracking library.
+ */
+
 private import go
 
 /**

--- a/ql/src/semmle/go/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/ql/src/semmle/go/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -1,3 +1,13 @@
+/**
+ * Provides an implementation of global (interprocedural) taint tracking.
+ * This file re-exports the local (intraprocedural) taint-tracking analysis
+ * from `TaintTrackingParameter::Public` and adds a global analysis, mainly
+ * exposed through the `Configuration` class. For some languages, this file
+ * exists in several identical copies, allowing queries to use multiple
+ * `Configuration` classes that depend on each other without introducing
+ * mutual recursion among those configurations.
+ */
+
 import TaintTrackingParameter::Public
 private import TaintTrackingParameter::Private
 


### PR DESCRIPTION
Apart from a missing module doc comment for `TaintTrackingImpl.qll` which we'll need to synchronize with the other languages (https://github.com/Semmle/ql/pull/3155), this gets us to 100% Qldoc coverage.