### PR TITLE
PrintAst: Label File nodes' package-name children, and ensure that child comes before all declarations

### DIFF
--- a/ql/src/semmle/go/PrintAst.qll
+++ b/ql/src/semmle/go/PrintAst.qll
@@ -195,6 +195,47 @@ class FileNode extends BaseAstNode {
   }
 
   /**
+   * Gets a child of this node, renumbering `packageNode`, our parent's
+   * `oldPackageIndex`th child, as the first child and moving others accordingly.
+   */
+  private BaseAstNode getChildPackageFirst(
+    int childIndex, BaseAstNode packageNode, int oldPackageIndex
+  ) {
+    super.getChild(oldPackageIndex) = packageNode and
+    (
+      childIndex = 0 and result = packageNode
+      or
+      result =
+        rank[childIndex](BaseAstNode node, int i |
+          node = super.getChild(i) and i != oldPackageIndex
+        |
+          node order by i
+        )
+    )
+  }
+
+  /**
+   * Gets a child of this node, moving the package-name expression to the front
+   * of the list if one exists.
+   */
+  override BaseAstNode getChild(int childIndex) {
+    if exists(ast.getPackageNameExpr())
+    then result = getChildPackageFirst(childIndex, TAstNode(ast.getPackageNameExpr()), _)
+    else result = super.getChild(childIndex)
+  }
+
+  /**
+   * Gets the label for the edge from this node to the specified child. The package name
+   * expression is named 'package'; others are numbered as per our parent's implementation
+   * of this method.
+   */
+  override string getChildEdgeLabel(int childIndex) {
+    if getChild(childIndex) = TAstNode(ast.getPackageNameExpr())
+    then result = "package"
+    else result = super.getChildEdgeLabel(childIndex)
+  }
+
+  /**
    * Gets the string representation of this File. Note explicitly using a relative path
    * like this rather than absolute as per default for the File class is a workaround for
    * a bug with codeql run test, which should replace absolute paths but currently does not.

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
@@ -4,30 +4,31 @@ go.mod:
 #    3|   1: [GoModGoLine] go.mod go line
 input.go:
 #    0| [File] library-tests/semmle/go/PrintAst/input.go
-#    5|   0: [CommentGroup] comment group
+#    1|   package: [Ident] main
+#    5|   1: [CommentGroup] comment group
 #    5|     0: [SlashSlashComment] comment
-#    7|   1: [CommentGroup] comment group
+#    7|   2: [CommentGroup] comment group
 #    7|     0: [SlashSlashComment] comment
-#    9|   2: [DocComment] comment group
+#    9|   3: [DocComment] comment group
 #    9|     0: [SlashSlashComment] comment
-#   17|   3: [CommentGroup] comment group
+#   17|   4: [CommentGroup] comment group
 #   17|     0: [SlashSlashComment] comment
-#   45|   4: [DocComment] comment group
+#   45|   5: [DocComment] comment group
 #   45|     0: [SlashSlashComment] comment
-#   64|   5: [DocComment] comment group
+#   64|   6: [DocComment] comment group
 #   64|     0: [SlashSlashComment] comment
-#   74|   6: [DocComment] comment group
+#   74|   7: [DocComment] comment group
 #   74|     0: [SlashSlashComment] comment
-#  111|   7: [DocComment] comment group
+#  111|   8: [DocComment] comment group
 #  111|     0: [SlashSlashComment] comment
-#  127|   8: [DocComment] comment group
+#  127|   9: [DocComment] comment group
 #  127|     0: [SlashSlashComment] comment
-#  132|   9: [DocComment] comment group
+#  132|   10: [DocComment] comment group
 #  132|     0: [SlashSlashComment] comment
-#    3|   10: [ImportDecl] import declaration
+#    3|   11: [ImportDecl] import declaration
 #    3|     0: [ImportSpec] import specifier
 #    3|       0: [StringLit] "fmt"
-#   10|   11: [FuncDecl] function declaration
+#   10|   12: [FuncDecl] function declaration
 #   10|     0: [FunctionName, Ident] test5
 #   10|         Type = func(bool) 
 #   10|     1: [FuncTypeExpr] function type
@@ -152,7 +153,7 @@ input.go:
 #   40|         1: [BlockStmt] block statement
 #   41|           0: [GotoStmt] goto statement
 #   41|             0: [Ident, LabelName] outer
-#   46|   12: [FuncDecl] function declaration
+#   46|   13: [FuncDecl] function declaration
 #   46|     0: [FunctionName, Ident] test6
 #   46|         Type = func(chan int, chan float32) 
 #   46|     1: [FuncTypeExpr] function type
@@ -262,7 +263,7 @@ input.go:
 #   58|                   Value = [IntLit] 42
 #   61|       3: [SelectStmt] select statement
 #   61|         0: [BlockStmt] block statement
-#   65|   13: [FuncDecl] function declaration
+#   65|   14: [FuncDecl] function declaration
 #   65|     0: [FunctionName, Ident] test7
 #   65|         Type = func(int) int
 #   65|     1: [FuncTypeExpr] function type
@@ -327,7 +328,7 @@ input.go:
 #   71|         0: [IntLit] 42
 #   71|             Type = int
 #   71|             Value = [IntLit] 42
-#   75|   14: [FuncDecl] function declaration
+#   75|   15: [FuncDecl] function declaration
 #   75|     0: [FunctionName, Ident] test8
 #   75|         Type = func(int) 
 #   75|     1: [FuncTypeExpr] function type
@@ -447,7 +448,7 @@ input.go:
 #  107|             0: [ConstantName, Ident] true
 #  107|                 Type = bool
 #  107|                 Value = [ConstantName, Ident] true
-#  112|   15: [FuncDecl] function declaration
+#  112|   16: [FuncDecl] function declaration
 #  112|     0: [FunctionName, Ident] test9
 #  112|         Type = func(interface {  }) 
 #  112|     1: [FuncTypeExpr] function type
@@ -518,7 +519,7 @@ input.go:
 #  123|                 1: [ConstantName, Ident] false
 #  123|                     Type = bool
 #  123|                     Value = [ConstantName, Ident] false
-#  128|   16: [FuncDecl] function declaration
+#  128|   17: [FuncDecl] function declaration
 #  128|     0: [FunctionName, Ident] test10
 #  128|         Type = func(func() ) 
 #  128|     1: [FuncTypeExpr] function type
@@ -533,7 +534,7 @@ input.go:
 #  129|             Type = ()
 #  129|           0: [Ident, VariableName] f
 #  129|               Type = func() 
-#  133|   17: [FuncDecl] function declaration
+#  133|   18: [FuncDecl] function declaration
 #  133|     0: [FunctionName, Ident] test11
 #  133|         Type = func([]int) 
 #  133|     1: [FuncTypeExpr] function type
@@ -595,25 +596,25 @@ input.go:
 #  145|         0: [Ident, VariableName] xs
 #  145|             Type = []int
 #  145|         1: [BlockStmt] block statement
-#    1|   18: [Ident] main
 other.go:
 #    0| [File] library-tests/semmle/go/PrintAst/other.go
-#    3|   0: [FuncDecl] function declaration
+#    1|   package: [Ident] main
+#    3|   1: [FuncDecl] function declaration
 #    3|     0: [FunctionName, Ident] main
 #    3|         Type = func() 
 #    3|     1: [FuncTypeExpr] function type
 #    3|     2: [BlockStmt] block statement
-#    5|   1: [FuncDecl] function declaration
+#    5|   2: [FuncDecl] function declaration
 #    5|     0: [FunctionName, Ident] f
 #    5|         Type = func() 
 #    5|     1: [FuncTypeExpr] function type
 #    5|     2: [BlockStmt] block statement
-#    6|   2: [FuncDecl] function declaration
+#    6|   3: [FuncDecl] function declaration
 #    6|     0: [FunctionName, Ident] g
 #    6|         Type = func() 
 #    6|     1: [FuncTypeExpr] function type
 #    6|     2: [BlockStmt] block statement
-#    8|   3: [FuncDecl] function declaration
+#    8|   4: [FuncDecl] function declaration
 #    8|     0: [FunctionName, Ident] hasNested
 #    8|         Type = func() 
 #    8|     1: [FuncTypeExpr] function type
@@ -638,7 +639,7 @@ other.go:
 #   11|             Type = int
 #   11|           0: [Ident, VariableName] myNested
 #   11|               Type = func() int
-#   15|   4: [VarDecl] variable declaration
+#   15|   5: [VarDecl] variable declaration
 #   15|     0: [ValueSpec] value declaration specifier
 #   15|       0: [Ident, VariableName] x
 #   15|           Type = int
@@ -647,4 +648,3 @@ other.go:
 #   15|       2: [IntLit] 0
 #   15|           Type = int
 #   15|           Value = [IntLit] 0
-#    1|   5: [Ident] main

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
@@ -4,10 +4,11 @@ go.mod:
 #    3|   1: [GoModGoLine] go.mod go line
 input.go:
 #    0| [File] library-tests/semmle/go/PrintAst/input.go
-#    3|   10: [ImportDecl] import declaration
+#    1|   package: [Ident] main
+#    3|   1: [ImportDecl] import declaration
 #    3|     0: [ImportSpec] import specifier
 #    3|       0: [StringLit] "fmt"
-#   10|   11: [FuncDecl] function declaration
+#   10|   2: [FuncDecl] function declaration
 #   10|     0: [FunctionName, Ident] test5
 #   10|         Type = func(bool) 
 #   10|     1: [FuncTypeExpr] function type
@@ -132,7 +133,7 @@ input.go:
 #   40|         1: [BlockStmt] block statement
 #   41|           0: [GotoStmt] goto statement
 #   41|             0: [Ident, LabelName] outer
-#   46|   12: [FuncDecl] function declaration
+#   46|   3: [FuncDecl] function declaration
 #   46|     0: [FunctionName, Ident] test6
 #   46|         Type = func(chan int, chan float32) 
 #   46|     1: [FuncTypeExpr] function type
@@ -242,7 +243,7 @@ input.go:
 #   58|                   Value = [IntLit] 42
 #   61|       3: [SelectStmt] select statement
 #   61|         0: [BlockStmt] block statement
-#   65|   13: [FuncDecl] function declaration
+#   65|   4: [FuncDecl] function declaration
 #   65|     0: [FunctionName, Ident] test7
 #   65|         Type = func(int) int
 #   65|     1: [FuncTypeExpr] function type
@@ -307,7 +308,7 @@ input.go:
 #   71|         0: [IntLit] 42
 #   71|             Type = int
 #   71|             Value = [IntLit] 42
-#   75|   14: [FuncDecl] function declaration
+#   75|   5: [FuncDecl] function declaration
 #   75|     0: [FunctionName, Ident] test8
 #   75|         Type = func(int) 
 #   75|     1: [FuncTypeExpr] function type
@@ -427,7 +428,7 @@ input.go:
 #  107|             0: [ConstantName, Ident] true
 #  107|                 Type = bool
 #  107|                 Value = [ConstantName, Ident] true
-#  112|   15: [FuncDecl] function declaration
+#  112|   6: [FuncDecl] function declaration
 #  112|     0: [FunctionName, Ident] test9
 #  112|         Type = func(interface {  }) 
 #  112|     1: [FuncTypeExpr] function type
@@ -498,7 +499,7 @@ input.go:
 #  123|                 1: [ConstantName, Ident] false
 #  123|                     Type = bool
 #  123|                     Value = [ConstantName, Ident] false
-#  128|   16: [FuncDecl] function declaration
+#  128|   7: [FuncDecl] function declaration
 #  128|     0: [FunctionName, Ident] test10
 #  128|         Type = func(func() ) 
 #  128|     1: [FuncTypeExpr] function type
@@ -513,7 +514,7 @@ input.go:
 #  129|             Type = ()
 #  129|           0: [Ident, VariableName] f
 #  129|               Type = func() 
-#  133|   17: [FuncDecl] function declaration
+#  133|   8: [FuncDecl] function declaration
 #  133|     0: [FunctionName, Ident] test11
 #  133|         Type = func([]int) 
 #  133|     1: [FuncTypeExpr] function type
@@ -575,25 +576,25 @@ input.go:
 #  145|         0: [Ident, VariableName] xs
 #  145|             Type = []int
 #  145|         1: [BlockStmt] block statement
-#    1|   18: [Ident] main
 other.go:
 #    0| [File] library-tests/semmle/go/PrintAst/other.go
-#    3|   0: [FuncDecl] function declaration
+#    1|   package: [Ident] main
+#    3|   1: [FuncDecl] function declaration
 #    3|     0: [FunctionName, Ident] main
 #    3|         Type = func() 
 #    3|     1: [FuncTypeExpr] function type
 #    3|     2: [BlockStmt] block statement
-#    5|   1: [FuncDecl] function declaration
+#    5|   2: [FuncDecl] function declaration
 #    5|     0: [FunctionName, Ident] f
 #    5|         Type = func() 
 #    5|     1: [FuncTypeExpr] function type
 #    5|     2: [BlockStmt] block statement
-#    6|   2: [FuncDecl] function declaration
+#    6|   3: [FuncDecl] function declaration
 #    6|     0: [FunctionName, Ident] g
 #    6|         Type = func() 
 #    6|     1: [FuncTypeExpr] function type
 #    6|     2: [BlockStmt] block statement
-#    8|   3: [FuncDecl] function declaration
+#    8|   4: [FuncDecl] function declaration
 #    8|     0: [FunctionName, Ident] hasNested
 #    8|         Type = func() 
 #    8|     1: [FuncTypeExpr] function type
@@ -618,7 +619,7 @@ other.go:
 #   11|             Type = int
 #   11|           0: [Ident, VariableName] myNested
 #   11|               Type = func() int
-#   15|   4: [VarDecl] variable declaration
+#   15|   5: [VarDecl] variable declaration
 #   15|     0: [ValueSpec] value declaration specifier
 #   15|       0: [Ident, VariableName] x
 #   15|           Type = int
@@ -627,4 +628,3 @@ other.go:
 #   15|       2: [IntLit] 0
 #   15|           Type = int
 #   15|           Value = [IntLit] 0
-#    1|   5: [Ident] main

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstNestedFunction.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstNestedFunction.expected
@@ -4,33 +4,34 @@ go.mod:
 #    3|   1: [GoModGoLine] go.mod go line
 input.go:
 #    0| [File] library-tests/semmle/go/PrintAst/input.go
-#    5|   0: [CommentGroup] comment group
+#    1|   package: [Ident] main
+#    5|   1: [CommentGroup] comment group
 #    5|     0: [SlashSlashComment] comment
-#    7|   1: [CommentGroup] comment group
+#    7|   2: [CommentGroup] comment group
 #    7|     0: [SlashSlashComment] comment
-#    9|   2: [DocComment] comment group
+#    9|   3: [DocComment] comment group
 #    9|     0: [SlashSlashComment] comment
-#   17|   3: [CommentGroup] comment group
+#   17|   4: [CommentGroup] comment group
 #   17|     0: [SlashSlashComment] comment
-#   45|   4: [DocComment] comment group
+#   45|   5: [DocComment] comment group
 #   45|     0: [SlashSlashComment] comment
-#   64|   5: [DocComment] comment group
+#   64|   6: [DocComment] comment group
 #   64|     0: [SlashSlashComment] comment
-#   74|   6: [DocComment] comment group
+#   74|   7: [DocComment] comment group
 #   74|     0: [SlashSlashComment] comment
-#  111|   7: [DocComment] comment group
+#  111|   8: [DocComment] comment group
 #  111|     0: [SlashSlashComment] comment
-#  127|   8: [DocComment] comment group
+#  127|   9: [DocComment] comment group
 #  127|     0: [SlashSlashComment] comment
-#  132|   9: [DocComment] comment group
+#  132|   10: [DocComment] comment group
 #  132|     0: [SlashSlashComment] comment
-#    3|   10: [ImportDecl] import declaration
+#    3|   11: [ImportDecl] import declaration
 #    3|     0: [ImportSpec] import specifier
 #    3|       0: [StringLit] "fmt"
-#    1|   18: [Ident] main
 other.go:
 #    0| [File] library-tests/semmle/go/PrintAst/other.go
-#    8|   3: [FuncDecl] function declaration
+#    1|   package: [Ident] main
+#    8|   1: [FuncDecl] function declaration
 #    8|     0: [FunctionName, Ident] hasNested
 #    8|         Type = func() 
 #    8|     1: [FuncTypeExpr] function type
@@ -55,7 +56,7 @@ other.go:
 #   11|             Type = int
 #   11|           0: [Ident, VariableName] myNested
 #   11|               Type = func() int
-#   15|   4: [VarDecl] variable declaration
+#   15|   2: [VarDecl] variable declaration
 #   15|     0: [ValueSpec] value declaration specifier
 #   15|       0: [Ident, VariableName] x
 #   15|           Type = int
@@ -64,4 +65,3 @@ other.go:
 #   15|       2: [IntLit] 0
 #   15|           Type = int
 #   15|           Value = [IntLit] 0
-#    1|   5: [Ident] main

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.expected
@@ -1,21 +1,22 @@
 other.go:
 #    0| [File] library-tests/semmle/go/PrintAst/other.go
-#    3|   0: [FuncDecl] function declaration
+#    1|   package: [Ident] main
+#    3|   1: [FuncDecl] function declaration
 #    3|     0: [FunctionName, Ident] main
 #    3|         Type = func() 
 #    3|     1: [FuncTypeExpr] function type
 #    3|     2: [BlockStmt] block statement
-#    5|   1: [FuncDecl] function declaration
+#    5|   2: [FuncDecl] function declaration
 #    5|     0: [FunctionName, Ident] f
 #    5|         Type = func() 
 #    5|     1: [FuncTypeExpr] function type
 #    5|     2: [BlockStmt] block statement
-#    6|   2: [FuncDecl] function declaration
+#    6|   3: [FuncDecl] function declaration
 #    6|     0: [FunctionName, Ident] g
 #    6|         Type = func() 
 #    6|     1: [FuncTypeExpr] function type
 #    6|     2: [BlockStmt] block statement
-#    8|   3: [FuncDecl] function declaration
+#    8|   4: [FuncDecl] function declaration
 #    8|     0: [FunctionName, Ident] hasNested
 #    8|         Type = func() 
 #    8|     1: [FuncTypeExpr] function type
@@ -40,7 +41,7 @@ other.go:
 #   11|             Type = int
 #   11|           0: [Ident, VariableName] myNested
 #   11|               Type = func() int
-#   15|   4: [VarDecl] variable declaration
+#   15|   5: [VarDecl] variable declaration
 #   15|     0: [ValueSpec] value declaration specifier
 #   15|       0: [Ident, VariableName] x
 #   15|           Type = int
@@ -49,4 +50,3 @@ other.go:
 #   15|       2: [IntLit] 0
 #   15|           Type = int
 #   15|           Value = [IntLit] 0
-#    1|   5: [Ident] main

--- a/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFunction.expected
+++ b/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFunction.expected
@@ -4,38 +4,39 @@ go.mod:
 #    3|   1: [GoModGoLine] go.mod go line
 input.go:
 #    0| [File] library-tests/semmle/go/PrintAst/input.go
-#    5|   0: [CommentGroup] comment group
+#    1|   package: [Ident] main
+#    5|   1: [CommentGroup] comment group
 #    5|     0: [SlashSlashComment] comment
-#    7|   1: [CommentGroup] comment group
+#    7|   2: [CommentGroup] comment group
 #    7|     0: [SlashSlashComment] comment
-#    9|   2: [DocComment] comment group
+#    9|   3: [DocComment] comment group
 #    9|     0: [SlashSlashComment] comment
-#   17|   3: [CommentGroup] comment group
+#   17|   4: [CommentGroup] comment group
 #   17|     0: [SlashSlashComment] comment
-#   45|   4: [DocComment] comment group
+#   45|   5: [DocComment] comment group
 #   45|     0: [SlashSlashComment] comment
-#   64|   5: [DocComment] comment group
+#   64|   6: [DocComment] comment group
 #   64|     0: [SlashSlashComment] comment
-#   74|   6: [DocComment] comment group
+#   74|   7: [DocComment] comment group
 #   74|     0: [SlashSlashComment] comment
-#  111|   7: [DocComment] comment group
+#  111|   8: [DocComment] comment group
 #  111|     0: [SlashSlashComment] comment
-#  127|   8: [DocComment] comment group
+#  127|   9: [DocComment] comment group
 #  127|     0: [SlashSlashComment] comment
-#  132|   9: [DocComment] comment group
+#  132|   10: [DocComment] comment group
 #  132|     0: [SlashSlashComment] comment
-#    3|   10: [ImportDecl] import declaration
+#    3|   11: [ImportDecl] import declaration
 #    3|     0: [ImportSpec] import specifier
 #    3|       0: [StringLit] "fmt"
-#    1|   18: [Ident] main
 other.go:
 #    0| [File] library-tests/semmle/go/PrintAst/other.go
-#    6|   2: [FuncDecl] function declaration
+#    1|   package: [Ident] main
+#    6|   1: [FuncDecl] function declaration
 #    6|     0: [FunctionName, Ident] g
 #    6|         Type = func() 
 #    6|     1: [FuncTypeExpr] function type
 #    6|     2: [BlockStmt] block statement
-#   15|   4: [VarDecl] variable declaration
+#   15|   2: [VarDecl] variable declaration
 #   15|     0: [ValueSpec] value declaration specifier
 #   15|       0: [Ident, VariableName] x
 #   15|           Type = int
@@ -44,4 +45,3 @@ other.go:
 #   15|       2: [IntLit] 0
 #   15|           Type = int
 #   15|           Value = [IntLit] 0
-#    1|   5: [Ident] main


### PR DESCRIPTION
As requested in https://github.com/github/codeql-go/issues/265