### PR TITLE
taint-tracking: String() must return a string type

### DIFF
--- a/ql/src/semmle/go/frameworks/Stdlib.qll
+++ b/ql/src/semmle/go/frameworks/Stdlib.qll
@@ -6,7 +6,11 @@ import go
 
 /** A `String()` method. */
 class StringMethod extends TaintTracking::FunctionModel, Method {
-  StringMethod() { getName() = "String" and getNumParameter() = 0 }
+  StringMethod() {
+    getName() = "String" and
+    getNumParameter() = 0 and
+    getResultType(0) = Builtin::string_().getType()
+  }
 
   override predicate hasTaintFlow(FunctionInput inp, FunctionOutput outp) {
     inp.isReceiver() and outp.isResult()


### PR DESCRIPTION
Make sure that the taint-tracking class for the `String()` method checks that the result type is a string.

