### PR TITLE
PrintAst: improve support for restricting subsets of the AST to print

### DIFF
--- a/ql/src/printAst.ql
+++ b/ql/src/printAst.ql
@@ -20,7 +20,7 @@ external string selectedSourceFile();
  * Hook to customize the functions printed by this query.
  */
 class Cfg extends PrintAstConfiguration {
-  override predicate shouldPrintFunction(FuncDef func) { shouldPrintFile(func.getFile()) }
+  override predicate shouldPrintFunction(FuncDecl func) { shouldPrintFile(func.getFile()) }
 
   override predicate shouldPrintFile(File file) { file = getEncodedFile(selectedSourceFile()) }
 

--- a/ql/src/printAst.ql
+++ b/ql/src/printAst.ql
@@ -20,7 +20,9 @@ external string selectedSourceFile();
  * Hook to customize the functions printed by this query.
  */
 class Cfg extends PrintAstConfiguration {
-  override predicate shouldPrintFunction(FuncDef func) {
-    func.getFile() = getEncodedFile(selectedSourceFile())
-  }
+  override predicate shouldPrintFunction(FuncDef func) { shouldPrintFile(func.getFile()) }
+
+  override predicate shouldPrintFile(File file) { file = getEncodedFile(selectedSourceFile()) }
+
+  override predicate shouldPrintComments(File file) { none() }
 }

--- a/ql/src/semmle/go/PrintAst.ql
+++ b/ql/src/semmle/go/PrintAst.ql
@@ -12,7 +12,7 @@ import PrintAst
  * Hook to customize the functions printed by this query.
  */
 class Cfg extends PrintAstConfiguration {
-  override predicate shouldPrintFunction(FuncDef func) { any() }
+  override predicate shouldPrintFunction(FuncDecl func) { any() }
 
   override predicate shouldPrintFile(File file) { any() }
 

--- a/ql/src/semmle/go/PrintAst.ql
+++ b/ql/src/semmle/go/PrintAst.ql
@@ -13,4 +13,6 @@ import PrintAst
  */
 class Cfg extends PrintAstConfiguration {
   override predicate shouldPrintFunction(FuncDef func) { any() }
+
+  override predicate shouldPrintFile(File file) { any() }
 }

--- a/ql/src/semmle/go/PrintAst.ql
+++ b/ql/src/semmle/go/PrintAst.ql
@@ -15,4 +15,6 @@ class Cfg extends PrintAstConfiguration {
   override predicate shouldPrintFunction(FuncDef func) { any() }
 
   override predicate shouldPrintFile(File file) { any() }
+
+  override predicate shouldPrintComments(File file) { any() }
 }

--- a/ql/src/semmle/go/PrintAst.qll
+++ b/ql/src/semmle/go/PrintAst.qll
@@ -181,6 +181,19 @@ class ExprNode extends BaseAstNode {
 class FileNode extends BaseAstNode {
   override File ast;
 
+  private string getRelativePath() { result = ast.getRelativePath() }
+
+  private int getSortOrder() {
+    rank[result](FileNode fn | any() | fn order by fn.getRelativePath()) = this
+  }
+
+  override string getProperty(string key) {
+    result = super.getProperty(key)
+    or
+    key = "semmle.order" and
+    result = getSortOrder().toString()
+  }
+
   /**
    * Gets the string representation of this File. Note explicitly using a relative path
    * like this rather than absolute as per default for the File class is a workaround for

--- a/ql/src/semmle/go/PrintAst.qll
+++ b/ql/src/semmle/go/PrintAst.qll
@@ -21,7 +21,7 @@ class PrintAstConfiguration extends string {
    * Holds if the AST for `func` should be printed. By default, holds for all
    * functions.
    */
-  predicate shouldPrintFunction(FuncDef func) { any() }
+  predicate shouldPrintFunction(FuncDecl func) { any() }
 
   /**
    * Holds if the AST for `file` should be printed. By default, holds for all
@@ -48,10 +48,7 @@ private predicate shouldPrintComments(File file) {
   exists(PrintAstConfiguration config | config.shouldPrintComments(file))
 }
 
-private FuncDef getEnclosingFunction(AstNode n) {
-  result = n or
-  result = n.getEnclosingFunction()
-}
+private FuncDecl getEnclosingFunctionDecl(AstNode n) { result = n.getParent*() }
 
 /**
  * An AST node that should be printed.
@@ -60,7 +57,7 @@ private newtype TPrintAstNode =
   TAstNode(AstNode ast) {
     shouldPrintFile(ast.getFile()) and
     // Do print ast nodes without an enclosing function, e.g. file headers, that are not otherwise excluded
-    forall(FuncDef f | f = getEnclosingFunction(ast) | shouldPrintFunction(f)) and
+    forall(FuncDecl f | f = getEnclosingFunctionDecl(ast) | shouldPrintFunction(f)) and
     (
       shouldPrintComments(ast.getFile())
       or

--- a/ql/src/semmle/go/PrintAst.qll
+++ b/ql/src/semmle/go/PrintAst.qll
@@ -5,7 +5,11 @@
 import go
 
 /**
- * Hook to customize the functions printed by this module.
+ * Hook to customize the files and functions printed by this module.
+ *
+ * For an AstNode to be printed, it always requires `shouldPrintFile(f)` to hold
+ * for its containing file `f`, and additionally requires `shouldPrintFunction(fun)`
+ * if it is, or falls within, function `fun`.
  */
 class PrintAstConfiguration extends string {
   /**
@@ -18,10 +22,25 @@ class PrintAstConfiguration extends string {
    * functions.
    */
   predicate shouldPrintFunction(FuncDef func) { any() }
+
+  /**
+   * Holds if the AST for `file` should be printed. By default, holds for all
+   * files.
+   */
+  predicate shouldPrintFile(File file) { any() }
 }
 
 private predicate shouldPrintFunction(FuncDef func) {
   exists(PrintAstConfiguration config | config.shouldPrintFunction(func))
+}
+
+private predicate shouldPrintFile(File file) {
+  exists(PrintAstConfiguration config | config.shouldPrintFile(file))
+}
+
+private FuncDef getEnclosingFunction(AstNode n) {
+  result = n or
+  result = n.getEnclosingFunction()
 }
 
 /**
@@ -29,8 +48,8 @@ private predicate shouldPrintFunction(FuncDef func) {
  */
 private newtype TPrintAstNode =
   TAstNode(AstNode ast) {
-    // Do print ast nodes without an enclosing function, e.g. file headers
-    forall(FuncDef f | f = ast.getEnclosingFunction() | shouldPrintFunction(f))
+    shouldPrintFile(ast.getFile()) and
+    forall(FuncDef f | f = getEnclosingFunction(ast) | shouldPrintFunction(f))
   }
 
 /**

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
@@ -15,16 +15,41 @@ other.go:
 #    6|         Type = func() 
 #    6|     1: [FuncTypeExpr] function type
 #    6|     2: [BlockStmt] block statement
-#    8|   3: [VarDecl] variable declaration
-#    8|     0: [ValueSpec] value declaration specifier
-#    8|       0: [Ident, VariableName] x
-#    8|           Type = int
-#    8|       1: [Ident, TypeName] int
-#    8|           Type = int
-#    8|       2: [IntLit] 0
-#    8|           Type = int
-#    8|           Value = [IntLit] 0
-#    1|   4: [Ident] main
+#    8|   3: [FuncDecl] function declaration
+#    8|     0: [FunctionName, Ident] hasNested
+#    8|         Type = func() 
+#    8|     1: [FuncTypeExpr] function type
+#    8|     2: [BlockStmt] block statement
+#   10|       0: [DefineStmt] ... := ...
+#   10|         0: [Ident, VariableName] myNested
+#   10|             Type = func() int
+#   10|         1: [FuncLit] function literal
+#   10|             Type = func() int
+#   10|           0: [FuncTypeExpr] function type
+#   10|               Type = func() int
+#   10|             0: [ResultVariableDecl] result variable declaration
+#   10|               0: [Ident, TypeName] int
+#   10|                   Type = int
+#   10|           1: [BlockStmt] block statement
+#   10|             0: [ReturnStmt] return statement
+#   10|               0: [IntLit] 1
+#   10|                   Type = int
+#   10|                   Value = [IntLit] 1
+#   11|       1: [ExprStmt] expression statement
+#   11|         0: [CallExpr] call to myNested
+#   11|             Type = int
+#   11|           0: [Ident, VariableName] myNested
+#   11|               Type = func() int
+#   15|   4: [VarDecl] variable declaration
+#   15|     0: [ValueSpec] value declaration specifier
+#   15|       0: [Ident, VariableName] x
+#   15|           Type = int
+#   15|       1: [Ident, TypeName] int
+#   15|           Type = int
+#   15|       2: [IntLit] 0
+#   15|           Type = int
+#   15|           Value = [IntLit] 0
+#    1|   5: [Ident] main
 go.mod:
 #    0| [GoModFile] library-tests/semmle/go/PrintAst/go.mod
 #    1|   0: [GoModModuleLine] go.mod module line

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
@@ -1,3 +1,34 @@
+other.go:
+#    0| [File] library-tests/semmle/go/PrintAst/other.go
+#    3|   0: [FuncDecl] function declaration
+#    3|     0: [FunctionName, Ident] main
+#    3|         Type = func() 
+#    3|     1: [FuncTypeExpr] function type
+#    3|     2: [BlockStmt] block statement
+#    5|   1: [FuncDecl] function declaration
+#    5|     0: [FunctionName, Ident] f
+#    5|         Type = func() 
+#    5|     1: [FuncTypeExpr] function type
+#    5|     2: [BlockStmt] block statement
+#    6|   2: [FuncDecl] function declaration
+#    6|     0: [FunctionName, Ident] g
+#    6|         Type = func() 
+#    6|     1: [FuncTypeExpr] function type
+#    6|     2: [BlockStmt] block statement
+#    8|   3: [VarDecl] variable declaration
+#    8|     0: [ValueSpec] value declaration specifier
+#    8|       0: [Ident, VariableName] x
+#    8|           Type = int
+#    8|       1: [Ident, TypeName] int
+#    8|           Type = int
+#    8|       2: [IntLit] 0
+#    8|           Type = int
+#    8|           Value = [IntLit] 0
+#    1|   4: [Ident] main
+go.mod:
+#    0| [GoModFile] library-tests/semmle/go/PrintAst/go.mod
+#    1|   0: [GoModModuleLine] go.mod module line
+#    3|   1: [GoModGoLine] go.mod go line
 input.go:
 #    0| [File] library-tests/semmle/go/PrintAst/input.go
 #    5|   0: [CommentGroup] comment group

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
@@ -1,55 +1,3 @@
-other.go:
-#    0| [File] library-tests/semmle/go/PrintAst/other.go
-#    3|   0: [FuncDecl] function declaration
-#    3|     0: [FunctionName, Ident] main
-#    3|         Type = func() 
-#    3|     1: [FuncTypeExpr] function type
-#    3|     2: [BlockStmt] block statement
-#    5|   1: [FuncDecl] function declaration
-#    5|     0: [FunctionName, Ident] f
-#    5|         Type = func() 
-#    5|     1: [FuncTypeExpr] function type
-#    5|     2: [BlockStmt] block statement
-#    6|   2: [FuncDecl] function declaration
-#    6|     0: [FunctionName, Ident] g
-#    6|         Type = func() 
-#    6|     1: [FuncTypeExpr] function type
-#    6|     2: [BlockStmt] block statement
-#    8|   3: [FuncDecl] function declaration
-#    8|     0: [FunctionName, Ident] hasNested
-#    8|         Type = func() 
-#    8|     1: [FuncTypeExpr] function type
-#    8|     2: [BlockStmt] block statement
-#   10|       0: [DefineStmt] ... := ...
-#   10|         0: [Ident, VariableName] myNested
-#   10|             Type = func() int
-#   10|         1: [FuncLit] function literal
-#   10|             Type = func() int
-#   10|           0: [FuncTypeExpr] function type
-#   10|               Type = func() int
-#   10|             0: [ResultVariableDecl] result variable declaration
-#   10|               0: [Ident, TypeName] int
-#   10|                   Type = int
-#   10|           1: [BlockStmt] block statement
-#   10|             0: [ReturnStmt] return statement
-#   10|               0: [IntLit] 1
-#   10|                   Type = int
-#   10|                   Value = [IntLit] 1
-#   11|       1: [ExprStmt] expression statement
-#   11|         0: [CallExpr] call to myNested
-#   11|             Type = int
-#   11|           0: [Ident, VariableName] myNested
-#   11|               Type = func() int
-#   15|   4: [VarDecl] variable declaration
-#   15|     0: [ValueSpec] value declaration specifier
-#   15|       0: [Ident, VariableName] x
-#   15|           Type = int
-#   15|       1: [Ident, TypeName] int
-#   15|           Type = int
-#   15|       2: [IntLit] 0
-#   15|           Type = int
-#   15|           Value = [IntLit] 0
-#    1|   5: [Ident] main
 go.mod:
 #    0| [GoModFile] library-tests/semmle/go/PrintAst/go.mod
 #    1|   0: [GoModModuleLine] go.mod module line
@@ -648,3 +596,55 @@ input.go:
 #  145|             Type = []int
 #  145|         1: [BlockStmt] block statement
 #    1|   18: [Ident] main
+other.go:
+#    0| [File] library-tests/semmle/go/PrintAst/other.go
+#    3|   0: [FuncDecl] function declaration
+#    3|     0: [FunctionName, Ident] main
+#    3|         Type = func() 
+#    3|     1: [FuncTypeExpr] function type
+#    3|     2: [BlockStmt] block statement
+#    5|   1: [FuncDecl] function declaration
+#    5|     0: [FunctionName, Ident] f
+#    5|         Type = func() 
+#    5|     1: [FuncTypeExpr] function type
+#    5|     2: [BlockStmt] block statement
+#    6|   2: [FuncDecl] function declaration
+#    6|     0: [FunctionName, Ident] g
+#    6|         Type = func() 
+#    6|     1: [FuncTypeExpr] function type
+#    6|     2: [BlockStmt] block statement
+#    8|   3: [FuncDecl] function declaration
+#    8|     0: [FunctionName, Ident] hasNested
+#    8|         Type = func() 
+#    8|     1: [FuncTypeExpr] function type
+#    8|     2: [BlockStmt] block statement
+#   10|       0: [DefineStmt] ... := ...
+#   10|         0: [Ident, VariableName] myNested
+#   10|             Type = func() int
+#   10|         1: [FuncLit] function literal
+#   10|             Type = func() int
+#   10|           0: [FuncTypeExpr] function type
+#   10|               Type = func() int
+#   10|             0: [ResultVariableDecl] result variable declaration
+#   10|               0: [Ident, TypeName] int
+#   10|                   Type = int
+#   10|           1: [BlockStmt] block statement
+#   10|             0: [ReturnStmt] return statement
+#   10|               0: [IntLit] 1
+#   10|                   Type = int
+#   10|                   Value = [IntLit] 1
+#   11|       1: [ExprStmt] expression statement
+#   11|         0: [CallExpr] call to myNested
+#   11|             Type = int
+#   11|           0: [Ident, VariableName] myNested
+#   11|               Type = func() int
+#   15|   4: [VarDecl] variable declaration
+#   15|     0: [ValueSpec] value declaration specifier
+#   15|       0: [Ident, VariableName] x
+#   15|           Type = int
+#   15|       1: [Ident, TypeName] int
+#   15|           Type = int
+#   15|       2: [IntLit] 0
+#   15|           Type = int
+#   15|           Value = [IntLit] 0
+#    1|   5: [Ident] main

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
@@ -1,0 +1,605 @@
+other.go:
+#    0| [File] library-tests/semmle/go/PrintAst/other.go
+#    3|   0: [FuncDecl] function declaration
+#    3|     0: [FunctionName, Ident] main
+#    3|         Type = func() 
+#    3|     1: [FuncTypeExpr] function type
+#    3|     2: [BlockStmt] block statement
+#    5|   1: [FuncDecl] function declaration
+#    5|     0: [FunctionName, Ident] f
+#    5|         Type = func() 
+#    5|     1: [FuncTypeExpr] function type
+#    5|     2: [BlockStmt] block statement
+#    6|   2: [FuncDecl] function declaration
+#    6|     0: [FunctionName, Ident] g
+#    6|         Type = func() 
+#    6|     1: [FuncTypeExpr] function type
+#    6|     2: [BlockStmt] block statement
+#    8|   3: [VarDecl] variable declaration
+#    8|     0: [ValueSpec] value declaration specifier
+#    8|       0: [Ident, VariableName] x
+#    8|           Type = int
+#    8|       1: [Ident, TypeName] int
+#    8|           Type = int
+#    8|       2: [IntLit] 0
+#    8|           Type = int
+#    8|           Value = [IntLit] 0
+#    1|   4: [Ident] main
+go.mod:
+#    0| [GoModFile] library-tests/semmle/go/PrintAst/go.mod
+#    1|   0: [GoModModuleLine] go.mod module line
+#    3|   1: [GoModGoLine] go.mod go line
+input.go:
+#    0| [File] library-tests/semmle/go/PrintAst/input.go
+#    3|   10: [ImportDecl] import declaration
+#    3|     0: [ImportSpec] import specifier
+#    3|       0: [StringLit] "fmt"
+#   10|   11: [FuncDecl] function declaration
+#   10|     0: [FunctionName, Ident] test5
+#   10|         Type = func(bool) 
+#   10|     1: [FuncTypeExpr] function type
+#   10|       0: [ParameterDecl] parameter declaration
+#   10|         0: [Ident, TypeName] bool
+#   10|             Type = bool
+#   10|         1: [Ident, VariableName] b
+#   10|             Type = bool
+#   10|     2: [BlockStmt] block statement
+#   11|       0: [BlockStmt] block statement
+#   12|         0: [IfStmt] if statement
+#   12|           0: [NotExpr] !...
+#   12|               Type = bool
+#   12|             0: [Ident, VariableName] b
+#   12|                 Type = bool
+#   12|           1: [BlockStmt] block statement
+#   13|             0: [GotoStmt] goto statement
+#   13|               0: [Ident, LabelName] outer
+#   15|         1: [BlockStmt] block statement
+#   17|         2: [EmptyStmt] empty statement
+#   20|       1: [ExprStmt] expression statement
+#   20|         0: [CallExpr] call to Println
+#   20|             Type = (int, error)
+#   20|           0: [FunctionName, SelectorExpr] selection of Println
+#   20|               Type = func([]interface {  }) int, error
+#   20|             0: [Ident, PackageName] fmt
+#   20|             1: [FunctionName, Ident] Println
+#   20|                 Type = func([]interface {  }) int, error
+#   20|           1: [StringLit] "Hi"
+#   20|               Type = string
+#   20|               Value = [StringLit] Hi
+#   22|       2: [LabelledStmt] labeled statement
+#   22|         0: [Ident, LabelName] outer
+#   23|         1: [ForStmt] for statement
+#   23|           0: [ConstantName, Ident] true
+#   23|               Type = bool literal
+#   23|               Value = [ConstantName, Ident] true
+#   23|           1: [BlockStmt] block statement
+#   24|             0: [ForStmt] for statement
+#   24|               0: [LssExpr] ...<...
+#   24|                   Type = bool literal
+#   24|                 0: [Ident, VariableName] i
+#   24|                     Type = int
+#   24|                 1: [IntLit] 10
+#   24|                     Type = int
+#   24|                     Value = [IntLit] 10
+#   24|               1: [DefineStmt] ... := ...
+#   24|                 0: [Ident, VariableName] i
+#   24|                     Type = int
+#   24|                 1: [IntLit] 0
+#   24|                     Type = int
+#   24|                     Value = [IntLit] 0
+#   24|               2: [IncStmt] increment statement
+#   24|                 0: [Ident, VariableName] i
+#   24|                     Type = int
+#   24|               3: [BlockStmt] block statement
+#   25|                 0: [IfStmt] if statement
+#   25|                   0: [GtrExpr] ...>...
+#   25|                       Type = bool literal
+#   25|                     0: [Ident, VariableName] j
+#   25|                         Type = int
+#   25|                     1: [IntLit] 5
+#   25|                         Type = int
+#   25|                         Value = [IntLit] 5
+#   25|                   1: [DefineStmt] ... := ...
+#   25|                     0: [Ident, VariableName] j
+#   25|                         Type = int
+#   25|                     1: [SubExpr] ...-...
+#   25|                         Type = int
+#   25|                       0: [Ident, VariableName] i
+#   25|                           Type = int
+#   25|                       1: [IntLit] 1
+#   25|                           Type = int
+#   25|                           Value = [IntLit] 1
+#   25|                   2: [BlockStmt] block statement
+#   26|                     0: [BreakStmt] break statement
+#   26|                       0: [Ident, LabelName] outer
+#   27|                   3: [IfStmt] if statement
+#   27|                     0: [LssExpr] ...<...
+#   27|                         Type = bool literal
+#   27|                       0: [Ident, VariableName] i
+#   27|                           Type = int
+#   27|                       1: [IntLit] 3
+#   27|                           Type = int
+#   27|                           Value = [IntLit] 3
+#   27|                     1: [BlockStmt] block statement
+#   28|                       0: [BreakStmt] break statement
+#   29|                     2: [IfStmt] if statement
+#   29|                       0: [NeqExpr] ...!=...
+#   29|                           Type = bool literal
+#   29|                         0: [Ident, VariableName] i
+#   29|                             Type = int
+#   29|                         1: [IntLit] 9
+#   29|                             Type = int
+#   29|                             Value = [IntLit] 9
+#   29|                       1: [BlockStmt] block statement
+#   30|                         0: [ContinueStmt] continue statement
+#   30|                           0: [Ident, LabelName] outer
+#   31|                       2: [IfStmt] if statement
+#   31|                         0: [GeqExpr] ...>=...
+#   31|                             Type = bool literal
+#   31|                           0: [Ident, VariableName] i
+#   31|                               Type = int
+#   31|                           1: [IntLit] 4
+#   31|                               Type = int
+#   31|                               Value = [IntLit] 4
+#   31|                         1: [BlockStmt] block statement
+#   32|                           0: [GotoStmt] goto statement
+#   32|                             0: [Ident, LabelName] outer
+#   33|                         2: [BlockStmt] block statement
+#   34|                           0: [ContinueStmt] continue statement
+#   39|       3: [DefineStmt] ... := ...
+#   39|         0: [Ident, VariableName] k
+#   39|             Type = int
+#   39|         1: [IntLit] 9
+#   39|             Type = int
+#   39|             Value = [IntLit] 9
+#   40|       4: [ForStmt] for statement
+#   40|         0: [IncStmt] increment statement
+#   40|           0: [Ident, VariableName] k
+#   40|               Type = int
+#   40|         1: [BlockStmt] block statement
+#   41|           0: [GotoStmt] goto statement
+#   41|             0: [Ident, LabelName] outer
+#   46|   12: [FuncDecl] function declaration
+#   46|     0: [FunctionName, Ident] test6
+#   46|         Type = func(chan int, chan float32) 
+#   46|     1: [FuncTypeExpr] function type
+#   46|       0: [ParameterDecl] parameter declaration
+#   46|         0: [SendRecvChanTypeExpr] channel type
+#   46|             Type = chan int
+#   46|           0: [Ident, TypeName] int
+#   46|               Type = int
+#   46|         1: [Ident, VariableName] ch1
+#   46|             Type = chan int
+#   46|       1: [ParameterDecl] parameter declaration
+#   46|         0: [SendRecvChanTypeExpr] channel type
+#   46|             Type = chan float32
+#   46|           0: [Ident, TypeName] float32
+#   46|               Type = float32
+#   46|         1: [Ident, VariableName] ch2
+#   46|             Type = chan float32
+#   46|     2: [BlockStmt] block statement
+#   47|       0: [DeclStmt] declaration statement
+#   47|         0: [VarDecl] variable declaration
+#   47|           0: [ValueSpec] value declaration specifier
+#   47|             0: [Ident, VariableName] a
+#   47|                 Type = [1]float32
+#   47|             1: [ArrayTypeExpr] array type
+#   47|                 Type = [1]float32
+#   47|               0: [IntLit] 1
+#   47|                   Type = int literal
+#   47|                   Value = [IntLit] 1
+#   47|               1: [Ident, TypeName] float32
+#   47|                   Type = float32
+#   48|       1: [DeclStmt] declaration statement
+#   48|         0: [VarDecl] variable declaration
+#   48|           0: [ValueSpec] value declaration specifier
+#   48|             0: [Ident, VariableName] w
+#   48|                 Type = bool
+#   48|             1: [Ident, TypeName] bool
+#   48|                 Type = bool
+#   50|       2: [SelectStmt] select statement
+#   50|         0: [BlockStmt] block statement
+#   51|           0: [CommClause] comm clause
+#   51|             0: [ExprStmt, RecvStmt] expression statement
+#   51|               0: [RecvExpr] <-...
+#   51|                   Type = int
+#   51|                 0: [Ident, VariableName] ch1
+#   51|                     Type = chan int
+#   52|             1: [ExprStmt] expression statement
+#   52|               0: [CallExpr] call to Println
+#   52|                   Type = (int, error)
+#   52|                 0: [FunctionName, SelectorExpr] selection of Println
+#   52|                     Type = func([]interface {  }) int, error
+#   52|                   0: [Ident, PackageName] fmt
+#   52|                   1: [FunctionName, Ident] Println
+#   52|                       Type = func([]interface {  }) int, error
+#   52|                 1: [StringLit] "Heard from ch1"
+#   52|                     Type = string
+#   52|                     Value = [StringLit] Heard from ch1
+#   53|           1: [CommClause] comm clause
+#   53|             0: [AssignStmt, RecvStmt] ... = ...
+#   53|               0: [Ident, VariableName] w
+#   53|                   Type = bool
+#   53|               1: [IndexExpr] index expression
+#   53|                   Type = float32
+#   53|                 0: [Ident, VariableName] a
+#   53|                     Type = [1]float32
+#   53|                 1: [IntLit] 0
+#   53|                     Type = int
+#   53|                     Value = [IntLit] 0
+#   53|               2: [RecvExpr] <-...
+#   53|                   Type = (float32, bool)
+#   53|                 0: [Ident, VariableName] ch2
+#   53|                     Type = chan float32
+#   54|             1: [ExprStmt] expression statement
+#   54|               0: [CallExpr] call to Println
+#   54|                   Type = (int, error)
+#   54|                 0: [FunctionName, SelectorExpr] selection of Println
+#   54|                     Type = func([]interface {  }) int, error
+#   54|                   0: [Ident, PackageName] fmt
+#   54|                   1: [FunctionName, Ident] Println
+#   54|                       Type = func([]interface {  }) int, error
+#   54|                 1: [Ident, VariableName] a
+#   54|                     Type = [1]float32
+#   55|             2: [ExprStmt] expression statement
+#   55|               0: [CallExpr] call to Println
+#   55|                   Type = (int, error)
+#   55|                 0: [FunctionName, SelectorExpr] selection of Println
+#   55|                     Type = func([]interface {  }) int, error
+#   55|                   0: [Ident, PackageName] fmt
+#   55|                   1: [FunctionName, Ident] Println
+#   55|                       Type = func([]interface {  }) int, error
+#   55|                 1: [Ident, VariableName] w
+#   55|                     Type = bool
+#   56|           2: [CommClause] comm clause
+#   57|             0: [ExprStmt] expression statement
+#   57|               0: [CallExpr] call to Println
+#   57|                   Type = (int, error)
+#   57|                 0: [FunctionName, SelectorExpr] selection of Println
+#   57|                     Type = func([]interface {  }) int, error
+#   57|                   0: [Ident, PackageName] fmt
+#   57|                   1: [FunctionName, Ident] Println
+#   57|                       Type = func([]interface {  }) int, error
+#   58|           3: [CommClause] comm clause
+#   58|             0: [SendStmt] send statement
+#   58|               0: [Ident, VariableName] ch1
+#   58|                   Type = chan int
+#   58|               1: [IntLit] 42
+#   58|                   Type = int
+#   58|                   Value = [IntLit] 42
+#   61|       3: [SelectStmt] select statement
+#   61|         0: [BlockStmt] block statement
+#   65|   13: [FuncDecl] function declaration
+#   65|     0: [FunctionName, Ident] test7
+#   65|         Type = func(int) int
+#   65|     1: [FuncTypeExpr] function type
+#   65|       0: [ParameterDecl] parameter declaration
+#   65|         0: [Ident, TypeName] int
+#   65|             Type = int
+#   65|         1: [Ident, VariableName] x
+#   65|             Type = int
+#   65|       1: [ResultVariableDecl] result variable declaration
+#   65|         0: [Ident, TypeName] int
+#   65|             Type = int
+#   65|     2: [BlockStmt] block statement
+#   66|       0: [IfStmt] if statement
+#   66|         0: [GtrExpr] ...>...
+#   66|             Type = bool literal
+#   66|           0: [Ident, VariableName] x
+#   66|               Type = int
+#   66|           1: [IntLit] 0
+#   66|               Type = int
+#   66|               Value = [IntLit] 0
+#   66|         1: [BlockStmt] block statement
+#   67|           0: [DeferStmt] defer statement
+#   67|             0: [CallExpr] function call
+#   67|                 Type = ()
+#   67|               0: [FuncLit] function literal
+#   67|                   Type = func() 
+#   67|                 0: [FuncTypeExpr] function type
+#   67|                     Type = func() 
+#   67|                 1: [BlockStmt] block statement
+#   67|                   0: [ExprStmt] expression statement
+#   67|                     0: [CallExpr] call to Println
+#   67|                         Type = (int, error)
+#   67|                       0: [FunctionName, SelectorExpr] selection of Println
+#   67|                           Type = func([]interface {  }) int, error
+#   67|                         0: [Ident, PackageName] fmt
+#   67|                         1: [FunctionName, Ident] Println
+#   67|                             Type = func([]interface {  }) int, error
+#   67|                       1: [Ident, VariableName] x
+#   67|                           Type = int
+#   68|         2: [BlockStmt] block statement
+#   69|           0: [DeferStmt] defer statement
+#   69|             0: [CallExpr] function call
+#   69|                 Type = ()
+#   69|               0: [FuncLit] function literal
+#   69|                   Type = func() 
+#   69|                 0: [FuncTypeExpr] function type
+#   69|                     Type = func() 
+#   69|                 1: [BlockStmt] block statement
+#   69|                   0: [ExprStmt] expression statement
+#   69|                     0: [CallExpr] call to Println
+#   69|                         Type = (int, error)
+#   69|                       0: [FunctionName, SelectorExpr] selection of Println
+#   69|                           Type = func([]interface {  }) int, error
+#   69|                         0: [Ident, PackageName] fmt
+#   69|                         1: [FunctionName, Ident] Println
+#   69|                             Type = func([]interface {  }) int, error
+#   69|                       1: [MinusExpr] -...
+#   69|                           Type = int
+#   69|                         0: [Ident, VariableName] x
+#   69|                             Type = int
+#   71|       1: [ReturnStmt] return statement
+#   71|         0: [IntLit] 42
+#   71|             Type = int
+#   71|             Value = [IntLit] 42
+#   75|   14: [FuncDecl] function declaration
+#   75|     0: [FunctionName, Ident] test8
+#   75|         Type = func(int) 
+#   75|     1: [FuncTypeExpr] function type
+#   75|       0: [ParameterDecl] parameter declaration
+#   75|         0: [Ident, TypeName] int
+#   75|             Type = int
+#   75|         1: [Ident, VariableName] x
+#   75|             Type = int
+#   75|     2: [BlockStmt] block statement
+#   76|       0: [ExpressionSwitchStmt] expression-switch statement
+#   76|         0: [Ident, VariableName] x
+#   76|             Type = int
+#   76|         1: [BlockStmt] block statement
+#   79|       1: [ExpressionSwitchStmt] expression-switch statement
+#   79|         0: [SubExpr] ...-...
+#   79|             Type = int
+#   79|           0: [Ident, VariableName] y
+#   79|               Type = int
+#   79|           1: [IntLit] 19
+#   79|               Type = int
+#   79|               Value = [IntLit] 19
+#   79|         1: [DefineStmt] ... := ...
+#   79|           0: [Ident, VariableName] y
+#   79|               Type = int
+#   79|           1: [Ident, VariableName] x
+#   79|               Type = int
+#   79|         2: [BlockStmt] block statement
+#   80|           0: [CaseClause] case clause
+#   81|             0: [ExprStmt] expression statement
+#   81|               0: [CallExpr] call to test5
+#   81|                   Type = ()
+#   81|                 0: [FunctionName, Ident] test5
+#   81|                     Type = func(bool) 
+#   81|                 1: [ConstantName, Ident] false
+#   81|                     Type = bool
+#   81|                     Value = [ConstantName, Ident] false
+#   84|       2: [ExpressionSwitchStmt] expression-switch statement
+#   84|         0: [Ident, VariableName] x
+#   84|             Type = int
+#   84|         1: [BlockStmt] block statement
+#   85|           0: [CaseClause] case clause
+#   85|             0: [IntLit] 1
+#   85|                 Type = int
+#   85|                 Value = [IntLit] 1
+#   86|           1: [CaseClause] case clause
+#   86|             0: [IntLit] 3
+#   86|                 Type = int
+#   86|                 Value = [IntLit] 3
+#   86|             1: [IntLit] 2
+#   86|                 Type = int
+#   86|                 Value = [IntLit] 2
+#   87|             2: [ExprStmt] expression statement
+#   87|               0: [CallExpr] call to test5
+#   87|                   Type = ()
+#   87|                 0: [FunctionName, Ident] test5
+#   87|                     Type = func(bool) 
+#   87|                 1: [ConstantName, Ident] true
+#   87|                     Type = bool
+#   87|                     Value = [ConstantName, Ident] true
+#   90|       3: [ExpressionSwitchStmt] expression-switch statement
+#   90|         0: [Ident, VariableName] x
+#   90|             Type = int
+#   90|         1: [BlockStmt] block statement
+#   91|           0: [CaseClause] case clause
+#   91|             0: [IntLit] 1
+#   91|                 Type = int
+#   91|                 Value = [IntLit] 1
+#   92|             1: [ExprStmt] expression statement
+#   92|               0: [CallExpr] call to test5
+#   92|                   Type = ()
+#   92|                 0: [FunctionName, Ident] test5
+#   92|                     Type = func(bool) 
+#   92|                 1: [ConstantName, Ident] false
+#   92|                     Type = bool
+#   92|                     Value = [ConstantName, Ident] false
+#   93|             2: [FallthroughStmt] fallthrough statement
+#   94|           1: [CaseClause] case clause
+#   94|             0: [SubExpr] ...-...
+#   94|                 Type = int
+#   94|                 Value = [SubExpr] -3
+#   94|               0: [IntLit] 2
+#   94|                   Type = int literal
+#   94|                   Value = [IntLit] 2
+#   94|               1: [IntLit] 5
+#   94|                   Type = int literal
+#   94|                   Value = [IntLit] 5
+#   95|             1: [ExprStmt] expression statement
+#   95|               0: [CallExpr] call to test5
+#   95|                   Type = ()
+#   95|                 0: [FunctionName, Ident] test5
+#   95|                     Type = func(bool) 
+#   95|                 1: [ConstantName, Ident] true
+#   95|                     Type = bool
+#   95|                     Value = [ConstantName, Ident] true
+#   98|       4: [ExpressionSwitchStmt] expression-switch statement
+#   98|         0: [Ident, VariableName] x
+#   98|             Type = int
+#   98|         1: [BlockStmt] block statement
+#   99|           0: [CaseClause] case clause
+#  100|           1: [CaseClause] case clause
+#  100|             0: [IntLit] 2
+#  100|                 Type = int
+#  100|                 Value = [IntLit] 2
+#  101|             1: [ExprStmt] expression statement
+#  101|               0: [CallExpr] call to test5
+#  101|                   Type = ()
+#  101|                 0: [FunctionName, Ident] test5
+#  101|                     Type = func(bool) 
+#  101|                 1: [ConstantName, Ident] true
+#  101|                     Type = bool
+#  101|                     Value = [ConstantName, Ident] true
+#  104|       5: [ExpressionSwitchStmt] expression-switch statement
+#  104|         0: [BlockStmt] block statement
+#  105|           0: [CaseClause] case clause
+#  106|             0: [BreakStmt] break statement
+#  107|           1: [CaseClause] case clause
+#  107|             0: [ConstantName, Ident] true
+#  107|                 Type = bool
+#  107|                 Value = [ConstantName, Ident] true
+#  112|   15: [FuncDecl] function declaration
+#  112|     0: [FunctionName, Ident] test9
+#  112|         Type = func(interface {  }) 
+#  112|     1: [FuncTypeExpr] function type
+#  112|       0: [ParameterDecl] parameter declaration
+#  112|         0: [InterfaceTypeExpr] interface type
+#  112|             Type = interface {  }
+#  112|         1: [Ident, VariableName] x
+#  112|             Type = interface {  }
+#  112|     2: [BlockStmt] block statement
+#  113|       0: [TypeSwitchStmt] type-switch statement
+#  113|         0: [DefineStmt] ... := ...
+#  113|           0: [Ident] y
+#  113|           1: [TypeAssertExpr] type assertion
+#  113|             0: [Ident, VariableName] x
+#  113|                 Type = interface {  }
+#  113|         1: [BlockStmt] block statement
+#  114|           0: [CaseClause] case clause
+#  114|             0: [Ident, TypeName] string
+#  114|                 Type = string
+#  114|             1: [Ident, TypeName] error
+#  114|                 Type = error
+#  115|             2: [ExprStmt] expression statement
+#  115|               0: [CallExpr] call to Println
+#  115|                   Type = (int, error)
+#  115|                 0: [FunctionName, SelectorExpr] selection of Println
+#  115|                     Type = func([]interface {  }) int, error
+#  115|                   0: [Ident, PackageName] fmt
+#  115|                   1: [FunctionName, Ident] Println
+#  115|                       Type = func([]interface {  }) int, error
+#  115|                 1: [Ident, VariableName] y
+#  115|                     Type = interface {  }
+#  116|           1: [CaseClause] case clause
+#  116|             0: [Ident, TypeName] float32
+#  116|                 Type = float32
+#  117|             1: [ExprStmt] expression statement
+#  117|               0: [CallExpr] call to test5
+#  117|                   Type = ()
+#  117|                 0: [FunctionName, Ident] test5
+#  117|                     Type = func(bool) 
+#  117|                 1: [ConstantName, Ident] true
+#  117|                     Type = bool
+#  117|                     Value = [ConstantName, Ident] true
+#  118|             2: [ExprStmt] expression statement
+#  118|               0: [CallExpr] call to test5
+#  118|                   Type = ()
+#  118|                 0: [FunctionName, Ident] test5
+#  118|                     Type = func(bool) 
+#  118|                 1: [ConstantName, Ident] false
+#  118|                     Type = bool
+#  118|                     Value = [ConstantName, Ident] false
+#  121|       1: [TypeSwitchStmt] type-switch statement
+#  121|         0: [DefineStmt] ... := ...
+#  121|           0: [Ident, VariableName] y
+#  121|               Type = interface {  }
+#  121|           1: [Ident, VariableName] x
+#  121|               Type = interface {  }
+#  121|         1: [ExprStmt] expression statement
+#  121|           0: [TypeAssertExpr] type assertion
+#  121|             0: [Ident, VariableName] y
+#  121|                 Type = interface {  }
+#  121|         2: [BlockStmt] block statement
+#  122|           0: [CaseClause] case clause
+#  123|             0: [ExprStmt] expression statement
+#  123|               0: [CallExpr] call to test5
+#  123|                   Type = ()
+#  123|                 0: [FunctionName, Ident] test5
+#  123|                     Type = func(bool) 
+#  123|                 1: [ConstantName, Ident] false
+#  123|                     Type = bool
+#  123|                     Value = [ConstantName, Ident] false
+#  128|   16: [FuncDecl] function declaration
+#  128|     0: [FunctionName, Ident] test10
+#  128|         Type = func(func() ) 
+#  128|     1: [FuncTypeExpr] function type
+#  128|       0: [ParameterDecl] parameter declaration
+#  128|         0: [FuncTypeExpr] function type
+#  128|             Type = func() 
+#  128|         1: [Ident, VariableName] f
+#  128|             Type = func() 
+#  128|     2: [BlockStmt] block statement
+#  129|       0: [GoStmt] go statement
+#  129|         0: [CallExpr] call to f
+#  129|             Type = ()
+#  129|           0: [Ident, VariableName] f
+#  129|               Type = func() 
+#  133|   17: [FuncDecl] function declaration
+#  133|     0: [FunctionName, Ident] test11
+#  133|         Type = func([]int) 
+#  133|     1: [FuncTypeExpr] function type
+#  133|       0: [ParameterDecl] parameter declaration
+#  133|         0: [ArrayTypeExpr] array type
+#  133|             Type = []int
+#  133|           0: [Ident, TypeName] int
+#  133|               Type = int
+#  133|         1: [Ident, VariableName] xs
+#  133|             Type = []int
+#  133|     2: [BlockStmt] block statement
+#  134|       0: [RangeStmt] range statement
+#  134|         0: [Ident, VariableName] x
+#  134|             Type = int
+#  134|         1: [Ident, VariableName] xs
+#  134|             Type = []int
+#  134|         2: [BlockStmt] block statement
+#  135|           0: [IfStmt] if statement
+#  135|             0: [GtrExpr] ...>...
+#  135|                 Type = bool literal
+#  135|               0: [Ident, VariableName] x
+#  135|                   Type = int
+#  135|               1: [IntLit] 5
+#  135|                   Type = int
+#  135|                   Value = [IntLit] 5
+#  135|             1: [BlockStmt] block statement
+#  136|               0: [ContinueStmt] continue statement
+#  138|           1: [ExprStmt] expression statement
+#  138|             0: [CallExpr] call to Print
+#  138|                 Type = (int, error)
+#  138|               0: [FunctionName, SelectorExpr] selection of Print
+#  138|                   Type = func([]interface {  }) int, error
+#  138|                 0: [Ident, PackageName] fmt
+#  138|                 1: [FunctionName, Ident] Print
+#  138|                     Type = func([]interface {  }) int, error
+#  138|               1: [Ident, VariableName] x
+#  138|                   Type = int
+#  141|       1: [RangeStmt] range statement
+#  141|         0: [Ident, VariableName] i
+#  141|             Type = int
+#  141|         1: [Ident, VariableName] v
+#  141|             Type = int
+#  141|         2: [Ident, VariableName] xs
+#  141|             Type = []int
+#  141|         3: [BlockStmt] block statement
+#  142|           0: [ExprStmt] expression statement
+#  142|             0: [CallExpr] call to Print
+#  142|                 Type = (int, error)
+#  142|               0: [FunctionName, SelectorExpr] selection of Print
+#  142|                   Type = func([]interface {  }) int, error
+#  142|                 0: [Ident, PackageName] fmt
+#  142|                 1: [FunctionName, Ident] Print
+#  142|                     Type = func([]interface {  }) int, error
+#  142|               1: [Ident, VariableName] i
+#  142|                   Type = int
+#  142|               2: [Ident, VariableName] v
+#  142|                   Type = int
+#  145|       2: [RangeStmt] range statement
+#  145|         0: [Ident, VariableName] xs
+#  145|             Type = []int
+#  145|         1: [BlockStmt] block statement
+#    1|   18: [Ident] main

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
@@ -15,16 +15,41 @@ other.go:
 #    6|         Type = func() 
 #    6|     1: [FuncTypeExpr] function type
 #    6|     2: [BlockStmt] block statement
-#    8|   3: [VarDecl] variable declaration
-#    8|     0: [ValueSpec] value declaration specifier
-#    8|       0: [Ident, VariableName] x
-#    8|           Type = int
-#    8|       1: [Ident, TypeName] int
-#    8|           Type = int
-#    8|       2: [IntLit] 0
-#    8|           Type = int
-#    8|           Value = [IntLit] 0
-#    1|   4: [Ident] main
+#    8|   3: [FuncDecl] function declaration
+#    8|     0: [FunctionName, Ident] hasNested
+#    8|         Type = func() 
+#    8|     1: [FuncTypeExpr] function type
+#    8|     2: [BlockStmt] block statement
+#   10|       0: [DefineStmt] ... := ...
+#   10|         0: [Ident, VariableName] myNested
+#   10|             Type = func() int
+#   10|         1: [FuncLit] function literal
+#   10|             Type = func() int
+#   10|           0: [FuncTypeExpr] function type
+#   10|               Type = func() int
+#   10|             0: [ResultVariableDecl] result variable declaration
+#   10|               0: [Ident, TypeName] int
+#   10|                   Type = int
+#   10|           1: [BlockStmt] block statement
+#   10|             0: [ReturnStmt] return statement
+#   10|               0: [IntLit] 1
+#   10|                   Type = int
+#   10|                   Value = [IntLit] 1
+#   11|       1: [ExprStmt] expression statement
+#   11|         0: [CallExpr] call to myNested
+#   11|             Type = int
+#   11|           0: [Ident, VariableName] myNested
+#   11|               Type = func() int
+#   15|   4: [VarDecl] variable declaration
+#   15|     0: [ValueSpec] value declaration specifier
+#   15|       0: [Ident, VariableName] x
+#   15|           Type = int
+#   15|       1: [Ident, TypeName] int
+#   15|           Type = int
+#   15|       2: [IntLit] 0
+#   15|           Type = int
+#   15|           Value = [IntLit] 0
+#    1|   5: [Ident] main
 go.mod:
 #    0| [GoModFile] library-tests/semmle/go/PrintAst/go.mod
 #    1|   0: [GoModModuleLine] go.mod module line

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
@@ -1,55 +1,3 @@
-other.go:
-#    0| [File] library-tests/semmle/go/PrintAst/other.go
-#    3|   0: [FuncDecl] function declaration
-#    3|     0: [FunctionName, Ident] main
-#    3|         Type = func() 
-#    3|     1: [FuncTypeExpr] function type
-#    3|     2: [BlockStmt] block statement
-#    5|   1: [FuncDecl] function declaration
-#    5|     0: [FunctionName, Ident] f
-#    5|         Type = func() 
-#    5|     1: [FuncTypeExpr] function type
-#    5|     2: [BlockStmt] block statement
-#    6|   2: [FuncDecl] function declaration
-#    6|     0: [FunctionName, Ident] g
-#    6|         Type = func() 
-#    6|     1: [FuncTypeExpr] function type
-#    6|     2: [BlockStmt] block statement
-#    8|   3: [FuncDecl] function declaration
-#    8|     0: [FunctionName, Ident] hasNested
-#    8|         Type = func() 
-#    8|     1: [FuncTypeExpr] function type
-#    8|     2: [BlockStmt] block statement
-#   10|       0: [DefineStmt] ... := ...
-#   10|         0: [Ident, VariableName] myNested
-#   10|             Type = func() int
-#   10|         1: [FuncLit] function literal
-#   10|             Type = func() int
-#   10|           0: [FuncTypeExpr] function type
-#   10|               Type = func() int
-#   10|             0: [ResultVariableDecl] result variable declaration
-#   10|               0: [Ident, TypeName] int
-#   10|                   Type = int
-#   10|           1: [BlockStmt] block statement
-#   10|             0: [ReturnStmt] return statement
-#   10|               0: [IntLit] 1
-#   10|                   Type = int
-#   10|                   Value = [IntLit] 1
-#   11|       1: [ExprStmt] expression statement
-#   11|         0: [CallExpr] call to myNested
-#   11|             Type = int
-#   11|           0: [Ident, VariableName] myNested
-#   11|               Type = func() int
-#   15|   4: [VarDecl] variable declaration
-#   15|     0: [ValueSpec] value declaration specifier
-#   15|       0: [Ident, VariableName] x
-#   15|           Type = int
-#   15|       1: [Ident, TypeName] int
-#   15|           Type = int
-#   15|       2: [IntLit] 0
-#   15|           Type = int
-#   15|           Value = [IntLit] 0
-#    1|   5: [Ident] main
 go.mod:
 #    0| [GoModFile] library-tests/semmle/go/PrintAst/go.mod
 #    1|   0: [GoModModuleLine] go.mod module line
@@ -628,3 +576,55 @@ input.go:
 #  145|             Type = []int
 #  145|         1: [BlockStmt] block statement
 #    1|   18: [Ident] main
+other.go:
+#    0| [File] library-tests/semmle/go/PrintAst/other.go
+#    3|   0: [FuncDecl] function declaration
+#    3|     0: [FunctionName, Ident] main
+#    3|         Type = func() 
+#    3|     1: [FuncTypeExpr] function type
+#    3|     2: [BlockStmt] block statement
+#    5|   1: [FuncDecl] function declaration
+#    5|     0: [FunctionName, Ident] f
+#    5|         Type = func() 
+#    5|     1: [FuncTypeExpr] function type
+#    5|     2: [BlockStmt] block statement
+#    6|   2: [FuncDecl] function declaration
+#    6|     0: [FunctionName, Ident] g
+#    6|         Type = func() 
+#    6|     1: [FuncTypeExpr] function type
+#    6|     2: [BlockStmt] block statement
+#    8|   3: [FuncDecl] function declaration
+#    8|     0: [FunctionName, Ident] hasNested
+#    8|         Type = func() 
+#    8|     1: [FuncTypeExpr] function type
+#    8|     2: [BlockStmt] block statement
+#   10|       0: [DefineStmt] ... := ...
+#   10|         0: [Ident, VariableName] myNested
+#   10|             Type = func() int
+#   10|         1: [FuncLit] function literal
+#   10|             Type = func() int
+#   10|           0: [FuncTypeExpr] function type
+#   10|               Type = func() int
+#   10|             0: [ResultVariableDecl] result variable declaration
+#   10|               0: [Ident, TypeName] int
+#   10|                   Type = int
+#   10|           1: [BlockStmt] block statement
+#   10|             0: [ReturnStmt] return statement
+#   10|               0: [IntLit] 1
+#   10|                   Type = int
+#   10|                   Value = [IntLit] 1
+#   11|       1: [ExprStmt] expression statement
+#   11|         0: [CallExpr] call to myNested
+#   11|             Type = int
+#   11|           0: [Ident, VariableName] myNested
+#   11|               Type = func() int
+#   15|   4: [VarDecl] variable declaration
+#   15|     0: [ValueSpec] value declaration specifier
+#   15|       0: [Ident, VariableName] x
+#   15|           Type = int
+#   15|       1: [Ident, TypeName] int
+#   15|           Type = int
+#   15|       2: [IntLit] 0
+#   15|           Type = int
+#   15|           Value = [IntLit] 0
+#    1|   5: [Ident] main

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.ql
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.ql
@@ -1,0 +1,14 @@
+/**
+ * @kind graph
+ */
+
+import go
+import semmle.go.PrintAst
+
+class Cfg extends PrintAstConfiguration {
+  override predicate shouldPrintFunction(FuncDef func) { any() }
+
+  override predicate shouldPrintFile(File file) { any() }
+
+  override predicate shouldPrintComments(File file) { none() }
+}

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.ql
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.ql
@@ -6,7 +6,7 @@ import go
 import semmle.go.PrintAst
 
 class Cfg extends PrintAstConfiguration {
-  override predicate shouldPrintFunction(FuncDef func) { any() }
+  override predicate shouldPrintFunction(FuncDecl func) { any() }
 
   override predicate shouldPrintFile(File file) { any() }
 

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstNestedFunction.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstNestedFunction.expected
@@ -1,10 +1,30 @@
 other.go:
 #    0| [File] library-tests/semmle/go/PrintAst/other.go
-#    6|   2: [FuncDecl] function declaration
-#    6|     0: [FunctionName, Ident] g
-#    6|         Type = func() 
-#    6|     1: [FuncTypeExpr] function type
-#    6|     2: [BlockStmt] block statement
+#    8|   3: [FuncDecl] function declaration
+#    8|     0: [FunctionName, Ident] hasNested
+#    8|         Type = func() 
+#    8|     1: [FuncTypeExpr] function type
+#    8|     2: [BlockStmt] block statement
+#   10|       0: [DefineStmt] ... := ...
+#   10|         0: [Ident, VariableName] myNested
+#   10|             Type = func() int
+#   10|         1: [FuncLit] function literal
+#   10|             Type = func() int
+#   10|           0: [FuncTypeExpr] function type
+#   10|               Type = func() int
+#   10|             0: [ResultVariableDecl] result variable declaration
+#   10|               0: [Ident, TypeName] int
+#   10|                   Type = int
+#   10|           1: [BlockStmt] block statement
+#   10|             0: [ReturnStmt] return statement
+#   10|               0: [IntLit] 1
+#   10|                   Type = int
+#   10|                   Value = [IntLit] 1
+#   11|       1: [ExprStmt] expression statement
+#   11|         0: [CallExpr] call to myNested
+#   11|             Type = int
+#   11|           0: [Ident, VariableName] myNested
+#   11|               Type = func() int
 #   15|   4: [VarDecl] variable declaration
 #   15|     0: [ValueSpec] value declaration specifier
 #   15|       0: [Ident, VariableName] x

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstNestedFunction.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstNestedFunction.expected
@@ -1,3 +1,33 @@
+go.mod:
+#    0| [GoModFile] library-tests/semmle/go/PrintAst/go.mod
+#    1|   0: [GoModModuleLine] go.mod module line
+#    3|   1: [GoModGoLine] go.mod go line
+input.go:
+#    0| [File] library-tests/semmle/go/PrintAst/input.go
+#    5|   0: [CommentGroup] comment group
+#    5|     0: [SlashSlashComment] comment
+#    7|   1: [CommentGroup] comment group
+#    7|     0: [SlashSlashComment] comment
+#    9|   2: [DocComment] comment group
+#    9|     0: [SlashSlashComment] comment
+#   17|   3: [CommentGroup] comment group
+#   17|     0: [SlashSlashComment] comment
+#   45|   4: [DocComment] comment group
+#   45|     0: [SlashSlashComment] comment
+#   64|   5: [DocComment] comment group
+#   64|     0: [SlashSlashComment] comment
+#   74|   6: [DocComment] comment group
+#   74|     0: [SlashSlashComment] comment
+#  111|   7: [DocComment] comment group
+#  111|     0: [SlashSlashComment] comment
+#  127|   8: [DocComment] comment group
+#  127|     0: [SlashSlashComment] comment
+#  132|   9: [DocComment] comment group
+#  132|     0: [SlashSlashComment] comment
+#    3|   10: [ImportDecl] import declaration
+#    3|     0: [ImportSpec] import specifier
+#    3|       0: [StringLit] "fmt"
+#    1|   18: [Ident] main
 other.go:
 #    0| [File] library-tests/semmle/go/PrintAst/other.go
 #    8|   3: [FuncDecl] function declaration
@@ -35,33 +65,3 @@ other.go:
 #   15|           Type = int
 #   15|           Value = [IntLit] 0
 #    1|   5: [Ident] main
-go.mod:
-#    0| [GoModFile] library-tests/semmle/go/PrintAst/go.mod
-#    1|   0: [GoModModuleLine] go.mod module line
-#    3|   1: [GoModGoLine] go.mod go line
-input.go:
-#    0| [File] library-tests/semmle/go/PrintAst/input.go
-#    5|   0: [CommentGroup] comment group
-#    5|     0: [SlashSlashComment] comment
-#    7|   1: [CommentGroup] comment group
-#    7|     0: [SlashSlashComment] comment
-#    9|   2: [DocComment] comment group
-#    9|     0: [SlashSlashComment] comment
-#   17|   3: [CommentGroup] comment group
-#   17|     0: [SlashSlashComment] comment
-#   45|   4: [DocComment] comment group
-#   45|     0: [SlashSlashComment] comment
-#   64|   5: [DocComment] comment group
-#   64|     0: [SlashSlashComment] comment
-#   74|   6: [DocComment] comment group
-#   74|     0: [SlashSlashComment] comment
-#  111|   7: [DocComment] comment group
-#  111|     0: [SlashSlashComment] comment
-#  127|   8: [DocComment] comment group
-#  127|     0: [SlashSlashComment] comment
-#  132|   9: [DocComment] comment group
-#  132|     0: [SlashSlashComment] comment
-#    3|   10: [ImportDecl] import declaration
-#    3|     0: [ImportSpec] import specifier
-#    3|       0: [StringLit] "fmt"
-#    1|   18: [Ident] main

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstNestedFunction.ql
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstNestedFunction.ql
@@ -6,7 +6,9 @@ import go
 import semmle.go.PrintAst
 
 class Cfg extends PrintAstConfiguration {
-  override predicate shouldPrintFunction(FuncDecl func) { func.getName() = "g" }
+  override predicate shouldPrintFunction(FuncDecl func) { func.getName() = "hasNested" }
 
   override predicate shouldPrintFile(File file) { any() }
+
+  override predicate shouldPrintComments(File file) { any() }
 }

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.expected
@@ -15,13 +15,38 @@ other.go:
 #    6|         Type = func() 
 #    6|     1: [FuncTypeExpr] function type
 #    6|     2: [BlockStmt] block statement
-#    8|   3: [VarDecl] variable declaration
-#    8|     0: [ValueSpec] value declaration specifier
-#    8|       0: [Ident, VariableName] x
-#    8|           Type = int
-#    8|       1: [Ident, TypeName] int
-#    8|           Type = int
-#    8|       2: [IntLit] 0
-#    8|           Type = int
-#    8|           Value = [IntLit] 0
-#    1|   4: [Ident] main
+#    8|   3: [FuncDecl] function declaration
+#    8|     0: [FunctionName, Ident] hasNested
+#    8|         Type = func() 
+#    8|     1: [FuncTypeExpr] function type
+#    8|     2: [BlockStmt] block statement
+#   10|       0: [DefineStmt] ... := ...
+#   10|         0: [Ident, VariableName] myNested
+#   10|             Type = func() int
+#   10|         1: [FuncLit] function literal
+#   10|             Type = func() int
+#   10|           0: [FuncTypeExpr] function type
+#   10|               Type = func() int
+#   10|             0: [ResultVariableDecl] result variable declaration
+#   10|               0: [Ident, TypeName] int
+#   10|                   Type = int
+#   10|           1: [BlockStmt] block statement
+#   10|             0: [ReturnStmt] return statement
+#   10|               0: [IntLit] 1
+#   10|                   Type = int
+#   10|                   Value = [IntLit] 1
+#   11|       1: [ExprStmt] expression statement
+#   11|         0: [CallExpr] call to myNested
+#   11|             Type = int
+#   11|           0: [Ident, VariableName] myNested
+#   11|               Type = func() int
+#   15|   4: [VarDecl] variable declaration
+#   15|     0: [ValueSpec] value declaration specifier
+#   15|       0: [Ident, VariableName] x
+#   15|           Type = int
+#   15|       1: [Ident, TypeName] int
+#   15|           Type = int
+#   15|       2: [IntLit] 0
+#   15|           Type = int
+#   15|           Value = [IntLit] 0
+#    1|   5: [Ident] main

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.expected
@@ -1,0 +1,27 @@
+other.go:
+#    0| [File] library-tests/semmle/go/PrintAst/other.go
+#    3|   0: [FuncDecl] function declaration
+#    3|     0: [FunctionName, Ident] main
+#    3|         Type = func() 
+#    3|     1: [FuncTypeExpr] function type
+#    3|     2: [BlockStmt] block statement
+#    5|   1: [FuncDecl] function declaration
+#    5|     0: [FunctionName, Ident] f
+#    5|         Type = func() 
+#    5|     1: [FuncTypeExpr] function type
+#    5|     2: [BlockStmt] block statement
+#    6|   2: [FuncDecl] function declaration
+#    6|     0: [FunctionName, Ident] g
+#    6|         Type = func() 
+#    6|     1: [FuncTypeExpr] function type
+#    6|     2: [BlockStmt] block statement
+#    8|   3: [VarDecl] variable declaration
+#    8|     0: [ValueSpec] value declaration specifier
+#    8|       0: [Ident, VariableName] x
+#    8|           Type = int
+#    8|       1: [Ident, TypeName] int
+#    8|           Type = int
+#    8|       2: [IntLit] 0
+#    8|           Type = int
+#    8|           Value = [IntLit] 0
+#    1|   4: [Ident] main

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.ql
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.ql
@@ -6,7 +6,7 @@ import go
 import semmle.go.PrintAst
 
 class Cfg extends PrintAstConfiguration {
-  override predicate shouldPrintFunction(FuncDef func) { any() }
+  override predicate shouldPrintFunction(FuncDecl func) { any() }
 
   override predicate shouldPrintFile(File file) { file.getBaseName() = "other.go" }
 }

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.ql
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.ql
@@ -1,0 +1,12 @@
+/**
+ * @kind graph
+ */
+
+import go
+import semmle.go.PrintAst
+
+class Cfg extends PrintAstConfiguration {
+  override predicate shouldPrintFunction(FuncDef func) { any() }
+
+  override predicate shouldPrintFile(File file) { file.getBaseName() = "other.go" }
+}

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFunction.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFunction.expected
@@ -1,0 +1,47 @@
+other.go:
+#    0| [File] library-tests/semmle/go/PrintAst/other.go
+#    6|   2: [FuncDecl] function declaration
+#    6|     0: [FunctionName, Ident] g
+#    6|         Type = func() 
+#    6|     1: [FuncTypeExpr] function type
+#    6|     2: [BlockStmt] block statement
+#    8|   3: [VarDecl] variable declaration
+#    8|     0: [ValueSpec] value declaration specifier
+#    8|       0: [Ident, VariableName] x
+#    8|           Type = int
+#    8|       1: [Ident, TypeName] int
+#    8|           Type = int
+#    8|       2: [IntLit] 0
+#    8|           Type = int
+#    8|           Value = [IntLit] 0
+#    1|   4: [Ident] main
+go.mod:
+#    0| [GoModFile] library-tests/semmle/go/PrintAst/go.mod
+#    1|   0: [GoModModuleLine] go.mod module line
+#    3|   1: [GoModGoLine] go.mod go line
+input.go:
+#    0| [File] library-tests/semmle/go/PrintAst/input.go
+#    5|   0: [CommentGroup] comment group
+#    5|     0: [SlashSlashComment] comment
+#    7|   1: [CommentGroup] comment group
+#    7|     0: [SlashSlashComment] comment
+#    9|   2: [DocComment] comment group
+#    9|     0: [SlashSlashComment] comment
+#   17|   3: [CommentGroup] comment group
+#   17|     0: [SlashSlashComment] comment
+#   45|   4: [DocComment] comment group
+#   45|     0: [SlashSlashComment] comment
+#   64|   5: [DocComment] comment group
+#   64|     0: [SlashSlashComment] comment
+#   74|   6: [DocComment] comment group
+#   74|     0: [SlashSlashComment] comment
+#  111|   7: [DocComment] comment group
+#  111|     0: [SlashSlashComment] comment
+#  127|   8: [DocComment] comment group
+#  127|     0: [SlashSlashComment] comment
+#  132|   9: [DocComment] comment group
+#  132|     0: [SlashSlashComment] comment
+#    3|   10: [ImportDecl] import declaration
+#    3|     0: [ImportSpec] import specifier
+#    3|       0: [StringLit] "fmt"
+#    1|   18: [Ident] main

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFunction.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFunction.expected
@@ -1,20 +1,3 @@
-other.go:
-#    0| [File] library-tests/semmle/go/PrintAst/other.go
-#    6|   2: [FuncDecl] function declaration
-#    6|     0: [FunctionName, Ident] g
-#    6|         Type = func() 
-#    6|     1: [FuncTypeExpr] function type
-#    6|     2: [BlockStmt] block statement
-#   15|   4: [VarDecl] variable declaration
-#   15|     0: [ValueSpec] value declaration specifier
-#   15|       0: [Ident, VariableName] x
-#   15|           Type = int
-#   15|       1: [Ident, TypeName] int
-#   15|           Type = int
-#   15|       2: [IntLit] 0
-#   15|           Type = int
-#   15|           Value = [IntLit] 0
-#    1|   5: [Ident] main
 go.mod:
 #    0| [GoModFile] library-tests/semmle/go/PrintAst/go.mod
 #    1|   0: [GoModModuleLine] go.mod module line
@@ -45,3 +28,20 @@ input.go:
 #    3|     0: [ImportSpec] import specifier
 #    3|       0: [StringLit] "fmt"
 #    1|   18: [Ident] main
+other.go:
+#    0| [File] library-tests/semmle/go/PrintAst/other.go
+#    6|   2: [FuncDecl] function declaration
+#    6|     0: [FunctionName, Ident] g
+#    6|         Type = func() 
+#    6|     1: [FuncTypeExpr] function type
+#    6|     2: [BlockStmt] block statement
+#   15|   4: [VarDecl] variable declaration
+#   15|     0: [ValueSpec] value declaration specifier
+#   15|       0: [Ident, VariableName] x
+#   15|           Type = int
+#   15|       1: [Ident, TypeName] int
+#   15|           Type = int
+#   15|       2: [IntLit] 0
+#   15|           Type = int
+#   15|           Value = [IntLit] 0
+#    1|   5: [Ident] main

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFunction.ql
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFunction.ql
@@ -1,0 +1,12 @@
+/**
+ * @kind graph
+ */
+
+import go
+import semmle.go.PrintAst
+
+class Cfg extends PrintAstConfiguration {
+  override predicate shouldPrintFunction(FuncDef func) { func.getName() = "g" }
+
+  override predicate shouldPrintFile(File file) { any() }
+}

--- a/ql/test/library-tests/semmle/go/PrintAst/go.mod
+++ b/ql/test/library-tests/semmle/go/PrintAst/go.mod
@@ -1,0 +1,4 @@
+module codeql-go-tests/printast
+
+go 1.14
+

--- a/ql/test/library-tests/semmle/go/PrintAst/other.go
+++ b/ql/test/library-tests/semmle/go/PrintAst/other.go
@@ -1,0 +1,8 @@
+package main
+
+func main() {}
+
+func f() {}
+func g() {}
+
+var x int = 0

--- a/ql/test/library-tests/semmle/go/PrintAst/other.go
+++ b/ql/test/library-tests/semmle/go/PrintAst/other.go
@@ -5,4 +5,11 @@ func main() {}
 func f() {}
 func g() {}
 
+func hasNested() {
+
+	myNested := func() int { return 1 }
+	myNested()
+
+}
+
 var x int = 0


### PR DESCRIPTION
* Exclude function definitions, not just their children, when excluded by configuration
* Allow excluding files
* Allow excluding comments
* Sort root files
* Tests for all of the above