### PR TITLE
Add Make target to autoformat all QL.

### DIFF
--- a/.github/workflows/codeqltest.yml
+++ b/.github/workflows/codeqltest.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Build
       run: env PATH=$PATH:$HOME/codeql make
 
+    - name: Check that all QL code is autoformatted
+      run: env PATH=$PATH:$HOME/codeql make AUTOFORMAT=--check-only autoformat
+
     - name: Test
       run: env PATH=$PATH:$HOME/codeql make test
 

--- a/.github/workflows/codeqltest.yml
+++ b/.github/workflows/codeqltest.yml
@@ -20,7 +20,7 @@ jobs:
         echo "Done"
         cd $HOME
         echo "Downloading CodeQL CLI..."
-        curl https://github.com/github/codeql-cli-binaries/releases/download/v2.1.1/codeql.zip -L -o codeql.zip
+        curl https://github.com/github/codeql-cli-binaries/releases/download/v2.2.0/codeql.zip -L -o codeql.zip
         echo "Done"
         echo "Unpacking CodeQL CLI..."
         unzip -q codeql.zip
@@ -56,7 +56,7 @@ jobs:
         echo "Done"
         cd $HOME
         echo "Downloading CodeQL CLI..."
-        curl https://github.com/github/codeql-cli-binaries/releases/download/v2.1.1/codeql.zip -L -o codeql.zip
+        curl https://github.com/github/codeql-cli-binaries/releases/download/v2.2.0/codeql.zip -L -o codeql.zip
         echo "Done"
         echo "Unpacking CodeQL CLI..."
         unzip -q codeql.zip
@@ -89,7 +89,7 @@ jobs:
         echo "Done"
         cd "$HOME"
         echo "Downloading CodeQL CLI..."
-        Invoke-WebRequest -Uri https://github.com/github/codeql-cli-binaries/releases/download/v2.1.1/codeql.zip -OutFile codeql.zip
+        Invoke-WebRequest -Uri https://github.com/github/codeql-cli-binaries/releases/download/v2.2.0/codeql.zip -OutFile codeql.zip
         echo "Done"
         echo "Unpacking CodeQL CLI..."
         Expand-Archive codeql.zip -DestinationPath $HOME

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,17 @@ EXTRACTOR_PACK_OUT = build/codeql-extractor-go
 
 BINARIES = go-extractor go-tokenizer go-autobuilder go-bootstrap go-gen-dbscheme
 
-.PHONY: tools tools-codeql tools-codeql-full clean \
+.PHONY: tools tools-codeql tools-codeql-full clean autoformat \
 	tools-linux64 tools-osx64 tools-win64
 
 clean:
 	rm -rf tools/bin tools/linux64 tools/osx64 tools/win64 tools/net tools/opencsv
 	rm -rf $(EXTRACTOR_PACK_OUT) build/stats build/testdb
+
+AUTOFORMAT=-qq -i
+
+autoformat:
+	find ql/src -name *.ql -or -name *.qll | xargs codeql query format $(AUTOFORMAT)
 
 tools: $(addsuffix $(EXE),$(addprefix tools/bin/,$(BINARIES))) tools/tokenizer.jar
 

--- a/ql/src/semmle/go/Comments.qll
+++ b/ql/src/semmle/go/Comments.qll
@@ -42,7 +42,7 @@ class Comment extends @comment, AstNode {
  * // a line comment
  * /* a block
  *   comment *&#47
-* 
+ *
  * /* a block
  * comment *&#47
  * /* another block comment *&#47
@@ -71,7 +71,7 @@ class CommentGroup extends @comment_group, AstNode {
  * ```go
  * // function documentation
  * func double(x int) int { return 2 * x }
- * 
+ *
  * // generic declaration documentation
  * const (
  *   // specifier documentation
@@ -93,7 +93,7 @@ class Documentable extends AstNode, @documentable {
  * ```go
  * // function documentation
  * func double(x int) int { return 2 * x }
- * 
+ *
  * // generic declaration documentation
  * const (
  *   // specifier documentation

--- a/ql/src/semmle/go/Expr.qll
+++ b/ql/src/semmle/go/Expr.qll
@@ -1559,7 +1559,7 @@ class SimpleName extends Name, Ident { }
  * ```go
  * fmt.Println
  * ```
-*/
+ */
 class QualifiedName extends Name, SelectorExpr { }
 
 /**
@@ -1769,7 +1769,7 @@ private predicate isTypeExprTopDown(Expr e) {
  *
  * ```go
  * int
- * func 
+ * func
  * ```
  */
 class TypeExpr extends Expr {

--- a/ql/src/semmle/go/Stmt.qll
+++ b/ql/src/semmle/go/Stmt.qll
@@ -832,17 +832,17 @@ class TypeSwitchStmt extends @typeswitchstmt, SwitchStmt {
  * ```go
  * case i1 = <-c1:
  *   print("received ", i1, " from c1\n")
- * 
+ *
  * case c2 <- i2:
  *   print("sent ", i2, " to c2\n")
- * 
+ *
  * case i3, ok := (<-c3):  // same as: i3, ok := <-c3
  *   if ok {
  *     print("received ", i3, " from c3\n")
  *   } else {
  *     print("c3 is closed\n")
  *   }
- * 
+ *
  * default:
  *   print("no communication\n")
  * ```
@@ -961,7 +961,7 @@ class SelectStmt extends @selectstmt, Stmt {
  * for a < b {
  *   a *= 2
  * }
- * 
+ *
  * for i := 0; i < 10; i++ {
  *   f(i)
  * }
@@ -985,7 +985,7 @@ class LoopStmt extends @loopstmt, Stmt, ScopeNode {
  * for a < b {
  *   a *= 2
  * }
- * 
+ *
  * for i := 0; i < 10; i++ {
  *   f(i)
  * }

--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -330,7 +330,8 @@ class CallNode extends ExprNode {
   /**
    * Gets the data-flow node corresponding to the `i`th result of this call.
    *
-   * If there is a single result then it is considered to be the 0th result. */
+   * If there is a single result then it is considered to be the 0th result.
+   */
   Node getResult(int i) {
     i = 0 and result = getResult()
     or


### PR DESCRIPTION
Use

```sh
make autoformat
```

to format all `.ql` and `.qll` files under `ql/src`.

Use

```sh
make AUTOFORMAT=--check-only autoformat
```

to check that all `.ql` and `.qll` files under `ql/src` are correctly formatted and fail if they are not.

The second commit adds a PR check to ensure everything is autoformatted. This is currently expected to fail; let's see whether it does. (**EDIT**: It does.)