### PR TITLE
Add more code-scanning suites

### DIFF
--- a/ql/src/codeql-suites/go-security-and-quality.qls
+++ b/ql/src/codeql-suites/go-security-and-quality.qls
@@ -1,0 +1,4 @@
+- description: Security-and-quality queries for Go
+- qlpack: codeql-go
+- apply: security-and-quality-selectors.yml
+  from: codeql-suite-helpers

--- a/ql/src/codeql-suites/go-security-extended.qls
+++ b/ql/src/codeql-suites/go-security-extended.qls
@@ -1,0 +1,4 @@
+- description: Security-extended queries for Go
+- qlpack: codeql-go
+- apply: security-extended-selectors.yml
+  from: codeql-suite-helpers


### PR DESCRIPTION
We want to add more code scanning query suites so that users to easily choose to run a larger set of query in a fully supported and maintainable way. We also don't want people to have to use the lgtm suites because it's an old product name that people shouldn't have to know about.

Suite names and contents were decided upon by @jhutchings1 and @sj.

See https://github.com/github/codeql/pull/3596 for more info