### PR TITLE
Exit after writing dbscheme

### DIFF
--- a/extractor/cli/go-extractor/go-extractor.go
+++ b/extractor/cli/go-extractor/go-extractor.go
@@ -65,6 +65,7 @@ func main() {
 		dbscheme.PrintDbScheme(f)
 		f.Close()
 		log.Printf("Dbscheme written to file %s.", dumpDbscheme)
+		os.Exit(0)
 	}
 
 	if cpuprofile != "" {


### PR DESCRIPTION
I thought this might make sense since we aren't likely to want to both extract and write the dbscheme at once.