### PR TITLE
Extractor: assign unique indices to comment-groups in go.mod files

### DIFF
--- a/ql/test/extractor-tests/go-mod-comments/commentGroups.expected
+++ b/ql/test/extractor-tests/go-mod-comments/commentGroups.expected
@@ -1,3 +1,3 @@
-| go.mod:1:1:2:32 | comment group |
-| go.mod:3:1:3:11 | comment group |
-| go.mod:5:1:5:13 | comment group |
+| go.mod:0:0:0:0 | go.mod | 0 | go.mod:1:1:2:32 | comment group |
+| go.mod:0:0:0:0 | go.mod | 1 | go.mod:3:1:3:11 | comment group |
+| go.mod:0:0:0:0 | go.mod | 2 | go.mod:5:1:5:13 | comment group |

--- a/ql/test/extractor-tests/go-mod-comments/commentGroups.ql
+++ b/ql/test/extractor-tests/go-mod-comments/commentGroups.ql
@@ -1,4 +1,5 @@
 import go
 
-from CommentGroup cg
-select cg
+from File f, CommentGroup cg, int idx
+where cg = f.getCommentGroup(idx)
+select f, idx, cg


### PR DESCRIPTION
The schema requires that (parent, index) is a key.