### PR TITLE
CodeQL: complete LGTM suites

### DIFF
--- a/ql/src/codeql-suites/go-lgtm-full.qls
+++ b/ql/src/codeql-suites/go-lgtm-full.qls
@@ -7,3 +7,5 @@
     tags contain:
       - ide-contextual-queries/local-definitions
       - ide-contextual-queries/local-references
+- query: Metrics/FLinesOfCode.ql
+


### PR DESCRIPTION
This PR extends the `lgtm-full.qls` suite to also include the non-alert queries that LGTM runs. This is important when we switch to using CodeQL instead of ODASA in LGTM.

@max-schaefer 