### PR TITLE
User-controlled bypass of a comparision

### DIFF
--- a/ql/src/experimental/CWE-840/ConditionBypass.qhelp
+++ b/ql/src/experimental/CWE-840/ConditionBypass.qhelp
@@ -1,0 +1,35 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+    <overview>
+        <p>
+Testing untrusted user input against untrusted user input results in
+a bypass of the conditional check as the attacker may modify parameters to match.
+</p>
+    </overview>
+    <recommendation>
+        <p>
+To guard against this, it is advisable to avoid framing a comparision 
+where both sides are untrusted user inputs.
+Instead, use a configuration to store and access the values required.
+</p>
+    </recommendation>
+    <example>
+        <p>
+The following example shows a comparision where both the sides 
+are from attacker controlled request headers. This should be avoided.:
+</p>
+        <sample src="ConditionBypassBad.go" />
+        <p>
+One way to remedy the problem is to test against a value stored in a configuration:
+</p>
+        <sample src="ConditionBypassGood.go" />
+    </example>
+    <references>
+        <li>
+            MITRE:
+            <a href="https://cwe.mitre.org/data/definitions/840.html">
+                CWE-840.
+            </a>
+        </li>
+    </references>
+</qhelp>

--- a/ql/src/experimental/CWE-840/ConditionBypass.qhelp
+++ b/ql/src/experimental/CWE-840/ConditionBypass.qhelp
@@ -8,15 +8,15 @@ a bypass of the conditional check as the attacker may modify parameters to match
     </overview>
     <recommendation>
         <p>
-To guard against this, it is advisable to avoid framing a comparision 
+To guard against this, it is advisable to avoid framing a comparison 
 where both sides are untrusted user inputs.
 Instead, use a configuration to store and access the values required.
 </p>
     </recommendation>
     <example>
         <p>
-The following example shows a comparision where both the sides 
-are from attacker controlled request headers. This should be avoided.:
+The following example shows a comparison where both the sides 
+are from attacker-controlled request headers. This should be avoided.:
 </p>
         <sample src="ConditionBypassBad.go" />
         <p>
@@ -24,12 +24,4 @@ One way to remedy the problem is to test against a value stored in a configurati
 </p>
         <sample src="ConditionBypassGood.go" />
     </example>
-    <references>
-        <li>
-            MITRE:
-            <a href="https://cwe.mitre.org/data/definitions/840.html">
-                CWE-840.
-            </a>
-        </li>
-    </references>
 </qhelp>

--- a/ql/src/experimental/CWE-840/ConditionBypass.ql
+++ b/ql/src/experimental/CWE-840/ConditionBypass.ql
@@ -1,0 +1,44 @@
+/**
+ * @name Comparision Expression Check Bypass
+ * @description This query tests for user-controlled bypassing
+ *  of a comparision expression i.e. instances where both the
+ *  lhs and rhs of a comparision are user controlled.
+ * @id go/condition-bypass
+ * @kind problem
+ * @problem.severity medium
+ * @tags external/cwe/cwe-840
+ */
+
+import go
+
+/**
+ * A data-flow configuration for reasoning about Condition Bypass.
+ */
+class Configuration extends TaintTracking::Configuration {
+  Configuration() { this = "Comparision Expression Check Bypass" }
+
+  override predicate isSource(DataFlow::Node source) {
+    source instanceof UntrustedFlowSource
+    or
+    exists(string fieldName |
+      source.(DataFlow::FieldReadNode).getField().hasQualifiedName("net/http", "Request", fieldName)
+    |
+      fieldName = "Host"
+    )
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(ComparisonExpr c | c.getAnOperand() = sink.asExpr())
+  }
+}
+
+from
+  Configuration config, DataFlow::PathNode lhsSource, DataFlow::PathNode lhs,
+  DataFlow::PathNode rhsSource, DataFlow::PathNode rhs, ComparisonExpr c
+where
+  config.hasFlowPath(rhsSource, rhs) and
+  rhs.getNode().asExpr() = c.getRightOperand() and
+  config.hasFlowPath(lhsSource, lhs) and
+  lhs.getNode().asExpr() = c.getLeftOperand()
+select c, "This comparision is between user controlled operands and "
++ "hence may be bypassed."

--- a/ql/src/experimental/CWE-840/ConditionBypassBad.go
+++ b/ql/src/experimental/CWE-840/ConditionBypassBad.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"net/http"
+)
+
+// bad the origin and the host headers are user controlled
+func ex1(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Origin") != "http://"+r.Host {
+		//do something
+	}
+}

--- a/ql/src/experimental/CWE-840/ConditionBypassBad.go
+++ b/ql/src/experimental/CWE-840/ConditionBypassBad.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 )
 
-// bad the origin and the host headers are user controlled
 func ex1(w http.ResponseWriter, r *http.Request) {
+	// bad the origin and the host headers are user controlled
 	if r.Header.Get("Origin") != "http://"+r.Host {
 		//do something
 	}

--- a/ql/src/experimental/CWE-840/ConditionBypassGood.go
+++ b/ql/src/experimental/CWE-840/ConditionBypassGood.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"net/http"
+)
+
+func ex1(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Origin") != config.get("Host") {
+		//do something
+	}
+}

--- a/ql/test/experimental/CWE-840/ConditionBypass.expected
+++ b/ql/test/experimental/CWE-840/ConditionBypass.expected
@@ -1,0 +1,2 @@
+| condition.go:9:5:9:46 | ...!=... | This comparision is between user controlled operands and hence may be bypassed. |
+| condition.go:16:5:16:62 | ...!=... | This comparision is between user controlled operands and hence may be bypassed. |

--- a/ql/test/experimental/CWE-840/ConditionBypass.expected
+++ b/ql/test/experimental/CWE-840/ConditionBypass.expected
@@ -1,2 +1,2 @@
-| condition.go:9:5:9:46 | ...!=... | This comparision is between user controlled operands and hence may be bypassed. |
-| condition.go:16:5:16:62 | ...!=... | This comparision is between user controlled operands and hence may be bypassed. |
+| condition.go:9:5:9:46 | ...!=... | This comparision is between user controlled operands derived from $@ | condition.go:9:5:9:12 | selection of Header : Header |  and $@ | condition.go:9:41:9:46 | selection of Host : string | hence may be bypassed. |
+| condition.go:16:5:16:62 | ...!=... | This comparision is between user controlled operands derived from $@ | condition.go:16:5:16:12 | selection of Header : Header |  and $@ | condition.go:16:41:16:48 | selection of Header : Header | hence may be bypassed. |

--- a/ql/test/experimental/CWE-840/ConditionBypass.qlref
+++ b/ql/test/experimental/CWE-840/ConditionBypass.qlref
@@ -1,0 +1,1 @@
+experimental/CWE-840/ConditionBypass.ql

--- a/ql/test/experimental/CWE-840/condition.go
+++ b/ql/test/experimental/CWE-840/condition.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"net/http"
+)
+
+// bad : taken from https://www.gorillatoolkit.org/pkg/websocket
+func ex1(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Origin") != "http://"+r.Host {
+		//do something
+	}
+}
+
+// bad both are from remote sources
+func ex2(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Origin") != "http://"+r.Header.Get("Header") {
+		//do something
+	}
+}
+
+// good
+func ex3(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Origin") != "http://"+"test" {
+		//do something
+	}
+}


### PR DESCRIPTION
This is a comparatively simpler query. 
This is inspired from the following code snippet which was found in [Gorillas websocket](https://www.gorillatoolkit.org/pkg/websocket#Upgrade) package documentation.

```go
if req.Header.Get("Origin") != "http://"+req.Host {
    http.Error(w, "Origin not allowed", http.StatusForbidden)
    return
}
```

Here, the comparison is between two attacker controlled fields and hence, the check can effectively be bypassed. 

Since, this has been done once and I can already see some instances on Github's fuzzy search where this is found, it makes sense to add this to the default set of queries.