### PR TITLE
Fix frontend errors

### DIFF
--- a/ql/test/experimental/CWE-322/vendor/golang.org/x/crypto/ssh/stub.go
+++ b/ql/test/experimental/CWE-322/vendor/golang.org/x/crypto/ssh/stub.go
@@ -9,6 +9,7 @@ package ssh
 
 import (
 	io "io"
+	net "net"
 	time "time"
 )
 
@@ -39,7 +40,7 @@ type Config struct {
 
 func (_ *Config) SetDefaults() {}
 
-type HostKeyCallback func(string, Addr, PublicKey) error
+type HostKeyCallback func(string, net.Addr, PublicKey) error
 
 func InsecureIgnoreHostKey() HostKeyCallback {
 	return nil

--- a/ql/test/library-tests/semmle/go/Types/SignatureType_getNumResult.expected
+++ b/ql/test/library-tests/semmle/go/Types/SignatureType_getNumResult.expected
@@ -1,4 +1,4 @@
-| depth.go:22:1:25:1 | function declaration | 1 |
+| depth.go:22:1:25:1 | function declaration | 0 |
 | main.go:5:1:5:30 | function declaration | 0 |
 | main.go:7:1:9:1 | function declaration | 2 |
 | main.go:11:1:11:14 | function declaration | 0 |

--- a/ql/test/library-tests/semmle/go/Types/depth.go
+++ b/ql/test/library-tests/semmle/go/Types/depth.go
@@ -19,7 +19,7 @@ type d struct {
 	f string
 }
 
-func test2() int {
+func test2() {
 	x := a{b{0}, c{d{"hi"}}}
 	fmt.Printf("%v", x.f) // prints `0`, not `"hi"`
 }


### PR DESCRIPTION
Found while testing the upcoming support for consistency queries in `codelq test run` :tada:

The second commit is due to a bug in depstubber (https://github.com/github/depstubber/issues/5), which I have worked around manually for now.