### PR TITLE
Add two missing change notes.

### DIFF
--- a/change-notes/1.24/analysis-go.md
+++ b/change-notes/1.24/analysis-go.md
@@ -3,7 +3,7 @@
 ## General improvements
 
 * Alert suppression can now be done with single-line block comments (`/* ... */`) as well as line comments (`// ...`).
-* Analysis of flow through fields has been improved.
+* Analysis of flow through fields and elements of arrays and slices has been improved, which may lead to more results from the security queries.
 * Detection of test code has been improved. LGTM will not show alerts in test code by default.
 * Go 1.14 library changes have been modeled.
 * More sources of untrusted input as well as vulnerable sinks are modelled, which may lead to more results from the security queries.

--- a/change-notes/1.24/extractor-go.md
+++ b/change-notes/1.24/extractor-go.md
@@ -10,5 +10,6 @@
 * The autobuilder now runs Makefiles or custom build scripts present in the codebase to install dependencies. The build command
   to invoke can be configured via `lgtm.yml`, or by setting the environment variable `CODEQL_EXTRACTOR_GO_BUILD_COMMAND`.
 * The autobuilder now attempts to automatically detect when dependencies have been vendored and use `-mod=vendor` appropriately.
+* The extractor now compresses intermediate files used for constructing databases, which reduces the amount of disk space it requires.
 * The extractor now supports extracting go.mod files, enabling queries on dependencies and their versions.
 * The extractor now supports Go 1.14.


### PR DESCRIPTION
Covering https://github.com/github/codeql-go/pull/57 and https://github.com/github/codeql-go/pull/69.