### PR TITLE
Remove `@precision` from experimental query.

### DIFF
--- a/ql/src/experimental/CWE-322/InsecureHostKeyCallback.ql
+++ b/ql/src/experimental/CWE-322/InsecureHostKeyCallback.ql
@@ -3,7 +3,6 @@
  * @description Detects insecure SSL client configurations with an implementation of the `HostKeyCallback` that accepts all host keys.
  * @kind path-problem
  * @problem.severity error
- * @precision very-high
  * @id go/insecure-hostkeycallback
  * @tags security
  */


### PR DESCRIPTION
We'll add it back when we take it out of experimental status.