### PR TITLE
Make FunctionOutput.isResult(0) and CallNode.getResult(0) match single results

### DIFF
--- a/ql/src/experimental/frameworks/Gin.qll
+++ b/ql/src/experimental/frameworks/Gin.qll
@@ -72,8 +72,6 @@ private module Gin {
           )
         |
           this = call.getResult(0)
-          or
-          this = call.getResult()
         )
         or
         // Field reads:
@@ -104,8 +102,6 @@ private module Gin {
           call.getTarget().hasQualifiedName(packagePath, typeName, ["ByName", "Get"])
         |
           this = call.getResult(0)
-          or
-          this = call.getResult()
         )
       )
     }

--- a/ql/src/semmle/go/dataflow/FunctionInputsAndOutputs.qll
+++ b/ql/src/semmle/go/dataflow/FunctionInputsAndOutputs.qll
@@ -100,7 +100,11 @@ private class ResultInput extends FunctionInput, TInResult {
 
   override predicate isResult() { index = -1 }
 
-  override predicate isResult(int i) { i = index and i >= 0 }
+  override predicate isResult(int i) {
+    index = -1 and i = 0
+    or
+    i = index and i >= 0
+  }
 
   override DataFlow::Node getEntryNode(DataFlow::CallNode c) {
     exists(DataFlow::PostUpdateNode pun, DataFlow::Node init |
@@ -181,7 +185,11 @@ private class OutResult extends FunctionOutput, TOutResult {
 
   override predicate isResult() { index = -1 }
 
-  override predicate isResult(int i) { i = index and i >= 0 }
+  override predicate isResult(int i) {
+    index = -1 and i = 0
+    or
+    i = index and i >= 0
+  }
 
   override DataFlow::Node getEntryNode(FuncDef f) {
     // return expressions

--- a/ql/src/semmle/go/dataflow/FunctionInputsAndOutputs.qll
+++ b/ql/src/semmle/go/dataflow/FunctionInputsAndOutputs.qll
@@ -101,7 +101,7 @@ private class ResultInput extends FunctionInput, TInResult {
   override predicate isResult() { index = -1 }
 
   override predicate isResult(int i) {
-    index = -1 and i = 0
+    i = 0 and isResult()
     or
     i = index and i >= 0
   }
@@ -186,7 +186,7 @@ private class OutResult extends FunctionOutput, TOutResult {
   override predicate isResult() { index = -1 }
 
   override predicate isResult(int i) {
-    index = -1 and i = 0
+    i = 0 and isResult()
     or
     i = index and i >= 0
   }

--- a/ql/src/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -19,7 +19,7 @@ class ReturnKind extends TReturnKind {
 class ReturnNode extends ResultNode {
   ReturnKind kind;
 
-  ReturnNode() { exists(int nr | nr = fd.getType().getNumResult() | kind = MkReturnKind(i)) }
+  ReturnNode() { kind = MkReturnKind(i) }
 
   /** Gets the kind of this returned value. */
   ReturnKind getKind() { result = kind }

--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -328,7 +328,11 @@ class CallNode extends ExprNode {
   FunctionNode getCallback(int i) { result.getASuccessor*() = this.getArgument(i) }
 
   /** Gets the data-flow node corresponding to the `i`th result of this call. */
-  Node getResult(int i) { result = extractTupleElement(this, i) }
+  Node getResult(int i) {
+    not getType() instanceof TupleType and i = 0 and result = this
+    or
+    result = extractTupleElement(this, i)
+  }
 
   /**
    * Gets the data-flow node corresponding to the result of this call.

--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -345,6 +345,9 @@ class CallNode extends ExprNode {
    */
   Node getResult() { not getType() instanceof TupleType and result = this }
 
+  /** Gets a result of this call. */
+  Node getAResult() { result = this.getResult(_) }
+
   /** Gets the data flow node corresponding to the receiver of this call, if any. */
   Node getReceiver() { result = getACalleeSource().(MethodReadNode).getReceiver() }
 }

--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -327,9 +327,12 @@ class CallNode extends ExprNode {
   /** Gets a function passed as the `i`th argument of this call. */
   FunctionNode getCallback(int i) { result.getASuccessor*() = this.getArgument(i) }
 
-  /** Gets the data-flow node corresponding to the `i`th result of this call. */
+  /**
+   * Gets the data-flow node corresponding to the `i`th result of this call.
+   *
+   * If there is a single result then it is considered to be the 0th result. */
   Node getResult(int i) {
-    not getType() instanceof TupleType and i = 0 and result = this
+    i = 0 and result = getResult()
     or
     result = extractTupleElement(this, i)
   }

--- a/ql/src/semmle/go/frameworks/Stdlib.qll
+++ b/ql/src/semmle/go/frameworks/Stdlib.qll
@@ -62,7 +62,7 @@ module PathFilePath {
 
     override predicate hasTaintFlow(DataFlow::FunctionInput inp, DataFlow::FunctionOutput outp) {
       inp.isParameter(_) and
-      (outp.isResult() or outp.isResult(_))
+      outp.isResult(_)
     }
   }
 }
@@ -472,7 +472,7 @@ module Path {
 
     override predicate hasTaintFlow(DataFlow::FunctionInput inp, DataFlow::FunctionOutput outp) {
       inp.isParameter(_) and
-      (outp.isResult() or outp.isResult(_))
+      outp.isResult(_)
     }
   }
 }

--- a/ql/src/semmle/go/frameworks/Stdlib.qll
+++ b/ql/src/semmle/go/frameworks/Stdlib.qll
@@ -684,8 +684,7 @@ module URL {
     }
 
     override predicate hasTaintFlow(DataFlow::FunctionInput inp, DataFlow::FunctionOutput outp) {
-      inp.isReceiver() and
-      if getName() = "Password" then outp.isResult(0) else outp.isResult()
+      inp.isReceiver() and outp.isResult(0)
     }
   }
 

--- a/ql/src/semmle/go/security/ReflectedXssCustomizations.qll
+++ b/ql/src/semmle/go/security/ReflectedXssCustomizations.qll
@@ -75,7 +75,7 @@ module ReflectedXss {
         pred.getStringValue().regexpMatch("^[^<].*")
         or
         // json data cannot begin with `<`
-        pred = any(EncodingJson::MarshalFunction mf).getOutput().getExitNode(_)
+        exists(EncodingJson::MarshalFunction mf | pred = mf.getOutput().getNode(mf.getACall()))
       )
     )
   }

--- a/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionInput_getEntryNode.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionInput_getEntryNode.expected
@@ -14,3 +14,4 @@
 | receiver | main.go:53:14:53:21 | call to bump | main.go:53:14:53:14 | c |
 | receiver | tst.go:10:2:10:29 | call to ReadFrom | tst.go:10:2:10:12 | bytesBuffer |
 | result | tst.go:9:17:9:33 | call to new | tst.go:9:2:9:12 | definition of bytesBuffer |
+| result 0 | tst.go:9:17:9:33 | call to new | tst.go:9:2:9:12 | definition of bytesBuffer |

--- a/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_getExitNode.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_getExitNode.expected
@@ -4,7 +4,11 @@
 | result | main.go:53:2:53:22 | call to op2 | main.go:53:2:53:22 | call to op2 |
 | result | main.go:53:14:53:21 | call to bump | main.go:53:14:53:21 | call to bump |
 | result | tst.go:9:17:9:33 | call to new | tst.go:9:17:9:33 | call to new |
+| result 0 | main.go:51:2:51:14 | call to op | main.go:51:2:51:14 | call to op |
+| result 0 | main.go:53:2:53:22 | call to op2 | main.go:53:2:53:22 | call to op2 |
+| result 0 | main.go:53:14:53:21 | call to bump | main.go:53:14:53:21 | call to bump |
 | result 0 | main.go:54:10:54:15 | call to test | main.go:54:2:54:15 | ... := ...[0] |
 | result 0 | main.go:56:9:56:15 | call to test2 | main.go:56:2:56:15 | ... = ...[0] |
+| result 0 | tst.go:9:17:9:33 | call to new | tst.go:9:17:9:33 | call to new |
 | result 1 | main.go:54:10:54:15 | call to test | main.go:54:2:54:15 | ... := ...[1] |
 | result 1 | main.go:56:9:56:15 | call to test2 | main.go:56:2:56:15 | ... = ...[1] |

--- a/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_isResult.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_isResult.expected
@@ -1,0 +1,4 @@
+| main.go:51:2:51:14 | call to op | main.go:51:2:51:14 | call to op | result |
+| main.go:53:2:53:22 | call to op2 | main.go:53:2:53:22 | call to op2 | result |
+| main.go:53:14:53:21 | call to bump | main.go:53:14:53:21 | call to bump | result |
+| tst.go:9:17:9:33 | call to new | tst.go:9:17:9:33 | call to new | result |

--- a/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_isResult.ql
+++ b/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_isResult.ql
@@ -1,0 +1,5 @@
+import go
+
+from FunctionOutput outp, DataFlow::CallNode c, DataFlow::Node nodeTo
+where outp.isResult() and nodeTo = outp.getNode(c)
+select c, nodeTo, outp

--- a/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_isResult_int.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_isResult_int.expected
@@ -1,8 +1,12 @@
 | main.go:51:2:51:14 | call to op | main.go:51:2:51:14 | call to op | 0 | result |
+| main.go:51:2:51:14 | call to op | main.go:51:2:51:14 | call to op | 0 | result 0 |
 | main.go:53:2:53:22 | call to op2 | main.go:53:2:53:22 | call to op2 | 0 | result |
+| main.go:53:2:53:22 | call to op2 | main.go:53:2:53:22 | call to op2 | 0 | result 0 |
 | main.go:53:14:53:21 | call to bump | main.go:53:14:53:21 | call to bump | 0 | result |
+| main.go:53:14:53:21 | call to bump | main.go:53:14:53:21 | call to bump | 0 | result 0 |
 | main.go:54:10:54:15 | call to test | main.go:54:2:54:15 | ... := ...[0] | 0 | result 0 |
 | main.go:54:10:54:15 | call to test | main.go:54:2:54:15 | ... := ...[1] | 1 | result 1 |
 | main.go:56:9:56:15 | call to test2 | main.go:56:2:56:15 | ... = ...[0] | 0 | result 0 |
 | main.go:56:9:56:15 | call to test2 | main.go:56:2:56:15 | ... = ...[1] | 1 | result 1 |
 | tst.go:9:17:9:33 | call to new | tst.go:9:17:9:33 | call to new | 0 | result |
+| tst.go:9:17:9:33 | call to new | tst.go:9:17:9:33 | call to new | 0 | result 0 |

--- a/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_isResult_int.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_isResult_int.expected
@@ -1,4 +1,8 @@
+| main.go:51:2:51:14 | call to op | main.go:51:2:51:14 | call to op | 0 | result |
+| main.go:53:2:53:22 | call to op2 | main.go:53:2:53:22 | call to op2 | 0 | result |
+| main.go:53:14:53:21 | call to bump | main.go:53:14:53:21 | call to bump | 0 | result |
 | main.go:54:10:54:15 | call to test | main.go:54:2:54:15 | ... := ...[0] | 0 | result 0 |
 | main.go:54:10:54:15 | call to test | main.go:54:2:54:15 | ... := ...[1] | 1 | result 1 |
 | main.go:56:9:56:15 | call to test2 | main.go:56:2:56:15 | ... = ...[0] | 0 | result 0 |
 | main.go:56:9:56:15 | call to test2 | main.go:56:2:56:15 | ... = ...[1] | 1 | result 1 |
+| tst.go:9:17:9:33 | call to new | tst.go:9:17:9:33 | call to new | 0 | result |

--- a/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_isResult_int.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_isResult_int.expected
@@ -1,0 +1,4 @@
+| main.go:54:10:54:15 | call to test | main.go:54:2:54:15 | ... := ...[0] | 0 | result 0 |
+| main.go:54:10:54:15 | call to test | main.go:54:2:54:15 | ... := ...[1] | 1 | result 1 |
+| main.go:56:9:56:15 | call to test2 | main.go:56:2:56:15 | ... = ...[0] | 0 | result 0 |
+| main.go:56:9:56:15 | call to test2 | main.go:56:2:56:15 | ... = ...[1] | 1 | result 1 |

--- a/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_isResult_int.ql
+++ b/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionOutput_isResult_int.ql
@@ -1,0 +1,5 @@
+import go
+
+from FunctionOutput outp, int i, DataFlow::CallNode c, DataFlow::Node nodeTo
+where outp.isResult(i) and nodeTo = outp.getNode(c)
+select c, nodeTo, i, outp

--- a/ql/test/library-tests/semmle/go/dataflow/Nodes/BinaryOperationNodes.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/Nodes/BinaryOperationNodes.expected
@@ -1,3 +1,4 @@
 | main.go:7:14:7:24 | ...+... | + | main.go:7:14:7:14 | x | main.go:7:19:7:23 | ...+... |
 | main.go:7:19:7:23 | ...+... | + | main.go:7:19:7:19 | y | main.go:7:23:7:23 | z |
-| main.go:15:2:15:13 | ... += ... | + | main.go:15:2:15:6 | index expression | main.go:15:11:15:13 | "!" |
+| main.go:10:14:10:18 | ...+... | + | main.go:10:14:10:14 | x | main.go:10:18:10:18 | y |
+| main.go:17:2:17:13 | ... += ... | + | main.go:17:2:17:6 | index expression | main.go:17:11:17:13 | "!" |

--- a/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode.expected
@@ -1,4 +1,6 @@
 | main.go:7:2:7:25 | call to Println |
 | main.go:8:5:8:7 | call to f |
-| main.go:12:8:12:24 | call to make |
-| main.go:14:2:14:26 | call to Println |
+| main.go:9:9:9:14 | call to test |
+| main.go:10:2:10:19 | call to Println |
+| main.go:14:8:14:24 | call to make |
+| main.go:16:2:16:26 | call to Println |

--- a/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode_getArgument.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode_getArgument.expected
@@ -1,5 +1,6 @@
 | main.go:7:2:7:25 | call to Println | 0 | main.go:7:14:7:24 | ...+... |
-| main.go:12:8:12:24 | call to make | 0 | main.go:12:23:12:23 | 1 |
-| main.go:14:2:14:26 | call to Println | 0 | main.go:14:14:14:15 | ss |
-| main.go:14:2:14:26 | call to Println | 1 | main.go:14:18:14:18 | 0 |
-| main.go:14:2:14:26 | call to Println | 2 | main.go:14:21:14:25 | index expression |
+| main.go:10:2:10:19 | call to Println | 0 | main.go:10:14:10:18 | ...+... |
+| main.go:14:8:14:24 | call to make | 0 | main.go:14:23:14:23 | 1 |
+| main.go:16:2:16:26 | call to Println | 0 | main.go:16:14:16:15 | ss |
+| main.go:16:2:16:26 | call to Println | 1 | main.go:16:18:16:18 | 0 |
+| main.go:16:2:16:26 | call to Println | 2 | main.go:16:21:16:25 | index expression |

--- a/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode_getResult.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode_getResult.expected
@@ -1,0 +1,1 @@
+| main.go:14:8:14:24 | call to make | main.go:14:8:14:24 | call to make |

--- a/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode_getResult.ql
+++ b/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode_getResult.ql
@@ -1,0 +1,5 @@
+import go
+
+from DataFlow::CallNode c, DataFlow::Node outp
+where outp = c.getResult()
+select c, outp

--- a/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode_getResult_int.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode_getResult_int.expected
@@ -1,2 +1,3 @@
 | main.go:9:9:9:14 | call to test | 0 | main.go:9:2:9:14 | ... = ...[0] |
 | main.go:9:9:9:14 | call to test | 1 | main.go:9:2:9:14 | ... = ...[1] |
+| main.go:14:8:14:24 | call to make | 0 | main.go:14:8:14:24 | call to make |

--- a/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode_getResult_int.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode_getResult_int.expected
@@ -1,0 +1,2 @@
+| main.go:9:9:9:14 | call to test | 0 | main.go:9:2:9:14 | ... = ...[0] |
+| main.go:9:9:9:14 | call to test | 1 | main.go:9:2:9:14 | ... = ...[1] |

--- a/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode_getResult_int.ql
+++ b/ql/test/library-tests/semmle/go/dataflow/Nodes/CallNode_getResult_int.ql
@@ -1,0 +1,5 @@
+import go
+
+from DataFlow::CallNode c, int i, DataFlow::Node outp
+where outp = c.getResult(i)
+select c, i, outp

--- a/ql/test/library-tests/semmle/go/dataflow/Nodes/main.go
+++ b/ql/test/library-tests/semmle/go/dataflow/Nodes/main.go
@@ -6,6 +6,8 @@ func main() {
 	x, y, z := 1, 2, 3
 	fmt.Println(x + (y + z))
 	go f()
+	x, y = test()
+	fmt.Println(x + y)
 }
 
 func f() {
@@ -13,4 +15,8 @@ func f() {
 	ss[0] = "hi"
 	fmt.Println(ss, 0, ss[0])
 	ss[0] += "!"
+}
+
+func test() (int, int) {
+	return 23, 42
 }


### PR DESCRIPTION
Resolves #146 

Note that `FunctionOutput.isResult()` and `CallNode.getResult()` do not match anything when there is more than one result. I think this is less confusing and error-prone than the alternative.