### PR TITLE
Add queries for ide search.

### DIFF
--- a/ql/src/codeql-suites/go-lgtm-full.qls
+++ b/ql/src/codeql-suites/go-lgtm-full.qls
@@ -2,3 +2,8 @@
 - qlpack: codeql-go
 - apply: lgtm-selectors.yml
   from: codeql-suite-helpers
+# These are only for IDE use.
+- exclude:
+    tags contain:
+      - ide-contextual-queries/local-definitions
+      - ide-contextual-queries/local-references

--- a/ql/src/localDefinitions.ql
+++ b/ql/src/localDefinitions.ql
@@ -1,0 +1,19 @@
+/**
+ * @name Jump-to-definition links
+ * @description Generates use-definition pairs that provide the data
+ *              for jump-to-definition in the code viewer.
+ * @kind definitions
+ * @id go/ide-jump-to-definition
+ * @tags ide-contextual-queries/local-definitions
+ */
+
+import go
+
+external string selectedSourceFile();
+
+cached
+File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }
+
+from Ident def, Ident use, Entity e
+where use.uses(e) and def.declares(e) and use.getFile() = getEncodedFile(selectedSourceFile())
+select use, def, "V"

--- a/ql/src/localReferences.ql
+++ b/ql/src/localReferences.ql
@@ -1,0 +1,19 @@
+/**
+ * @name Find-references links
+ * @description Generates use-definition pairs that provide the data
+ *              for find-references in the code viewer.
+ * @kind definitions
+ * @id go/ide-find-references
+ * @tags ide-contextual-queries/local-references
+ */
+
+import go
+
+external string selectedSourceFile();
+
+cached
+File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }
+
+from Ident def, Ident use, Entity e
+where use.uses(e) and def.declares(e) and def.getFile() = getEncodedFile(selectedSourceFile())
+select use, def, "V"


### PR DESCRIPTION
This enables jump-to-definition and find-references in the VS Code
extension, for golang source archives.