### PR TITLE
Refine potential targets for method call through interface

### DIFF
--- a/change-notes/2020-06-19-call-graph.md
+++ b/change-notes/2020-06-19-call-graph.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Resolution of method calls through interfaces has been improved, resulting in more precise call-graph information, which in turn may eliminate false positives from the security queries.

--- a/ql/src/semmle/go/dataflow/internal/DataFlowDispatch.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowDispatch.qll
@@ -2,18 +2,20 @@ private import go
 private import DataFlowPrivate
 
 /**
- * Holds if `call` is an interface call to method `m`, meaning that its receiver `recv` has an
- * interface type.
+ * Holds if `call` is an interface call to method `m`, meaning that its receiver `recv` has
+ * interface type `tp`.
  */
-private predicate isInterfaceCallReceiver(DataFlow::CallNode call, DataFlow::Node recv, string m) {
+private predicate isInterfaceCallReceiver(
+  DataFlow::CallNode call, DataFlow::Node recv, InterfaceType tp, string m
+) {
   call.getReceiver() = recv and
-  recv.getType().getUnderlyingType() instanceof InterfaceType and
+  recv.getType().getUnderlyingType() = tp and
   m = call.getCalleeName()
 }
 
 /** Gets a data-flow node that may flow into the receiver value of `call`, which is an interface value. */
 private DataFlow::Node getInterfaceCallReceiverSource(DataFlow::CallNode call) {
-  isInterfaceCallReceiver(call, result.getASuccessor*(), _)
+  isInterfaceCallReceiver(call, result.getASuccessor*(), _, _)
 }
 
 /** Gets the type of `nd`, which must be a valid type and not an interface type. */
@@ -44,7 +46,7 @@ private predicate isConcreteValue(DataFlow::Node nd) {
  * types of `recv` can be established by local reasoning.
  */
 private predicate isConcreteInterfaceCall(DataFlow::Node call, DataFlow::Node recv, string m) {
-  isInterfaceCallReceiver(call, recv, m) and isConcreteValue(recv)
+  isInterfaceCallReceiver(call, recv, _, m) and isConcreteValue(recv)
 }
 
 /**

--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -64,6 +64,21 @@ class Node extends TNode {
     endcolumn = 0
   }
 
+  /** Gets the file in which this node appears. */
+  File getFile() { hasLocationInfo(result.getAbsolutePath(), _, _, _, _) }
+
+  /** Gets the start line of the location of this node. */
+  int getStartLine() { hasLocationInfo(_, result, _, _, _) }
+
+  /** Gets the start column of the location of this node. */
+  int getStartColumn() { hasLocationInfo(_, _, result, _, _) }
+
+  /** Gets the end line of the location of this node. */
+  int getEndLine() { hasLocationInfo(_, _, _, result, _) }
+
+  /** Gets the end column of the location of this node. */
+  int getEndColumn() { hasLocationInfo(_, _, _, _, result) }
+
   /**
    * Gets an upper bound on the type of this node.
    */

--- a/ql/test/library-tests/semmle/go/dataflow/CallGraph/getACallee.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/CallGraph/getACallee.expected
@@ -3,3 +3,4 @@ spuriousCallee
 | main.go:44:3:44:7 | call to m | main.go:17:1:17:17 | function declaration |
 | main.go:44:3:44:7 | call to m | main.go:21:1:21:20 | function declaration |
 | main.go:56:2:56:6 | call to m | main.go:21:1:21:20 | function declaration |
+| test.go:42:2:42:13 | call to Write | test.go:36:1:39:1 | function declaration |

--- a/ql/test/library-tests/semmle/go/dataflow/CallGraph/test.go
+++ b/ql/test/library-tests/semmle/go/dataflow/CallGraph/test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"hash"
+	"io"
+)
+
+type Resetter struct{}
+
+func (_ Resetter) Reset() {} // name: Resetter.Reset
+
+type MockHash struct {
+	Resetter
+}
+
+func (_ MockHash) Write(p []byte) (n int, err error) { // name: MockHash.Write
+	fmt.Println("MockHash.Write")
+	return 0, nil
+}
+
+func (_ MockHash) Sum(b []byte) []byte {
+	return nil
+}
+
+func (_ MockHash) Size() int {
+	return 0
+}
+
+func (_ MockHash) BlockSize() int {
+	return 0
+}
+
+type MockWriter struct{}
+
+func (_ MockWriter) Write(p []byte) (n int, err error) { // name: MockWriter.Write
+	fmt.Println("MockWriter.Write")
+	return 0, nil
+}
+
+func test5(h hash.Hash, w io.Writer) { // name: test5
+	h.Write(nil) // callee: MockHash.Write
+	w.Write(nil) // callee: MockWriter.Write callee: MockHash.Write
+	h.Reset()    // callee: Resetter.Reset
+}
+
+func test6(h MockHash, w MockWriter) {
+	test5(h, w) // callee: test5
+}


### PR DESCRIPTION
When faced with a call `x.m()` where the type of `x` is some interface `I`, `getACallee()` does the conservative thing and resolves the call to all overriding definitions of `m`.

For the data-flow analysis, we try a bit harder: the `viableCallee` predicate checks whether it can by local reasoning determine a concrete (non-interface) type for `x`, or perhaps a set of such types, and then resolves `m` on those.

This PR adds an orthogonal refinement: even if we can't determine a concrete type for `x`, we can still require that the overriding definition of `m` we select must belong to a type that implements `I`. This isn't a trivial condition, since `I` might inherit `m` from another interface `J`, and this way we might be able to exclude some definitions of `m` in types that implement `J` but not `I`.

[Evaluation](https://github.com/max-schaefer/dist-compare-reports/blob/master/go/refine-virtual-dispatch/report.md) (internal link) shows no performance change and one alert change. The alert in question had 56 paths; I didn't check all of them, but the ones I did inspect all had a spurious call step of the kind described above in them, so I'm inclined to believe that this was a false positive that is now fixed.

It also fixes a wrong call step observed by @owen-mc, but it does not, by itself, fix the false positive that gave rise to. There is another imprecision involved, which I will fix in a separate PR.

Commit-by-commit review is encouraged. The first commit is not logically related to the rest of the PR, but it's useful for debugging and I've wanted to add it for a while.