### PR TITLE
Extract more dependency ASTs

### DIFF
--- a/change-notes/2020-06-12-more-dependency-extraction.md
+++ b/change-notes/2020-06-12-more-dependency-extraction.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The extractor now attempts to extract the AST of all dependencies that are related to the packages passed explicitly on the commandline, which is determined by using the module root or, if not using modules, the directory containing the source for those packages.

--- a/change-notes/2020-06-12-more-dependency-extraction.md
+++ b/change-notes/2020-06-12-more-dependency-extraction.md
@@ -1,2 +1,2 @@
 lgtm,codescanning
-* The extractor now attempts to extract the AST of all dependencies that are related to the packages passed explicitly on the commandline, which is determined by using the module root or, if not using modules, the directory containing the source for those packages.
+* The extractor now attempts to extract the AST of all dependencies that are related to the packages passed explicitly on the commandline, which is determined by using the module root or, if not using modules, the directory containing the source for those packages. In particular, this means if a package passed to the extractor depends on another package inside the same module, the dependency's AST will now be extracted.

--- a/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -52,14 +52,6 @@ func getEnvGoVersion() string {
 	return strings.Fields(string(gover))[2]
 }
 
-func fileExists(filename string) bool {
-	_, err := os.Stat(filename)
-	if err != nil && !os.IsNotExist(err) {
-		log.Printf("Unable to stat %s: %s\n", filename, err.Error())
-	}
-	return err == nil
-}
-
 func run(cmd *exec.Cmd) bool {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -80,7 +72,7 @@ func run(cmd *exec.Cmd) bool {
 }
 
 func tryBuild(buildFile, cmd string, args ...string) bool {
-	if fileExists(buildFile) {
+	if util.FileExists(buildFile) {
 		log.Printf("%s found, running %s\n", buildFile, cmd)
 		return run(exec.Command(cmd, args...))
 	}
@@ -168,21 +160,21 @@ func main() {
 	// extraction
 	depMode := GoGetNoModules
 	needGopath := true
-	if fileExists("go.mod") {
+	if util.FileExists("go.mod") {
 		depMode = GoGetWithModules
 		needGopath = false
 		log.Println("Found go.mod, enabling go modules")
-	} else if fileExists("Gopkg.toml") {
+	} else if util.FileExists("Gopkg.toml") {
 		depMode = Dep
 		log.Println("Found Gopkg.toml, using dep instead of go get")
-	} else if fileExists("glide.yaml") {
+	} else if util.FileExists("glide.yaml") {
 		depMode = Glide
 		log.Println("Found glide.yaml, enabling go modules")
 	}
 
 	// if a vendor/modules.txt file exists, we assume that there are vendored Go dependencies, and
 	// skip the dependency installation step and run the extractor with `-mod=vendor`
-	hasVendor := fileExists("vendor/modules.txt")
+	hasVendor := util.FileExists("vendor/modules.txt")
 
 	// if `LGTM_INDEX_NEED_GOPATH` is set, it overrides the value for `needGopath` inferred above
 	if needGopathOverride := os.Getenv("LGTM_INDEX_NEED_GOPATH"); needGopathOverride != "" {
@@ -328,7 +320,7 @@ func main() {
 						}
 					}
 
-					if fileExists("Gopkg.lock") {
+					if util.FileExists("Gopkg.lock") {
 						// if Gopkg.lock exists, don't update it and only vendor dependencies
 						install = exec.Command("dep", "ensure", "-v", "-vendor-only")
 					} else {

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -42,6 +42,13 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
 
+	var modFlag string
+	for _, flag := range buildFlags {
+		if strings.HasPrefix(flag, "-mod=") {
+			modFlag = flag
+		}
+	}
+
 	if err != nil {
 		return err
 	}
@@ -59,8 +66,8 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 	// root directories of packages that we want to extract
 	wantedRoots := make(map[string]bool)
 	for _, pkg := range pkgs {
-		mdir := util.GetModDir(pkg.PkgPath)
-		pdir := util.GetPkgDir(pkg.PkgPath)
+		mdir := util.GetModDir(pkg.PkgPath, modFlag)
+		pdir := util.GetPkgDir(pkg.PkgPath, modFlag)
 		if mdir == "" {
 			mdir = pdir
 		}
@@ -79,8 +86,8 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 		return true
 	}, func(pkg *packages.Package) {
 		if _, ok := pkgRoots[pkg.PkgPath]; !ok {
-			mdir := util.GetModDir(pkg.PkgPath)
-			pdir := util.GetPkgDir(pkg.PkgPath)
+			mdir := util.GetModDir(pkg.PkgPath, modFlag)
+			pdir := util.GetPkgDir(pkg.PkgPath, modFlag)
 			if mdir == "" {
 				mdir = pdir
 			}

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -42,10 +42,10 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
 
-	var modFlag string
+	modFlags := make([]string, 0, 1)
 	for _, flag := range buildFlags {
 		if strings.HasPrefix(flag, "-mod=") {
-			modFlag = flag
+			modFlags = append(modFlags, flag)
 		}
 	}
 
@@ -73,8 +73,8 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 		return true
 	}, func(pkg *packages.Package) {
 		if _, ok := pkgRoots[pkg.PkgPath]; !ok {
-			mdir := util.GetModDir(pkg.PkgPath, modFlag)
-			pdir := util.GetPkgDir(pkg.PkgPath, modFlag)
+			mdir := util.GetModDir(pkg.PkgPath, modFlags...)
+			pdir := util.GetPkgDir(pkg.PkgPath, modFlags...)
 			// GetModDir returns the empty string if the module directory cannot be determined, e.g. if the package
 			// is not using modules. If this is the case, fall back to the package directory
 			if mdir == "" {

--- a/extractor/util/util.go
+++ b/extractor/util/util.go
@@ -1,6 +1,12 @@
 package util
 
-import "os"
+import (
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
 
 // Getenv retrieves the value of the environment variable named by the key.
 // If that variable is not present, it iterates over the given aliases until
@@ -17,4 +23,62 @@ func Getenv(key string, aliases ...string) string {
 		}
 	}
 	return ""
+}
+
+// GetModDir gets directory of the module containing the package with path `pkgpath`.
+func GetModDir(pkgpath string) string {
+	mod, err := exec.Command("go", "list", "-e", "-f", "{{.Module}}", pkgpath).Output()
+	if err != nil {
+		if err, ok := err.(*exec.ExitError); ok {
+			log.Printf("Warning: go list command failed, output below:\n%s%s", mod, err.Stderr)
+		} else {
+			log.Printf("Warning: Failed to run go list: %s", err.Error())
+		}
+
+		return ""
+	}
+
+	if strings.TrimSpace(string(mod)) == "<nil>" {
+		// if modules aren't being used, return nothing
+		return ""
+	}
+
+	modDir, err := exec.Command("go", "list", "-e", "-f", "{{.Module.Dir}}", pkgpath).Output()
+	if err != nil {
+		if err, ok := err.(*exec.ExitError); ok {
+			log.Printf("Warning: go list command failed, output below:\n%s%s", modDir, err.Stderr)
+		} else {
+			log.Printf("Warning: Failed to run go list: %s", err.Error())
+		}
+
+		return ""
+	}
+
+	trimmed := strings.TrimSpace(string(modDir))
+	abs, err := filepath.Abs(trimmed)
+	if err != nil {
+		log.Printf("Warning: unable to make %s absolute: %s", trimmed, err.Error())
+	}
+	return abs
+}
+
+// GetPkgDir gets directory containing the package with path `pkgpath`.
+func GetPkgDir(pkgpath string) string {
+	pkgDir, err := exec.Command("go", "list", "-e", "-f", "{{.Dir}}", pkgpath).Output()
+	if err != nil {
+		if err, ok := err.(*exec.ExitError); ok {
+			log.Printf("Warning: go list command failed, output below:\n%s%s", pkgDir, err.Stderr)
+		} else {
+			log.Printf("Warning: Failed to run go list: %s", err.Error())
+		}
+
+		return ""
+	}
+
+	trimmed := strings.TrimSpace(string(pkgDir))
+	abs, err := filepath.Abs(trimmed)
+	if err != nil {
+		log.Printf("Warning: unable to make %s absolute: %s", trimmed, err.Error())
+	}
+	return abs
 }

--- a/extractor/util/util.go
+++ b/extractor/util/util.go
@@ -47,7 +47,7 @@ func GetModDir(pkgpath string, modflag string) string {
 	}
 
 	if strings.TrimSpace(string(mod)) == "<nil>" {
-		// if modules aren't being used, return nothing
+		// if modules aren't being used, return the empty string
 		return ""
 	}
 
@@ -104,7 +104,7 @@ func GetPkgDir(pkgpath string, modflag string) string {
 	return abs
 }
 
-// FileExists tests whether the file at `filename` exists.
+// FileExists tests whether the file at `filename` exists and is not a directory.
 func FileExists(filename string) bool {
 	info, err := os.Stat(filename)
 	if err != nil && !os.IsNotExist(err) {

--- a/extractor/util/util.go
+++ b/extractor/util/util.go
@@ -82,3 +82,12 @@ func GetPkgDir(pkgpath string) string {
 	}
 	return abs
 }
+
+// FileExists tests whether the file at `filename` exists.
+func FileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	if err != nil && !os.IsNotExist(err) {
+		log.Printf("Unable to stat %s: %s\n", filename, err.Error())
+	}
+	return err == nil
+}

--- a/extractor/util/util.go
+++ b/extractor/util/util.go
@@ -25,9 +25,17 @@ func Getenv(key string, aliases ...string) string {
 	return ""
 }
 
-// GetModDir gets directory of the module containing the package with path `pkgpath`.
-func GetModDir(pkgpath string) string {
-	mod, err := exec.Command("go", "list", "-e", "-f", "{{.Module}}", pkgpath).Output()
+// GetModDir gets directory of the module containing the package with path `pkgpath`. It passes the
+// `go list` command `modflag`, which should be of the form `-mod=<mod mode>`, as described by `go
+// help modules`.
+func GetModDir(pkgpath string, modflag string) string {
+	var cmd *exec.Cmd
+	if modflag != "" {
+		cmd = exec.Command("go", "list", "-e", "-f", "{{.Module}}", modflag, pkgpath)
+	} else {
+		cmd = exec.Command("go", "list", "-e", "-f", "{{.Module}}", pkgpath)
+	}
+	mod, err := cmd.Output()
 	if err != nil {
 		if err, ok := err.(*exec.ExitError); ok {
 			log.Printf("Warning: go list command failed, output below:\n%s%s", mod, err.Stderr)
@@ -43,7 +51,12 @@ func GetModDir(pkgpath string) string {
 		return ""
 	}
 
-	modDir, err := exec.Command("go", "list", "-e", "-f", "{{.Module.Dir}}", pkgpath).Output()
+	if modflag != "" {
+		cmd = exec.Command("go", "list", "-e", "-f", "{{.Module.Dir}}", modflag, pkgpath)
+	} else {
+		cmd = exec.Command("go", "list", "-e", "-f", "{{.Module.Dir}}", pkgpath)
+	}
+	modDir, err := cmd.Output()
 	if err != nil {
 		if err, ok := err.(*exec.ExitError); ok {
 			log.Printf("Warning: go list command failed, output below:\n%s%s", modDir, err.Stderr)
@@ -62,9 +75,17 @@ func GetModDir(pkgpath string) string {
 	return abs
 }
 
-// GetPkgDir gets directory containing the package with path `pkgpath`.
-func GetPkgDir(pkgpath string) string {
-	pkgDir, err := exec.Command("go", "list", "-e", "-f", "{{.Dir}}", pkgpath).Output()
+// GetPkgDir gets directory containing the package with path `pkgpath`. It passes the `go list`
+// command `modflag`, which should be of the form `-mod=<mod mode>`, as described by `go help
+// modules`.
+func GetPkgDir(pkgpath string, modflag string) string {
+	var cmd *exec.Cmd
+	if modflag != "" {
+		cmd = exec.Command("go", "list", "-e", "-f", "{{.Dir}}", modflag, pkgpath)
+	} else {
+		cmd = exec.Command("go", "list", "-e", "-f", "{{.Dir}}", pkgpath)
+	}
+	pkgDir, err := cmd.Output()
 	if err != nil {
 		if err, ok := err.(*exec.ExitError); ok {
 			log.Printf("Warning: go list command failed, output below:\n%s%s", pkgDir, err.Stderr)

--- a/extractor/util/util.go
+++ b/extractor/util/util.go
@@ -85,9 +85,9 @@ func GetPkgDir(pkgpath string) string {
 
 // FileExists tests whether the file at `filename` exists.
 func FileExists(filename string) bool {
-	_, err := os.Stat(filename)
+	info, err := os.Stat(filename)
 	if err != nil && !os.IsNotExist(err) {
 		log.Printf("Unable to stat %s: %s\n", filename, err.Error())
 	}
-	return err == nil
+	return err == nil && !info.IsDir()
 }

--- a/extractor/util/util.go
+++ b/extractor/util/util.go
@@ -45,8 +45,8 @@ func runGoList(format string, pkgpath string, flags ...string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// GetModDir gets directory of the module containing the package with path `pkgpath`. It passes the
-// `go list` the flags specified by `flags`.
+// GetModDir gets the absolute directory of the module containing the package with path
+// `pkgpath`. It passes the `go list` the flags specified by `flags`.
 func GetModDir(pkgpath string, flags ...string) string {
 	mod, err := runGoList("{{.Module}}", pkgpath, flags...)
 	if err != nil || mod == "<nil>" {
@@ -67,8 +67,8 @@ func GetModDir(pkgpath string, flags ...string) string {
 	return abs
 }
 
-// GetPkgDir gets directory containing the package with path `pkgpath`. It passes the `go list`
-// command the flags specified by `flags`.
+// GetPkgDir gets the absolute directory containing the package with path `pkgpath`. It passes the
+// `go list` command the flags specified by `flags`.
 func GetPkgDir(pkgpath string, flags ...string) string {
 	pkgDir, err := runGoList("{{.Dir}}", pkgpath, flags...)
 	if err != nil {


### PR DESCRIPTION
A [dist-compare](https://git.semmle.com/sauyon/dist-compare-reports/tree/0460ebb817c6ecedbc9f2fcf2495c70e19354564) shows 60 new results on kubernetes due to the new way that files are picked up.

The results that I looked at look like false positives, but are reasonable, so I'm going to open issues for them and not worry about them for this PR.

Also, evaluation has slowed significantly for both `cadence` and `kubernetes`.

Matt established that the OS X issues I've been having are an issue with the tracer, and he's working on that now.