### PR TITLE
PrintAst: order parameter and result declarations

### DIFF
--- a/ql/src/semmle/go/AST.qll
+++ b/ql/src/semmle/go/AST.qll
@@ -35,6 +35,40 @@ class AstNode extends @node, Locatable {
    */
   int getNumChild() { result = count(getAChild()) }
 
+  /**
+   * Gets a child with the given index and of the given kind, if one exists.
+   * Note that a given parent can have multiple children with the same index but differing kind.
+   */
+  private AstNode getChildOfKind(string kind, int i) {
+    kind = "expr" and result = this.(ExprParent).getChildExpr(i)
+    or
+    kind = "gomodexpr" and result = this.(GoModExprParent).getChildGoModExpr(i)
+    or
+    kind = "stmt" and result = this.(StmtParent).getChildStmt(i)
+    or
+    kind = "decl" and result = this.(DeclParent).getDecl(i)
+    or
+    kind = "spec" and result = this.(GenDecl).getSpec(i)
+    or
+    kind = "field" and result = this.(FieldParent).getField(i)
+    or
+    kind = "commentgroup" and result = this.(File).getCommentGroup(i)
+    or
+    kind = "comment" and result = this.(CommentGroup).getComment(i)
+  }
+
+  /**
+   * Get an AstNode child, ordered by child kind and then by index.
+   */
+  AstNode getUniquelyNumberedChild(int index) {
+    result =
+      rank[index + 1](AstNode child, string kind, int i |
+        child = getChildOfKind(kind, i)
+      |
+        child order by kind, i
+      )
+  }
+
   /** Gets the parent node of this AST node, if any. */
   AstNode getParent() { this = result.getAChild() }
 

--- a/ql/src/semmle/go/Expr.qll
+++ b/ql/src/semmle/go/Expr.qll
@@ -884,6 +884,13 @@ class FuncTypeExpr extends @functypeexpr, TypeExpr, ScopeNode, FieldParent {
   override string toString() { result = "function type" }
 
   override string getAPrimaryQlClass() { result = "FuncTypeExpr" }
+
+  /** Gets the `i`th child of this node, parameters first followed by results. */
+  override AstNode getUniquelyNumberedChild(int i) {
+    if i < getNumParameter()
+    then result = getParameterDecl(i)
+    else result = getResultDecl(i - getNumParameter())
+  }
 }
 
 /**

--- a/ql/src/semmle/go/PrintAst.qll
+++ b/ql/src/semmle/go/PrintAst.qll
@@ -101,40 +101,6 @@ private string qlClass(AstNode el) {
 }
 
 /**
- * Gets a child with the given index and of the given kind, if one exists.
- * Note that a given parent can have multiple children with the same index but differing kind.
- */
-private AstNode getChildOfKind(AstNode parent, string kind, int i) {
-  kind = "expr" and result = parent.(ExprParent).getChildExpr(i)
-  or
-  kind = "gomodexpr" and result = parent.(GoModExprParent).getChildGoModExpr(i)
-  or
-  kind = "stmt" and result = parent.(StmtParent).getChildStmt(i)
-  or
-  kind = "decl" and result = parent.(DeclParent).getDecl(i)
-  or
-  kind = "spec" and result = parent.(GenDecl).getSpec(i)
-  or
-  kind = "field" and result = parent.(FieldParent).getField(i)
-  or
-  kind = "commentgroup" and result = parent.(File).getCommentGroup(i)
-  or
-  kind = "comment" and result = parent.(CommentGroup).getComment(i)
-}
-
-/**
- * Get an AstNode child, ordered by child kind and then by index
- */
-private AstNode getUniquelyNumberedChild(AstNode node, int index) {
-  result =
-    rank[index + 1](AstNode child, string kind, int i |
-      child = getChildOfKind(node, kind, i)
-    |
-      child order by kind, i
-    )
-}
-
-/**
  * A graph node representing a real AST node.
  */
 class BaseAstNode extends PrintAstNode, TAstNode {
@@ -147,7 +113,7 @@ class BaseAstNode extends PrintAstNode, TAstNode {
     // nodes have multiple different types of child (e.g. a File has a
     // child expression, the package name, and child declarations whose
     // indices may clash), so we renumber them:
-    result = TAstNode(getUniquelyNumberedChild(ast, childIndex))
+    result = TAstNode(ast.getUniquelyNumberedChild(childIndex))
   }
 
   override string toString() { result = qlClass(ast) + ast }

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
@@ -262,13 +262,13 @@ input.go:
 #   65|     0: [FunctionName, Ident] test7
 #   65|         Type = func(int) int
 #   65|     1: [FuncTypeExpr] function type
-#   65|       0: [ResultVariableDecl] result variable declaration
-#   65|         0: [Ident, TypeName] int
-#   65|             Type = int
-#   65|       1: [ParameterDecl] parameter declaration
+#   65|       0: [ParameterDecl] parameter declaration
 #   65|         0: [Ident, TypeName] int
 #   65|             Type = int
 #   65|         1: [Ident, VariableName] x
+#   65|             Type = int
+#   65|       1: [ResultVariableDecl] result variable declaration
+#   65|         0: [Ident, TypeName] int
 #   65|             Type = int
 #   65|     2: [BlockStmt] block statement
 #   66|       0: [IfStmt] if statement


### PR DESCRIPTION
This adds support for generally overriding the default AstNode child ordering, and uses it to sort parameter and result declarations in the context of a FuncTypeExpr in left-to-right textual order.