### PR TITLE
Extend negativeLengthCheck query to unsigned integers

### DIFF
--- a/change-notes/2020-08-07-negative-length-check.md
+++ b/change-notes/2020-08-07-negative-length-check.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* Query "Redundant check for negative value" (`go/negative-length-check`) has been expanded to consider unsigned integers, along
+  with the return values of `len` and `cap` which it already handled. It has also been renamed to match its expanded role.

--- a/ql/src/RedundantCode/NegativeLengthCheck.qhelp
+++ b/ql/src/RedundantCode/NegativeLengthCheck.qhelp
@@ -10,7 +10,7 @@ never less than zero. Hence, checking whether the result of a call to <code>len<
 is either redundant or indicates a logic mistake.
 </p>
 <p>
-The same applies to the built-in function <code>cap</code>.
+The same applies to the built-in function <code>cap</code>, and to unsigned integer values.
 </p>
 </overview>
 

--- a/ql/test/query-tests/RedundantCode/NegativeLengthCheck/NegativeLengthCheck.expected
+++ b/ql/test/query-tests/RedundantCode/NegativeLengthCheck/NegativeLengthCheck.expected
@@ -3,3 +3,5 @@
 | main.go:14:5:14:20 | ...<... | 'cap' is always non-negative, and hence cannot be less than 0. |
 | main.go:18:5:18:22 | ...<=... | 'len' is always non-negative, and hence cannot be less than -1. |
 | main.go:22:5:22:22 | ...==... | 'len' is always non-negative, and hence cannot equal -1. |
+| main.go:28:9:28:13 | ...<... | This unsigned value is always non-negative, and hence cannot be less than 0. |
+| main.go:36:9:36:15 | ...==... | This unsigned value is always non-negative, and hence cannot equal -1. |

--- a/ql/test/query-tests/RedundantCode/NegativeLengthCheck/main.go
+++ b/ql/test/query-tests/RedundantCode/NegativeLengthCheck/main.go
@@ -23,3 +23,15 @@ func main() {
 		println("No arguments provided.")
 	}
 }
+
+func checkNegative(x uint) bool {
+	return x < 0 // NOT OK
+}
+
+func checkNonPositive(x uint) bool {
+	return x <= 0 // OK
+}
+
+func checkIsMinusOne(x uint) bool {
+	return x == -1 // NOT OK
+}


### PR DESCRIPTION
Like return values from len and cap, unsigned integers are never negative.

This allows us to catch [CVE-2018-18206](https://www.whitesourcesoftware.com/vulnerability-database/CVE-2018-18206).