### PR TITLE
Update HTTP.qll

### DIFF
--- a/ql/src/semmle/go/frameworks/HTTP.qll
+++ b/ql/src/semmle/go/frameworks/HTTP.qll
@@ -19,7 +19,6 @@ private module StdlibHttp {
         fieldName = "Trailer" or
         fieldName = "URL" or
         fieldName = "Host" or
-        fieldName = "Method" or
         fieldName = "RequestURI"
       )
     }

--- a/ql/src/semmle/go/frameworks/HTTP.qll
+++ b/ql/src/semmle/go/frameworks/HTTP.qll
@@ -17,7 +17,10 @@ private module StdlibHttp {
         fieldName = "MultipartForm" or
         fieldName = "Header" or
         fieldName = "Trailer" or
-        fieldName = "URL"
+        fieldName = "URL" or
+        fieldName = "Host" or
+        fieldName = "Method" or
+        fieldName = "RequestURI"
       )
     }
   }
@@ -33,7 +36,8 @@ private module StdlibHttp {
         methName = "MultipartReader" or
         methName = "PostFormValue" or
         methName = "Referer" or
-        methName = "UserAgent"
+        methName = "UserAgent" or
+        methName = "BasicAuth"     
       )
     }
   }

--- a/ql/test/library-tests/semmle/go/frameworks/HTTP/controller.go
+++ b/ql/test/library-tests/semmle/go/frameworks/HTTP/controller.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func handlerExample() {
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println("r.Host", r.Host)
+		fmt.Println("r.RequestURI", r.RequestURI)
+
+		fmt.Println("r.BasicAuth()")
+		user, password, _ := r.BasicAuth()
+		fmt.Println(fmt.Sprintf("username %q, password %q", user, password))
+		fmt.Println("---")
+	})
+	fmt.Println("running server on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
Add more fields to `UserControlledRequestField()`, and more methods to `UserControlledRequestMethod()` on `"net/http".Request`.


# Example server

```go
package main

import (
	"fmt"
	"log"
	"net/http"
)

func main() {

	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		fmt.Println("r.Host", r.Host)
		fmt.Println("r.Method", r.Method)
		fmt.Println("r.RequestURI", r.RequestURI)

		fmt.Println("r.BasicAuth()")
		user, password, _ := r.BasicAuth()
		fmt.Println(fmt.Sprintf("username %q, password %q", user, password))

		fmt.Println("---")
	})
	fmt.Println("running server on :8080")
	log.Fatal(http.ListenAndServe(":8080", nil))
}
```

# Example request

```bash
printf "H&&\$ /\$(echo\u00A0hello\u00A0world) HTTP/1.0\r\nHost: lite\$(echo;hello;world)).whatever.com\r\nAuthorization: Basic JChlY2hvIGhlbGxvIHdvcmxkKTokKGVjaG8gd29ybGQpCg==\r\n\r\n" | nc 127.0.0.1 8080
```

Server log of this request:

```
r.Host lite$(echo;hello;world)).whatever.com
r.Method H&&$
r.RequestURI /$(echo hello world)
r.BasicAuth()
username "$(echo hello world)", password "$(echo world)\n"
---
```