### PR TITLE
Draft: check for missing error checks on functions that return a (pointer, error) pair

### DIFF
--- a/ql/src/experimental/MissingErrorCheck.ql
+++ b/ql/src/experimental/MissingErrorCheck.ql
@@ -1,0 +1,95 @@
+import go
+
+class FatalFunction extends NoreturnAnnotatedFunction {
+  FatalFunction() { getName() = ["Fatal", "Fatalf"] }
+}
+
+class OsExitFunction extends NoreturnAnnotatedFunction {
+  OsExitFunction() { hasQualifiedName("os", "Exit") }
+}
+
+class GinkgoFailFunction extends NoreturnAnnotatedFunction {
+  GinkgoFailFunction() { hasQualifiedName("github.com/onsi/ginkgo", "Fail") }
+}
+
+abstract class NoreturnAnnotatedFunction extends Function {
+  override predicate mayReturnNormally() { none() }
+}
+
+class UserDefinedFunction extends DeclaredFunction {
+  UserDefinedFunction() { not this instanceof NoreturnAnnotatedFunction and exists(getBody()) }
+
+  override predicate mayReturnNormally() { ControlFlow::mayReturnNormally(getFuncDecl()) }
+}
+
+/**
+ * Matches if `node` is a reference to the `nil` builtin constant.
+ */
+predicate isNil(DataFlow::Node node) {
+  exists(Expr nilRef | nilRef = Builtin::nil().getAReference() | node.asExpr() = nilRef)
+}
+
+/**
+ * Holds if `n1` and `n2` are both in a reachable basic block, and `n1` dominates `n2`.
+ */
+predicate dominates(ControlFlow::Node n1, ControlFlow::Node n2) {
+  exists(BasicBlock bb, int i, int j |
+    bb = n1.getBasicBlock() and
+    bb = n2.getBasicBlock() and
+    bb.getNode(i) = n1 and
+    bb.getNode(j) = n2 and
+    i <= j
+  )
+  or
+  n1.getBasicBlock().(ReachableBasicBlock).strictlyDominates(n2.getBasicBlock())
+}
+
+/**
+ * Matches if `value` is certainly consumed as the parameter to some function call before `useSite`.
+ */
+predicate valueConsumedByFunctionBefore(DataFlow::SsaNode value, DataFlow::Node useSite) {
+  exists(DataFlow::CallNode checkCall |
+    value.getAUse() = checkCall.getAnArgument() and
+    dominates(checkCall.asInstruction(), useSite.asInstruction())
+  )
+}
+
+/**
+ * Matches if any of the return-sites in `call` may return a non-nil pointer alongside an error value
+ */
+predicate calleeMayReturnNonNilWithError(DataFlow::CallNode call) {
+  exists(
+    FuncDef callee, IR::ReturnInstruction ret, DataFlow::Node ptrReturn, DataFlow::Node errReturn
+  |
+    callee = call.getACallee() and
+    callee = ret.getRoot() and
+    ptrReturn = DataFlow::instructionNode(ret.getResult(0)) and
+    errReturn = DataFlow::instructionNode(ret.getResult(1)) and
+    not isNil(ptrReturn) and
+    not isNil(errReturn)
+  )
+}
+
+from
+  DataFlow::SsaNode ptr, DataFlow::SsaNode err, DataFlow::CallNode call,
+  DataFlow::PointerDereferenceNode deref
+where
+  ptr.getAPredecessor() = call.getResult(0) and
+  err.getAPredecessor() = call.getResult(1) and
+  exists(Type t | t = ptr.getType().getUnderlyingType() |
+    t instanceof PointerType or t instanceof SliceType or t instanceof InterfaceType
+  ) and
+  err.getType().getEntity() = Builtin::error() and
+  deref.getOperand() = ptr.getAUse() and
+  not calleeMayReturnNonNilWithError(call) and
+  not exists(ControlFlow::ConditionGuardNode cgn |
+    cgn.ensuresEq(err.getAUse(), Builtin::nil().getARead()) or
+    cgn.ensuresNeq(ptr.getAUse(), Builtin::nil().getARead())
+  |
+    cgn.dominates(deref.getBasicBlock())
+  ) and
+  not valueConsumedByFunctionBefore(err, deref) and
+  not valueConsumedByFunctionBefore(ptr, deref)
+select deref.getOperand(),
+  ptr.getSourceVariable().getName() + " may be nil here, because $@ has not been checked.", err,
+  err.getSourceVariable().getName()

--- a/ql/src/experimental/MissingErrorCheckTake2.ql
+++ b/ql/src/experimental/MissingErrorCheckTake2.ql
@@ -1,0 +1,106 @@
+/**
+ * @kind problem
+ */
+
+import go
+
+class SwitchNodeOverride extends ControlFlow::Node {
+  override ControlFlow::Node getASuccessor() {
+    result = super.getASuccessor() and
+    forall(ExpressionSwitchStmt s | this.isFirstNodeOf(s) |
+      exists(s.getExpr()) or
+      s.getNumCase() = 0 or
+      result.isFirstNodeOf(s.getACase().getAnExpr()) or
+      result.isFirstNodeOf(s.getACase().getStmt(0))
+    )
+  }
+}
+
+/**
+ * Matches if `node` is a reference to the `nil` builtin constant.
+ */
+predicate isNil(DataFlow::Node node) {
+  exists(Expr nilRef | nilRef = Builtin::nil().getAReference() | node.asExpr() = nilRef)
+}
+
+/**
+ * Matches if any of the return-sites in `call` may return a nil pointer alongside an error value.
+ *
+ * This is both an over- and under-estimate: over in that opaque functions may use this convention,
+ * and under in that functions with bodies are only recognised if they use a literal `nil` for the
+ * pointer return value at some return site.
+ */
+predicate calleeMayReturnNilWithError(DataFlow::CallNode call) {
+  not exists(call.getACallee())
+  or
+  exists(FuncDef callee | callee = call.getACallee() |
+    not exists(callee.getBody())
+    or
+    exists(IR::ReturnInstruction ret, DataFlow::Node ptrReturn, DataFlow::Node errReturn |
+      callee = call.getACallee() and
+      callee = ret.getRoot() and
+      ptrReturn = DataFlow::instructionNode(ret.getResult(0)) and
+      errReturn = DataFlow::instructionNode(ret.getResult(1)) and
+      isNil(ptrReturn) and
+      not isNil(errReturn)
+    )
+  )
+}
+
+predicate isCallReturningPointerAndError(
+  DataFlow::CallNode call, DataFlow::SsaNode ptr, DataFlow::SsaNode err
+) {
+  calleeMayReturnNilWithError(call) and
+  exists(Type t | t = ptr.getType().getUnderlyingType() |
+    t instanceof PointerType or t instanceof SliceType or t instanceof InterfaceType
+  ) and
+  err.getType().getEntity() = Builtin::error()
+}
+
+predicate checksValue(IR::Instruction instruction, DataFlow::SsaNode value) {
+  exists(DataFlow::InstructionNode instNode | instNode.asInstruction() = instruction |
+    instNode.(DataFlow::CallNode).getAnArgument() = value.getAUse() or
+    instNode.(DataFlow::EqualityTestNode).getAnOperand() = value.getAUse()
+  )
+  or
+  value.getAUse().asInstruction() = instruction and
+  (
+    exists(ExpressionSwitchStmt s | instruction.(IR::EvalInstruction).getExpr() = s.getExpr())
+    or
+    // This case accounts for both a type-switch or cast used to check `value`
+    exists(TypeAssertExpr e | instruction.(IR::EvalInstruction).getExpr() = e.getExpr())
+  )
+}
+
+predicate returnUncheckedAtNode(
+  DataFlow::CallNode call, ControlFlow::Node node, DataFlow::SsaNode ptr, DataFlow::SsaNode err
+) {
+  ptr.getAPredecessor() = call.getResult(0) and
+  err.getAPredecessor() = call.getResult(1) and
+  (
+    isCallReturningPointerAndError(call, ptr, err) and call.asInstruction() = node
+    or
+    returnUncheckedAtNode(call, node.getAPredecessor(), ptr, err) and
+    not exists(DataFlow::SsaNode checked | DataFlow::localFlow(ptr, checked) |
+      checksValue(node, checked)
+    ) and
+    not exists(DataFlow::SsaNode checked | DataFlow::localFlow(err, checked) |
+      checksValue(node, checked)
+    )
+    // Alternate more-generous implementation, considering any use to be a check,
+    // including e.g. copying into a parameter or other variable:
+    //not exists(DataFlow::InstructionNode i | i = ptr.getAUse() and i.asInstruction() = node) and
+    //not exists(DataFlow::InstructionNode i | i = err.getAUse() and i.asInstruction() = node))
+  )
+}
+
+from
+  DataFlow::CallNode call, DataFlow::SsaNode ptr, DataFlow::SsaNode err,
+  DataFlow::PointerDereferenceNode deref, ControlFlow::Node derefNodePred
+where
+  deref.getOperand().asInstruction().getAPredecessor() = derefNodePred and
+  returnUncheckedAtNode(call, derefNodePred, ptr, err) and
+  deref.getOperand() = ptr.getAUse()
+select deref.getOperand(),
+  ptr.getSourceVariable().getName() + " may be nil here, because $@ may not been checked.", err,
+  err.getSourceVariable().getName()

--- a/ql/src/semmle/go/Scopes.qll
+++ b/ql/src/semmle/go/Scopes.qll
@@ -350,6 +350,8 @@ class Function extends ValueEntity, @functionobject {
   /** Holds if this function has no observable side effects. */
   predicate mayHaveSideEffects() { none() }
 
+  predicate mayReturnNormally() { any() }
+
   /**
    * Holds if calling this function may cause a runtime panic.
    *
@@ -516,6 +518,8 @@ class DeclaredFunction extends Function, DeclaredEntity, @declfunctionobject {
 /** A built-in function. */
 class BuiltinFunction extends Function, BuiltinEntity, @builtinfunctionobject {
   override predicate mayHaveSideEffects() { builtinFunction(getName(), false, _, _) }
+
+  override predicate mayReturnNormally() { builtinFunction(getName(), _, _, false) }
 
   override predicate mayPanic() { builtinFunction(getName(), _, true, _) }
 

--- a/ql/src/semmle/go/controlflow/ControlFlowGraph.qll
+++ b/ql/src/semmle/go/controlflow/ControlFlowGraph.qll
@@ -259,6 +259,8 @@ module ControlFlow {
    * Gets the exit node of function or file `root`.
    */
   Node exitNode(Root root) { result = MkExitNode(root) }
+
+  predicate mayReturnNormally(FuncDecl f) { CFG::mayReturnNormally(f.getBody()) }
 }
 
 class Write = ControlFlow::WriteNode;

--- a/ql/src/semmle/go/controlflow/ControlFlowGraphImpl.qll
+++ b/ql/src/semmle/go/controlflow/ControlFlowGraphImpl.qll
@@ -918,7 +918,7 @@ module CFG {
     }
 
     override Completion getCompletion() {
-      not getTarget().mustPanic() and
+      (not exists(getTarget()) or getTarget().mayReturnNormally()) and
       result = Done()
       or
       (not exists(getTarget()) or getTarget().mayPanic()) and
@@ -1922,6 +1922,11 @@ module CFG {
       or
       result = succ(notDeferSucc+(nd))
     )
+  }
+
+  cached
+  predicate mayReturnNormally(ControlFlowTree root) {
+    exists(ControlFlow::Node last, Completion cmpl | lastNode(root, last, cmpl) and cmpl != Panic())
   }
 
   /** Gets a successor of `nd`, that is, a node that is executed after `nd`. */


### PR DESCRIPTION
Main outstanding snag: phrasing the check for user-defined die functions in terms of mustPanic resulted in a query that would populate a callsite normal-return edge only if not-must-panic(callee). The logic amounts to the same thing, but looking for absence rather than presence led to a non-monotonic recursion complaint.

Rephrasing the whole thing in terms of mayReturnNormally, similar to positively marking normal-return edges across the interprocedural callgraph until nothing more can be marked and then only at the very top checking the negative, worked as I hoped.

This draft addresses issues:

* Always returns non-nil
* User-defined noreturn function

It doesn't yet address:

* User-defined error-test function (`if isError(err) { ... }`)
* User-defined require-no-error function (`requireNoError(err); f(*ptr)`)
* Is-nil test within a conjunction of conditions (`e == nil && f() == g()`)