### PR TITLE
Fix a few compiler errors in tests

### DIFF
--- a/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalFlowStep.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalFlowStep.expected
@@ -83,6 +83,8 @@
 | main.go:38:7:38:20 | composite literal | main.go:38:2:38:2 | definition of s |
 | main.go:39:2:39:3 | definition of s1 | main.go:40:18:40:19 | s1 |
 | main.go:39:8:39:25 | call to append | main.go:39:2:39:3 | definition of s1 |
+| main.go:40:2:40:3 | definition of s2 | main.go:43:9:43:10 | s2 |
+| main.go:40:8:40:23 | call to append | main.go:40:2:40:3 | definition of s2 |
 | main.go:41:2:41:3 | definition of s4 | main.go:42:10:42:11 | s4 |
 | main.go:41:8:41:21 | call to make | main.go:41:2:41:3 | definition of s4 |
 | strings.go:8:12:8:12 | argument corresponding to s | strings.go:8:12:8:12 | definition of s |

--- a/ql/test/library-tests/semmle/go/dataflow/FlowSteps/main.go
+++ b/ql/test/library-tests/semmle/go/dataflow/FlowSteps/main.go
@@ -34,10 +34,11 @@ func main() {
 	test1(test2()(), test2())
 }
 
-func test9() {
+func test9() []int {
 	s := []int{1, 2, 3}
 	s1 := append(s, 4, 5, 6)
 	s2 := append(s, s1...)
 	s4 := make([]int, 4)
 	copy(s, s4)
+	return s2
 }

--- a/ql/test/query-tests/InconsistentCode/MistypedExponentiation/main.go
+++ b/ql/test/query-tests/InconsistentCode/MistypedExponentiation/main.go
@@ -26,4 +26,6 @@ func main() {
 	// than the xor operator and so the query doesn't see a constant on the left
 	// hand side of ^.
 	fmt.Println(nonconst()*10 ^ 9)
+
+	fmt.Println(mask)
 }

--- a/ql/test/query-tests/RedundantCode/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/ql/test/query-tests/RedundantCode/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -20,9 +20,10 @@
 | testdata.go:268:2:268:2 | assignment to x | This definition of x is never used. |
 | testdata.go:309:2:309:2 | assignment to a | This definition of a is never used. |
 | testdata.go:321:2:321:2 | assignment to a | This definition of a is never used. |
-| testdata.go:431:3:431:3 | assignment to x | This definition of x is never used. |
-| testdata.go:433:3:433:3 | assignment to x | This definition of x is never used. |
-| testdata.go:440:2:440:2 | assignment to x | This definition of x is never used. |
-| testdata.go:487:3:487:3 | assignment to x | This definition of x is never used. |
-| testdata.go:541:3:541:3 | assignment to x | This definition of x is never used. |
-| testdata.go:579:4:579:4 | assignment to x | This definition of x is never used. |
+| testdata.go:387:3:387:3 | assignment to x | This definition of x is never used. |
+| testdata.go:432:3:432:3 | assignment to x | This definition of x is never used. |
+| testdata.go:434:3:434:3 | assignment to x | This definition of x is never used. |
+| testdata.go:441:2:441:2 | assignment to x | This definition of x is never used. |
+| testdata.go:488:3:488:3 | assignment to x | This definition of x is never used. |
+| testdata.go:542:3:542:3 | assignment to x | This definition of x is never used. |
+| testdata.go:580:4:580:4 | assignment to x | This definition of x is never used. |

--- a/ql/test/query-tests/RedundantCode/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/ql/test/query-tests/RedundantCode/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -20,10 +20,9 @@
 | testdata.go:268:2:268:2 | assignment to x | This definition of x is never used. |
 | testdata.go:309:2:309:2 | assignment to a | This definition of a is never used. |
 | testdata.go:321:2:321:2 | assignment to a | This definition of a is never used. |
-| testdata.go:385:3:385:3 | assignment to x | This definition of x is never used. |
-| testdata.go:430:3:430:3 | assignment to x | This definition of x is never used. |
-| testdata.go:432:3:432:3 | assignment to x | This definition of x is never used. |
-| testdata.go:439:2:439:2 | assignment to x | This definition of x is never used. |
-| testdata.go:486:3:486:3 | assignment to x | This definition of x is never used. |
-| testdata.go:540:3:540:3 | assignment to x | This definition of x is never used. |
-| testdata.go:578:4:578:4 | assignment to x | This definition of x is never used. |
+| testdata.go:431:3:431:3 | assignment to x | This definition of x is never used. |
+| testdata.go:433:3:433:3 | assignment to x | This definition of x is never used. |
+| testdata.go:440:2:440:2 | assignment to x | This definition of x is never used. |
+| testdata.go:487:3:487:3 | assignment to x | This definition of x is never used. |
+| testdata.go:541:3:541:3 | assignment to x | This definition of x is never used. |
+| testdata.go:579:4:579:4 | assignment to x | This definition of x is never used. |

--- a/ql/test/query-tests/RedundantCode/DeadStoreOfLocal/testdata.go
+++ b/ql/test/query-tests/RedundantCode/DeadStoreOfLocal/testdata.go
@@ -381,11 +381,12 @@ func _() {
 func _() {
 	var x int
 	switch b {
+	case true:
+		_ = x
 	default:
 		x = deadStore() // BAD
 		fallthrough
 	case b:
-		_ = x
 	}
 }
 

--- a/ql/test/query-tests/RedundantCode/DeadStoreOfLocal/testdata.go
+++ b/ql/test/query-tests/RedundantCode/DeadStoreOfLocal/testdata.go
@@ -385,6 +385,7 @@ func _() {
 		x = deadStore() // BAD
 		fallthrough
 	case b:
+		_ = x
 	}
 }
 

--- a/ql/test/query-tests/Security/CWE-190/AllocationSizeOverflowGood2.go
+++ b/ql/test/query-tests/Security/CWE-190/AllocationSizeOverflowGood2.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 )
 
-func encryptValueGood(v interface{}) ([]byte, error) {
+func encryptValueGood2(v interface{}) ([]byte, error) {
 	jsonData, err := json.Marshal(v)
 	if err != nil {
 		return nil, err

--- a/ql/test/query-tests/Security/CWE-295/DisabledCertificateCheck/tst.go
+++ b/ql/test/query-tests/Security/CWE-295/DisabledCertificateCheck/tst.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+)
 
 func TestSomethingExciting(t *testing.T) {
 	transport := &http.Transport{


### PR DESCRIPTION
This fixes all (unintentional) errors not covered by https://github.com/github/codeql-go/pull/96.