### PR TITLE
Speed up `unresolvedReference`.

### DIFF
--- a/ql/src/semmle/go/dataflow/SSA.qll
+++ b/ql/src/semmle/go/dataflow/SSA.qll
@@ -42,12 +42,20 @@ class SsaSourceVariable extends LocalVariable {
  */
 private predicate unresolvedReference(string name, FuncDef fn) {
   exists(Ident unresolved |
-    unresolved.getName() = name and
-    unresolved instanceof ReferenceExpr and
+    unresolvedIdentifier(unresolved, name) and
     not unresolved = any(SelectorExpr sel).getSelector() and
-    not unresolved.refersTo(_) and
     fn = unresolved.getEnclosingFunction()
   )
+}
+
+/**
+ * Holds if `id` is an unresolved identifier with the given `name`.
+ */
+pragma[noinline]
+private predicate unresolvedIdentifier(Ident id, string name) {
+  id.getName() = name and
+  id instanceof ReferenceExpr and
+  not id.refersTo(_)
 }
 
 /**


### PR DESCRIPTION
Initial evaluation was positive, but with a few outliers in both directions:

Project | before | after | after/before
--|--|--|-
gobot_9a9d580de37056c636751930c9b33c03c294d3a9 | 135 | 59 | 0.437037
hydra_7f50b944ea7a0bc02f37a08c860670bd33453986 | 86 | 42 | 0.488372
gobot_9b97c70ca6bed3ef922d8e43a01e4524e956a04a | 98 | 60 | 0.612245
sourcegraph_bde46f4ae891ca5bccaab042cab8fa72f6c2b165 | 237 | 175 | 0.738397
hydra_9b5bbd48a72096930af08402c5e07fce7dd770f3 | 50 | 42 | 0.84
sourcegraph_2555ef0e46d4b0c457cb1894d63773af48821388 | 214 | 186 | 0.869159
lyft-go-samples | 21 | 20 | 0.952381
pam-ussh | 21 | 20 | 0.952381
image_a3d69a4a89244803d2f5350aca6dd0fcbe444551 | 44 | 42 | 0.954545
assume-role-cli | 23 | 22 | 0.956522
carbonserver | 23 | 22 | 0.956522
lyft-go-sdk | 23 | 22 | 0.956522
carbonzipper | 25 | 24 | 0.96
kubernetes_47063891dd782835170f500a83f37cc98c3c1013 | 1529 | 1469 | 0.960759
archiver | 26 | 25 | 0.961538
protoc-gen-star | 26 | 25 | 0.961538
gogs_1f247cf8139cb483276cd8dd06385a800ce9d4b2 | 83 | 80 | 0.963855
go-jose_789a4c4bd4c118f7564954f441b29c153ccd6a96 | 29 | 28 | 0.965517
carbonapi | 30 | 29 | 0.966667
gorm | 31 | 30 | 0.967742
kiam | 31 | 30 | 0.967742
thrift_264a3f318ed3e9e51573f67f963c8509786bcec2 | 32 | 31 | 0.96875
client-go_689d090711762a4ab315320d706d3c9e3b225d3d | 103 | 100 | 0.970874
dns_833bf76c282d338e307ff7ec181b95cfc117deb2 | 45 | 44 | 0.977778
ngrok | 51 | 50 | 0.980392
tchannel-go | 52 | 51 | 0.980769
zanzibar | 180 | 177 | 0.983333
tilt | 65 | 64 | 0.984615
aws-sdk-go | 1519 | 1496 | 0.984858
beego | 71 | 70 | 0.985915
client-go_66e83da33c604751671a39f929644b8f471e5cd9 | 99 | 98 | 0.989899
concourse_fabee1733ee9d084604c909fff2a015dcb21dd8e | 157 | 156 | 0.993631
kubernetes | 748 | 747 | 0.998663
aresdb | 121 | 121 | 1
astro | 26 | 26 | 1
authenticator | 32 | 32 | 1
cadvisor | 43 | 43 | 1
cherami-client-go | 26 | 26 | 1
cni-ipvlan-vpc-k8s | 27 | 27 | 1
concourse_091671e19b3779e439f5ad4a6b4b89aa20a33778 | 152 | 152 | 1
dns_501e858f679edecd4a38a86317ce50271014a80d | 44 | 44 | 1
flytestdlib | 31 | 31 | 1
go-blessclient | 26 | 26 | 1
go-jose_d00415a0a4fdbcfbdf69deae1fe07fc953d9e76d | 29 | 29 | 1
gonduit | 21 | 21 | 1
goruntime | 20 | 20 | 1
image_8ad47b442feae0a21bff51a6058227fa1e45bb41 | 43 | 43 | 1
makisu | 40 | 40 | 1
oauth2_proxy_712739f7775378d39b8a6f6c8051188962062e9b | 29 | 29 | 1
orangeforum_1f6313cb3a1e755880fc1354f3e1efc4dd2dd4aa | 28 | 28 | 1
plugins | 27 | 27 | 1
ringpop-go | 35 | 35 | 1
smokescreen | 21 | 21 | 1
spark-on-k8s-operator | 33 | 33 | 1
sqlx | 23 | 23 | 1
storagetapper | 41 | 41 | 1
thrift_6e5c0f6e315ea1cd8526789558bfd10d6cee2173 | 32 | 32 | 1
gogs_c9bb33afc3ae35db21b26fd914bd80ca277a4e0d | 82 | 83 | 1.0122
kubernetes_7fbfe70147f963bc1fd2b0376d7efc116cc757a8 | 1507 | 1526 | 1.01261
nomad | 230 | 233 | 1.01304
concourse_dc3d15ab6c3a69890c9985f9c875d4c2949be727 | 149 | 152 | 1.02013
cadence | 393 | 401 | 1.02036
cockroach | 2567 | 2620 | 1.02065
prototool | 41 | 42 | 1.02439
cherami-server | 89 | 92 | 1.03371
oauth2_proxy_289a6ccf463a425c7606178c510fc5eeb9c8b050 | 29 | 30 | 1.03448
orangeforum_3f73f963cdf0b9093877711f0d84ff091683e452 | 28 | 29 | 1.03571
concourse_38cb4cc025e5ed28764b4adc363a0bbf41f3c7cb | 150 | 156 | 1.04
gojenkins | 23 | 24 | 1.04348
gostats | 23 | 24 | 1.04348
go-torch | 20 | 21 | 1.05
tcheck | 20 | 21 | 1.05
uberalls | 20 | 21 | 1.05
go_reuseport | 19 | 20 | 1.05263
arachne | 22 | 24 | 1.09091
vitess | 283 | 336 | 1.18728
rclone | 171 | 221 | 1.2924
source-to-image | 37 | 93 | 2.51351

These disappeared on rerunning:

Project | before | after | after/before
--|--|--|--
source-to-image | 36 | 35 | 0.972222
rclone | 171 | 167 | 0.976608
gobot_9a9d580de37056c636751930c9b33c03c294d3a9 | 59 | 58 | 0.983051
arachne | 24 | 24 | 1
gobot_9b97c70ca6bed3ef922d8e43a01e4524e956a04a | 57 | 57 | 1
hydra_7f50b944ea7a0bc02f37a08c860670bd33453986 | 41 | 41 | 1
hydra_9b5bbd48a72096930af08402c5e07fce7dd770f3 | 41 | 41 | 1
terraform | 169 | 169 | 1
vitess | 283 | 284 | 1.00353
sourcegraph_bde46f4ae891ca5bccaab042cab8fa72f6c2b165 | 172 | 175 | 1.01744

On the whole, this looks like a fairly consistent small speedup.