### PR TITLE
Extractor: give the go.mod comment groups a source location

### DIFF
--- a/extractor/gomodextractor.go
+++ b/extractor/gomodextractor.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/github/codeql-go/extractor/dbscheme"
 	"github.com/github/codeql-go/extractor/srcarchive"
@@ -155,9 +156,10 @@ func extractGoModComments(tw *trap.Writer, expr modfile.Expr, exprlbl trap.Label
 	var first bool = true
 	idx := 0
 	for _, comment := range allComments {
-		extractGoModComment(tw, comment, grouplbl, idx)
+		commentToken := strings.TrimSuffix(comment.Token, "\r")
+		extractGoModComment(tw, comment, commentToken, grouplbl, idx)
 		idx++
-		commentEndCol := comment.Start.LineRune + (len(comment.Token) - 1)
+		commentEndCol := comment.Start.LineRune + (len(commentToken) - 1)
 		if first {
 			startLine, startCol, endLine, endCol = comment.Start.Line, comment.Start.LineRune, comment.Start.Line, commentEndCol
 			first = false
@@ -170,9 +172,11 @@ func extractGoModComments(tw *trap.Writer, expr modfile.Expr, exprlbl trap.Label
 	extractLocation(tw, grouplbl, startLine, startCol, endLine, endCol)
 }
 
-func extractGoModComment(tw *trap.Writer, comment modfile.Comment, grouplbl trap.Label, idx int) {
-	lbl := tw.Labeler.LocalID(comment)
-	dbscheme.CommentsTable.Emit(tw, lbl, dbscheme.SlashSlashComment.Index(), grouplbl, idx, comment.Token)
 
-	extractLocation(tw, lbl, comment.Start.Line, comment.Start.LineRune, comment.Start.Line, comment.Start.LineRune+len(comment.Token))
+
+func extractGoModComment(tw *trap.Writer, comment modfile.Comment, commentToken string, grouplbl trap.Label, idx int) {
+	lbl := tw.Labeler.LocalID(comment)
+	dbscheme.CommentsTable.Emit(tw, lbl, dbscheme.SlashSlashComment.Index(), grouplbl, idx, commentToken)
+
+	extractLocation(tw, lbl, comment.Start.Line, comment.Start.LineRune, comment.Start.Line, comment.Start.LineRune + (len(commentToken) - 1))
 }

--- a/extractor/gomodextractor.go
+++ b/extractor/gomodextractor.go
@@ -100,27 +100,74 @@ type GoModExprCommentWrapper struct {
 	expr modfile.Expr
 }
 
+func minInt(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt(a int, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func lexMin(a1 int, a2 int, b1 int, b2 int) (int, int) {
+	if a1 < b1 {
+		return a1, a2
+	} else if a1 > b1 {
+		return b1, b2
+	} else {
+		return a1, minInt(b1, b2)
+	}
+}
+
+func lexMax(a1 int, a2 int, b1 int, b2 int) (int, int) {
+	if a1 < b1 {
+		return b1, b2
+	} else if a1 > b1 {
+		return a1, a2
+	} else {
+		return a1, maxInt(b1, b2)
+	}
+}
+
 func extractGoModComments(tw *trap.Writer, expr modfile.Expr, exprlbl trap.Label) {
+	comments := expr.Comment()
+
+	if len(comments.Before) == 0 && len(comments.Suffix) == 0 && len(comments.After) == 0 {
+		return
+	}
+
 	// extract a pseudo `@commentgroup` for each expr that contains their associated comments
 	grouplbl := tw.Labeler.LocalID(GoModExprCommentWrapper{expr})
 	dbscheme.CommentGroupsTable.Emit(tw, grouplbl)
 	dbscheme.DocCommentsTable.Emit(tw, exprlbl, grouplbl)
 
-	comments := expr.Comment()
+	var allComments []modfile.Comment
+	allComments = append(allComments, comments.Before...)
+	allComments = append(allComments, comments.Suffix...)
+	allComments = append(allComments, comments.After...)
 
+	var startLine, startCol, endLine, endCol int = 0, 0, 0, 0
+	var first bool = true
 	idx := 0
-	for _, comment := range comments.Before {
+	for _, comment := range allComments {
 		extractGoModComment(tw, comment, grouplbl, idx)
 		idx++
+		commentEndCol := comment.Start.LineRune + (len(comment.Token) - 1)
+		if first {
+			startLine, startCol, endLine, endCol = comment.Start.Line, comment.Start.LineRune, comment.Start.Line, commentEndCol
+			first = false
+		} else {
+			startLine, startCol = lexMin(comment.Start.Line, comment.Start.LineRune, startLine, startCol)
+			endLine, endCol = lexMax(comment.Start.Line, commentEndCol, endLine, endCol)
+		}
 	}
-	for _, comment := range comments.Suffix {
-		extractGoModComment(tw, comment, grouplbl, idx)
-		idx++
-	}
-	for _, comment := range comments.After {
-		extractGoModComment(tw, comment, grouplbl, idx)
-		idx++
-	}
+
+	extractLocation(tw, grouplbl, startLine, startCol, endLine, endCol)
 }
 
 func extractGoModComment(tw *trap.Writer, comment modfile.Comment, grouplbl trap.Label, idx int) {

--- a/ql/test/extractor-tests/go-mod-comments/commentGroups.expected
+++ b/ql/test/extractor-tests/go-mod-comments/commentGroups.expected
@@ -1,0 +1,3 @@
+| go.mod:1:1:2:32 | comment group |
+| go.mod:3:1:3:11 | comment group |
+| go.mod:5:1:5:13 | comment group |

--- a/ql/test/extractor-tests/go-mod-comments/commentGroups.ql
+++ b/ql/test/extractor-tests/go-mod-comments/commentGroups.ql
@@ -1,0 +1,4 @@
+import go
+
+from CommentGroup cg
+select cg

--- a/ql/test/extractor-tests/go-mod-comments/comments.expected
+++ b/ql/test/extractor-tests/go-mod-comments/comments.expected
@@ -1,0 +1,4 @@
+| go.mod:1:1:1:11 | comment | // atthetop |
+| go.mod:2:21:2:32 | comment | // endofline |
+| go.mod:3:1:3:11 | comment | // onitsown |
+| go.mod:5:1:5:13 | comment | // afterwards |

--- a/ql/test/extractor-tests/go-mod-comments/comments.ql
+++ b/ql/test/extractor-tests/go-mod-comments/comments.ql
@@ -1,0 +1,4 @@
+import go
+
+from Comment c
+select c, c.getText()

--- a/ql/test/extractor-tests/go-mod-comments/go.mod
+++ b/ql/test/extractor-tests/go-mod-comments/go.mod
@@ -1,0 +1,6 @@
+// atthetop
+module smowton/test // endofline
+// onitsown
+go 1.14
+// afterwards
+


### PR DESCRIPTION
The comment group is now omitted entirely if empty, and otherwise delimits the range of the comments ascribed to this group.

Pre-emptive reviewer response: yes, really, Go's `math` package only provides `Min` and `Max` for float types, so you either have to cast back and forth, take a dependency such as `github.com/pkg/math` or write your own `IntMin` and `IntMax`.