### PR TITLE
Add consistency query flagging tests with unexpected frontend errors

### DIFF
--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -254,38 +255,45 @@ func extractObjectType(tw *trap.Writer, obj types.Object, lbl trap.Label) {
 	}
 }
 
+var (
+	// file:line:col
+	threePartPos = regexp.MustCompile(`^(.+):(\d+):(\d+)$`)
+	// file:line
+	twoPartPos = regexp.MustCompile(`^(.+):(\d+)$`)
+)
+
 // extractError extracts the message and location of a frontend error
 func extractError(tw *trap.Writer, err packages.Error, pkglbl trap.Label, idx int) {
 	var (
-		lbl           = tw.Labeler.FreshID()
-		kind          = dbscheme.ErrorTypes[err.Kind].Index()
-		pos           = err.Pos
-		posComponents = strings.Split(err.Pos, ":")
-		file          = ""
-		line          = 0
-		col           = 0
-		e             error
+		lbl  = tw.Labeler.FreshID()
+		kind = dbscheme.ErrorTypes[err.Kind].Index()
+		pos  = err.Pos
+		file = ""
+		line = 0
+		col  = 0
+		e    error
 	)
-	switch len(posComponents) {
-	case 3:
+
+	if parts := threePartPos.FindStringSubmatch(pos); parts != nil {
 		// "file:line:col"
-		col, e = strconv.Atoi(posComponents[2])
+		col, e = strconv.Atoi(parts[3])
 		if e != nil {
-			log.Printf("Warning: malformed column number `%s`: %v", posComponents[2], e)
+			log.Printf("Warning: malformed column number `%s`: %v", parts[3], e)
 		}
-		fallthrough
-	case 2:
+		line, e = strconv.Atoi(parts[2])
+		if e != nil {
+			log.Printf("Warning: malformed line number `%s`: %v", parts[2], e)
+		}
+		file = parts[1]
+	} else if parts := twoPartPos.FindStringSubmatch(pos); parts != nil {
 		// "file:line"
-		file = posComponents[0]
-		line, e = strconv.Atoi(posComponents[1])
+		line, e = strconv.Atoi(parts[2])
 		if e != nil {
-			log.Printf("Warning: malformed line number `%s`: %v", posComponents[1], e)
+			log.Printf("Warning: malformed line number `%s`: %v", parts[2], e)
 		}
-	default:
-		// "", "-"
-		if pos != "" && pos != "-" {
-			log.Printf("Warning: malformed error position `%s`", pos)
-		}
+		file = parts[1]
+	} else if pos != "" && pos != "-" {
+		log.Printf("Warning: malformed error position `%s`", pos)
 	}
 	file = filepath.ToSlash(srcarchive.TransformPath(file))
 	dbscheme.ErrorsTable.Emit(tw, lbl, kind, err.Msg, pos, file, line, col, pkglbl, idx)

--- a/ql/src/semmle/go/Errors.qll
+++ b/ql/src/semmle/go/Errors.qll
@@ -18,6 +18,9 @@ class Error extends @error {
   /** Gets the index of this error among all errors reported for the same package. */
   int getIndex() { errors(this, _, _, _, _, _, _, _, result) }
 
+  /** Gets the file in which this error was reported, if it can be determined. */
+  File getFile() { hasLocationInfo(result.getAbsolutePath(), _, _, _, _) }
+
   /**
    * Holds if this element is at the specified location.
    * The location spans column `startcolumn` of line `startline` to

--- a/ql/test/consistency/UnexpectedFrontendErrors.ql
+++ b/ql/test/consistency/UnexpectedFrontendErrors.ql
@@ -1,0 +1,16 @@
+/**
+ * @name Unexpected frontend error
+ * @description This query produces a list of all errors produced by the Go frontend
+ *              during extraction, except for those occurring in files annotated with
+ *              "// codeql test: expect frontend errors".
+ * @id go/unexpected-frontend-error
+ */
+
+import go
+
+from Error e
+where
+  not exists(Comment c | c.getFile() = e.getFile() |
+    c.getText().trim() = "codeql test: expect frontend errors"
+  )
+select e

--- a/ql/test/consistency/test.go
+++ b/ql/test/consistency/test.go
@@ -1,0 +1,7 @@
+package main
+
+// Example file with a syntax error to demonstrate use of "expect frontend errors" directive
+
+// codeql test: expect frontend errors
+
+This is not a valid Go program

--- a/ql/test/library-tests/semmle/go/Types/SignatureType_getNumParameter.expected
+++ b/ql/test/library-tests/semmle/go/Types/SignatureType_getNumParameter.expected
@@ -8,4 +8,4 @@
 | pkg1/tst.go:33:1:35:1 | function declaration | 0 |
 | pkg1/tst.go:37:1:37:26 | function declaration | 1 |
 | pkg1/tst.go:39:1:57:1 | function declaration | 2 |
-| unknownFunction.go:8:1:12:1 | function declaration | 0 |
+| unknownFunction.go:10:1:14:1 | function declaration | 0 |

--- a/ql/test/library-tests/semmle/go/Types/SignatureType_getNumResult.expected
+++ b/ql/test/library-tests/semmle/go/Types/SignatureType_getNumResult.expected
@@ -8,4 +8,4 @@
 | pkg1/tst.go:33:1:35:1 | function declaration | 1 |
 | pkg1/tst.go:37:1:37:26 | function declaration | 0 |
 | pkg1/tst.go:39:1:57:1 | function declaration | 0 |
-| unknownFunction.go:8:1:12:1 | function declaration | 0 |
+| unknownFunction.go:10:1:14:1 | function declaration | 0 |

--- a/ql/test/library-tests/semmle/go/Types/notype.expected
+++ b/ql/test/library-tests/semmle/go/Types/notype.expected
@@ -1,3 +1,3 @@
-| unknownFunction.go:9:7:9:21 | unknownFunction | invalid type |
-| unknownFunction.go:9:7:9:23 | call to unknownFunction | invalid type |
-| unknownFunction.go:10:7:10:15 | ...+... | invalid type |
+| unknownFunction.go:11:7:11:21 | unknownFunction | invalid type |
+| unknownFunction.go:11:7:11:23 | call to unknownFunction | invalid type |
+| unknownFunction.go:12:7:12:15 | ...+... | invalid type |

--- a/ql/test/library-tests/semmle/go/Types/unknownFunction.go
+++ b/ql/test/library-tests/semmle/go/Types/unknownFunction.go
@@ -1,7 +1,9 @@
 package main
 
 // This file tests type inference for expressions referencing undeclared entities.
-// It is therefore expected to produce extractor warnings.
+// It is therefore expected to expected frontend errors.
+
+// codeql test: expect frontend errors
 
 import "fmt"
 

--- a/ql/test/query-tests/RedundantCode/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/ql/test/query-tests/RedundantCode/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -1,4 +1,4 @@
-| main.go:25:2:25:2 | assignment to x | This definition of x is never used. |
+| main.go:27:2:27:2 | assignment to x | This definition of x is never used. |
 | testdata.go:32:2:32:2 | assignment to x | This definition of x is never used. |
 | testdata.go:37:2:37:2 | assignment to x | This definition of x is never used. |
 | testdata.go:61:2:61:2 | assignment to x | This definition of x is never used. |

--- a/ql/test/query-tests/RedundantCode/DeadStoreOfLocal/main.go
+++ b/ql/test/query-tests/RedundantCode/DeadStoreOfLocal/main.go
@@ -2,6 +2,8 @@ package p
 
 import "fmt"
 
+// codeql test: expect frontend errors
+
 func test() {
 	if false {
 		x := deadStore() // OK

--- a/ql/test/query-tests/RedundantCode/ImpossibleInterfaceNilCheck/err.go
+++ b/ql/test/query-tests/RedundantCode/ImpossibleInterfaceNilCheck/err.go
@@ -2,6 +2,8 @@ package main
 
 import "fmt"
 
+// codeql test: expect frontend errors
+
 func errtest() {
 	x := unknownFunction()
 	var y interface{} = x


### PR DESCRIPTION
CodeQL does not support consistency queries yet, but I have verified that it works as expected with `odasa qltest`.