### PR TITLE
Make receiver a separate case in TFunctionOutput

### DIFF
--- a/ql/src/semmle/go/dataflow/FunctionInputsAndOutputs.qll
+++ b/ql/src/semmle/go/dataflow/FunctionInputsAndOutputs.qll
@@ -222,7 +222,7 @@ private class OutResult extends FunctionOutput, TOutResult {
   }
 }
 
-/** A result position of a function, viewed as an output. */
+/** The receiver of a function, viewed as an output. */
 private class OutReceiver extends FunctionOutput, TOutReceiver {
   override predicate isReceiver() { any() }
 
@@ -242,13 +242,13 @@ private class OutReceiver extends FunctionOutput, TOutReceiver {
   override string toString() { result = "receiver" }
 }
 
-/** A result position of a function, viewed as an output. */
+/** A parameter of a function, viewed as an output. */
 private class OutParameter extends FunctionOutput, TOutParameter {
   int index;
 
   OutParameter() { this = TOutParameter(index) }
 
-  override predicate isParameter(int i) { i = index and i >= 0 }
+  override predicate isParameter(int i) { i = index }
 
   override DataFlow::Node getEntryNode(FuncDef f) {
     // there is no generic way of assigning to a parameter; operations that taint a parameter

--- a/ql/src/semmle/go/dataflow/FunctionInputsAndOutputs.qll
+++ b/ql/src/semmle/go/dataflow/FunctionInputsAndOutputs.qll
@@ -139,13 +139,8 @@ private newtype TFunctionOutput =
     // one among several results
     exists(SignatureType s | exists(s.getResultType(index)))
   } or
-  TOutParameter(int index) {
-    // the receiver parameter
-    index = -1
-    or
-    // another parameter
-    exists(SignatureType s | exists(s.getParameterType(index)))
-  }
+  TOutReceiver() or
+  TOutParameter(int index) { exists(SignatureType s | exists(s.getParameterType(index))) }
 
 /**
  * An abstract representation of an output of a function, which is one of its results
@@ -228,12 +223,30 @@ private class OutResult extends FunctionOutput, TOutResult {
 }
 
 /** A result position of a function, viewed as an output. */
+private class OutReceiver extends FunctionOutput, TOutReceiver {
+  override predicate isReceiver() { any() }
+
+  override DataFlow::Node getEntryNode(FuncDef f) {
+    // there is no generic way of assigning to a receiver; operations that taint a receiver
+    // have to be handled on a case-by-case basis
+    none()
+  }
+
+  override DataFlow::Node getExitNode(DataFlow::CallNode c) {
+    exists(DataFlow::Node arg |
+      arg = getArgument(c, -1) and
+      result.(DataFlow::PostUpdateNode).getPreUpdateNode() = arg
+    )
+  }
+
+  override string toString() { result = "receiver" }
+}
+
+/** A result position of a function, viewed as an output. */
 private class OutParameter extends FunctionOutput, TOutParameter {
   int index;
 
   OutParameter() { this = TOutParameter(index) }
-
-  override predicate isReceiver() { index = -1 }
 
   override predicate isParameter(int i) { i = index and i >= 0 }
 
@@ -250,9 +263,5 @@ private class OutParameter extends FunctionOutput, TOutParameter {
     )
   }
 
-  override string toString() {
-    index = -1 and result = "receiver"
-    or
-    index >= 0 and result = "parameter " + index
-  }
+  override string toString() { result = "parameter " + index }
 }


### PR DESCRIPTION
This is for consistency with TFunctionInput, which already does this