### PR TITLE
Add the printAst contextual query

### DIFF
--- a/ql/src/ideContextual.qll
+++ b/ql/src/ideContextual.qll
@@ -1,0 +1,9 @@
+/**
+ * Provides classes and predicates related to contextual queries
+ * in the code viewer.
+ */
+
+import go
+
+cached
+File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }

--- a/ql/src/localDefinitions.ql
+++ b/ql/src/localDefinitions.ql
@@ -8,11 +8,9 @@
  */
 
 import go
+import ideContextual
 
 external string selectedSourceFile();
-
-cached
-File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }
 
 from Ident def, Ident use, Entity e
 where use.uses(e) and def.declares(e) and use.getFile() = getEncodedFile(selectedSourceFile())

--- a/ql/src/localReferences.ql
+++ b/ql/src/localReferences.ql
@@ -8,11 +8,9 @@
  */
 
 import go
+import ideContextual
 
 external string selectedSourceFile();
-
-cached
-File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }
 
 from Ident def, Ident use, Entity e
 where use.uses(e) and def.declares(e) and def.getFile() = getEncodedFile(selectedSourceFile())

--- a/ql/src/printAst.ql
+++ b/ql/src/printAst.ql
@@ -1,0 +1,26 @@
+/**
+ * @name Print AST
+ * @description Outputs a representation of a file's Abstract Syntax Tree. This
+ *              query is used by the VS Code extension.
+ * @id go/print-ast
+ * @kind graph
+ * @tags ide-contextual-queries/print-ast
+ */
+
+import go
+import semmle.go.PrintAst
+import ideContextual
+
+/**
+ * The source file to generate an AST from.
+ */
+external string selectedSourceFile();
+
+/**
+ * Hook to customize the functions printed by this query.
+ */
+class Cfg extends PrintAstConfiguration {
+  override predicate shouldPrintFunction(FuncDef func) {
+    func.getFile() = getEncodedFile(selectedSourceFile())
+  }
+}


### PR DESCRIPTION
This is similar to the cpp query for printing the AST in the context of VS Code.

This PR also includes a small refactoring to extract the `getEncodedFile` predicate to a new `qll` file.

Fixes #260.