### PR TITLE
Add code-scanning suites

### DIFF
--- a/ql/src/codeql-suites/go-code-scanning.qls
+++ b/ql/src/codeql-suites/go-code-scanning.qls
@@ -1,0 +1,4 @@
+- description: Standard Code Scanning queries for Go
+- qlpack: codeql-go
+- apply: code-scanning-selectors.yml
+  from: codeql-suite-helpers


### PR DESCRIPTION
This is the suite that'll be run by default for the code-scanning feature.
Also see https://github.com/Semmle/ql/pull/3163 for the definition of `code-scanning-selectors.yml`.