### PR TITLE
Remove accidentally committed binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tools/linux64
 tools/osx64
 tools/win64
 tools/tokenizer.jar
+main


### PR DESCRIPTION
I accidentally added this while testing some time ago.

Should we remove this from our history?

I've also added the name `main` to the gitignore.