### PR TITLE
Improve performance of upgrade script

### DIFF
--- a/upgrades/ee5c327face2866a7b3b12dcce5c291be52ebf52/upgrade_comment_groups.ql
+++ b/upgrades/ee5c327face2866a7b3b12dcce5c291be52ebf52/upgrade_comment_groups.ql
@@ -33,6 +33,7 @@ Location getLocation(CommentGroup cg) {
   not exists(cg.getLocation()) and result = cg.getComment(0).getLocation()
 }
 
+pragma[noinline]
 predicate hasLocation(CommentGroup cg, File f, int startLine) {
   exists(Location loc | loc = getLocation(cg) |
     f = loc.getFile() and

--- a/upgrades/ee5c327face2866a7b3b12dcce5c291be52ebf52/upgrade_comment_groups.ql
+++ b/upgrades/ee5c327face2866a7b3b12dcce5c291be52ebf52/upgrade_comment_groups.ql
@@ -33,12 +33,15 @@ Location getLocation(CommentGroup cg) {
   not exists(cg.getLocation()) and result = cg.getComment(0).getLocation()
 }
 
-from CommentGroup cg, File f, int idx
+predicate hasLocation(CommentGroup cg, File f, int startLine) {
+  exists(Location loc | loc = getLocation(cg) |
+    f = loc.getFile() and
+    startLine = loc.getStartLine()
+  )
+}
+
+from CommentGroup cg, File file, int idx
 where
-  f = getLocation(cg).getFile() and
-  rank[idx + 1](CommentGroup rankedcg |
-    getLocation(rankedcg).getFile() = f
-  |
-    rankedcg order by getLocation(rankedcg).getStartLine()
-  ) = cg
-select cg, f, idx
+  hasLocation(cg, file, _) and
+  cg = rank[idx + 1](CommentGroup cg2, int line | hasLocation(cg2, file, line) | cg2 order by line)
+select cg, file, idx


### PR DESCRIPTION
I noticed that this script was taking a very long time to upgrade a database of `cockroach` downloaded from LGTM.com, probably due to a bad join ordering. This seems to fix it.