### PR TITLE
Escape go-fmt file filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ DATAFLOW_BRANCH=master
 
 autoformat:
 	find ql/src -name "*.ql" -or -name "*.qll" | xargs codeql query format -qq -i
-	git ls-files | grep \\.go$ | xargs grep -L "//\s*autoformat-ignore" | xargs gofmt -w
+	git ls-files | grep \\.go$$ | xargs grep -L "//\s*autoformat-ignore" | xargs gofmt -w
 
 check-formatting:
 	find ql/src -name "*.ql" -or -name "*.qll" | xargs codeql query format --check-only


### PR DESCRIPTION
This should have been looking for \.go$, but I forgot to escape the dollar sign in a Makefile