### PR TITLE
Clean up @field and @fieldparent usage

### DIFF
--- a/ql/src/semmle/go/AST.qll
+++ b/ql/src/semmle/go/AST.qll
@@ -20,7 +20,7 @@ class AstNode extends @node, Locatable {
     result = this.(StmtParent).getChildStmt(i) or
     result = this.(DeclParent).getDecl(i) or
     result = this.(GenDecl).getSpec(i) or
-    fields(result, this, i)
+    result = this.(FieldParent).getField(i)
   }
 
   /**
@@ -138,6 +138,29 @@ class DeclParent extends @declparent, AstNode {
    * Gets the number of child declarations of this node.
    */
   int getNumDecl() { result = count(getADecl()) }
+}
+
+/**
+ * An AST node whose children include fields.
+ */
+class FieldParent extends @fieldparent, AstNode {
+  /**
+   * Gets the `i`th field of this node.
+   *
+   * Note that the precise indices of fields are considered an implementation detail
+   * and are subject to change without notice.
+   */
+  FieldBase getField(int i) { fields(result, this, i) }
+
+  /**
+   * Gets a child field of this node in the AST.
+   */
+  FieldBase getAField() { result = getField(_) }
+
+  /**
+   * Gets the number of child fields of this node.
+   */
+  int getNumFields() { result = count(getAField()) }
 }
 
 /**

--- a/ql/src/semmle/go/Expr.qll
+++ b/ql/src/semmle/go/Expr.qll
@@ -792,16 +792,7 @@ class ArrayTypeExpr extends @arraytypeexpr, TypeExpr {
  * struct {x, y int; z float32}
  * ```
  */
-class StructTypeExpr extends @structtypeexpr, TypeExpr {
-  /** Gets the `i`th field declared in this struct type expression (0-based). */
-  FieldDecl getField(int i) { fields(result, this, i) }
-
-  /** Gets a field declared in this struct type expression. */
-  FieldDecl getAField() { result = getField(_) }
-
-  /** Gets the number of fields declared in this struct type expression. */
-  int getNumField() { result = count(getAField()) }
-
+class StructTypeExpr extends @structtypeexpr, TypeExpr, FieldParent {
   override string toString() { result = "struct type" }
 }
 
@@ -814,12 +805,9 @@ class StructTypeExpr extends @structtypeexpr, TypeExpr {
  * func(a, b int, c float32) (float32, bool)
  * ```
  */
-class FuncTypeExpr extends @functypeexpr, TypeExpr, ScopeNode {
+class FuncTypeExpr extends @functypeexpr, TypeExpr, ScopeNode, FieldParent {
   /** Gets the `i`th parameter of this function type (0-based). */
-  ParameterDecl getParameterDecl(int i) {
-    result.getFunctionTypeExpr() = this and
-    result.getIndex() = i
-  }
+  ParameterDecl getParameterDecl(int i) { result = getField(i) and i >= 0 }
 
   /** Gets a parameter of this function type. */
   ParameterDecl getAParameterDecl() { result = getParameterDecl(_) }
@@ -828,10 +816,7 @@ class FuncTypeExpr extends @functypeexpr, TypeExpr, ScopeNode {
   int getNumParameter() { result = count(getAParameterDecl()) }
 
   /** Gets the `i`th result of this function type (0-based). */
-  ResultVariableDecl getResultDecl(int i) {
-    result.getFunctionTypeExpr() = this and
-    result.getIndex() = i
-  }
+  ResultVariableDecl getResultDecl(int i) { result = getField(-(i + 1)) }
 
   /** Gets a result of this function type. */
   ResultVariableDecl getAResultDecl() { result = getResultDecl(_) }
@@ -854,12 +839,9 @@ class FuncTypeExpr extends @functypeexpr, TypeExpr, ScopeNode {
  * interface { Read(p []byte) (n int, err error); Close() error}
  * ```
  */
-class InterfaceTypeExpr extends @interfacetypeexpr, TypeExpr {
+class InterfaceTypeExpr extends @interfacetypeexpr, TypeExpr, FieldParent {
   /** Gets the `i`th method specification of this interface type. */
-  MethodSpec getMethod(int i) {
-    result.getInterfaceTypeExpr() = this and
-    result.getIndex() = i
-  }
+  MethodSpec getMethod(int i) { result = getField(i) }
 
   /** Gets a method of this interface type. */
   MethodSpec getAMethod() { result = getMethod(_) }


### PR DESCRIPTION
* Centralise use of raw types and database predicates in FieldParent and FieldBase classes
* Deduplicate type predicates common to all fields
* Deduplicate predicates common to function parameters and results