### PR TITLE
Add support for ioutil TempFile and TempDir

### DIFF
--- a/change-notes/2020-05-12-tainted-path.md
+++ b/change-notes/2020-05-12-tainted-path.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* The queries "Uncontrolled data used in path expression" and "Arbitrary file write during zip
+  extraction ("zip slip")" have been improved to recognize more file APIs, which may lead to more
+  alerts.

--- a/ql/src/semmle/go/frameworks/Stdlib.qll
+++ b/ql/src/semmle/go/frameworks/Stdlib.qll
@@ -166,11 +166,13 @@ module IoUtil {
       exists(string fn | getTarget().hasQualifiedName("io/ioutil", fn) |
         fn = "ReadDir" or
         fn = "ReadFile" or
+        fn = "TempDir" or
+        fn = "TempFile" or
         fn = "WriteFile"
       )
     }
 
-    override DataFlow::Node getAPathArgument() { result = getArgument(0) }
+    override DataFlow::Node getAPathArgument() { result = getAnArgument() }
   }
 
   /**

--- a/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
+++ b/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
@@ -1,10 +1,18 @@
 edges
 | TaintedPath.go:10:10:10:14 | selection of URL : pointer type | TaintedPath.go:13:29:13:32 | path |
 | TaintedPath.go:10:10:10:14 | selection of URL : pointer type | TaintedPath.go:17:28:17:61 | call to Join |
+| tst.go:14:22:14:39 | call to FormFile : tuple type | tst.go:17:41:17:47 | implicit dereference : FileHeader |
+| tst.go:14:22:14:39 | call to FormFile : tuple type | tst.go:17:41:17:56 | selection of Filename |
+| tst.go:17:41:17:47 | implicit dereference : FileHeader | tst.go:17:41:17:47 | implicit dereference : FileHeader |
+| tst.go:17:41:17:47 | implicit dereference : FileHeader | tst.go:17:41:17:56 | selection of Filename |
 nodes
 | TaintedPath.go:10:10:10:14 | selection of URL : pointer type | semmle.label | selection of URL : pointer type |
 | TaintedPath.go:13:29:13:32 | path | semmle.label | path |
 | TaintedPath.go:17:28:17:61 | call to Join | semmle.label | call to Join |
+| tst.go:14:22:14:39 | call to FormFile : tuple type | semmle.label | call to FormFile : tuple type |
+| tst.go:17:41:17:47 | implicit dereference : FileHeader | semmle.label | implicit dereference : FileHeader |
+| tst.go:17:41:17:56 | selection of Filename | semmle.label | selection of Filename |
 #select
 | TaintedPath.go:13:29:13:32 | path | TaintedPath.go:10:10:10:14 | selection of URL : pointer type | TaintedPath.go:13:29:13:32 | path | This path depends on $@. | TaintedPath.go:10:10:10:14 | selection of URL | a user-provided value |
 | TaintedPath.go:17:28:17:61 | call to Join | TaintedPath.go:10:10:10:14 | selection of URL : pointer type | TaintedPath.go:17:28:17:61 | call to Join | This path depends on $@. | TaintedPath.go:10:10:10:14 | selection of URL | a user-provided value |
+| tst.go:17:41:17:56 | selection of Filename | tst.go:14:22:14:39 | call to FormFile : tuple type | tst.go:17:41:17:56 | selection of Filename | This path depends on $@. | tst.go:14:22:14:39 | call to FormFile | a user-provided value |

--- a/ql/test/query-tests/Security/CWE-022/ZipSlip.expected
+++ b/ql/test/query-tests/Security/CWE-022/ZipSlip.expected
@@ -1,15 +1,15 @@
 edges
 | ZipSlip.go:12:24:12:29 | selection of Name : string | ZipSlip.go:14:20:14:20 | p |
 | tarslip.go:14:23:14:33 | selection of Name : string | tarslip.go:14:14:14:34 | call to Dir |
-| tst.go:15:11:15:16 | selection of Name : string | tst.go:20:20:20:23 | path |
+| tst.go:24:11:24:16 | selection of Name : string | tst.go:29:20:29:23 | path |
 nodes
 | ZipSlip.go:12:24:12:29 | selection of Name : string | semmle.label | selection of Name : string |
 | ZipSlip.go:14:20:14:20 | p | semmle.label | p |
 | tarslip.go:14:14:14:34 | call to Dir | semmle.label | call to Dir |
 | tarslip.go:14:23:14:33 | selection of Name : string | semmle.label | selection of Name : string |
-| tst.go:15:11:15:16 | selection of Name : string | semmle.label | selection of Name : string |
-| tst.go:20:20:20:23 | path | semmle.label | path |
+| tst.go:24:11:24:16 | selection of Name : string | semmle.label | selection of Name : string |
+| tst.go:29:20:29:23 | path | semmle.label | path |
 #select
 | ZipSlip.go:12:24:12:29 | selection of Name | ZipSlip.go:12:24:12:29 | selection of Name : string | ZipSlip.go:14:20:14:20 | p | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipSlip.go:14:20:14:20 | p | file system operation |
 | tarslip.go:14:23:14:33 | selection of Name | tarslip.go:14:23:14:33 | selection of Name : string | tarslip.go:14:14:14:34 | call to Dir | Unsanitized archive entry, which may contain '..', is used in a $@. | tarslip.go:14:14:14:34 | call to Dir | file system operation |
-| tst.go:15:11:15:16 | selection of Name | tst.go:15:11:15:16 | selection of Name : string | tst.go:20:20:20:23 | path | Unsanitized archive entry, which may contain '..', is used in a $@. | tst.go:20:20:20:23 | path | file system operation |
+| tst.go:24:11:24:16 | selection of Name | tst.go:24:11:24:16 | selection of Name : string | tst.go:29:20:29:23 | path | Unsanitized archive entry, which may contain '..', is used in a $@. | tst.go:29:20:29:23 | path | file system operation |

--- a/ql/test/query-tests/Security/CWE-022/tst.go
+++ b/ql/test/query-tests/Security/CWE-022/tst.go
@@ -3,11 +3,20 @@ package main
 import (
 	"archive/zip"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 )
+
+func uploadFile(w http.ResponseWriter, r *http.Request) {
+	file, handler, _ := r.FormFile("file")
+	// err handling
+	defer file.Close()
+	tempFile, _ := ioutil.TempFile("/tmp", handler.Filename) // NOT OK
+	// do stuff with tempFile
+}
 
 func unzip2(f string, root string) {
 	r, _ := zip.OpenReader(f)


### PR DESCRIPTION
[Evaluation](https://git.semmle.com/sauyon/dist-compare-reports/tree/917c7ae7b9fc276befaf4b1d0b202ced1d848e32) is clean apart from the sourcegraph false positives, which I've opened an issue for.