### PR TITLE
Restore repo layout post-autobuild

### DIFF
--- a/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -149,7 +149,7 @@ func restoreRepoLayout(fromDir string, dirEntries []string, scratchDirName strin
 			log.Printf("Restoring %s/%s to %s/%s.\n", fromDir, dirEntry, toDir, dirEntry)
 			err := os.Rename(filepath.Join(fromDir, dirEntry), filepath.Join(toDir, dirEntry))
 			if err != nil {
-				log.Fatalf("Failed to move file/directory %s from directory %s to directory %s: %s\n", dirEntry, fromDir, toDir, err.Error())
+				log.Printf("Failed to move file/directory %s from directory %s to directory %s: %s\n", dirEntry, fromDir, toDir, err.Error())
 			}
 		}
 	}


### PR DESCRIPTION
This works fine in testing, so long as the DB is outside the source tree:

```
chris@orchard:/tmp/x$ SEMMLE_REPO_URL=http://chriskindrepos.org/myorg/myproj codeql database create --language=go ../y
Initializing database at /private/tmp/y.
Running command [/Users/chris/codeql-home/codeql-go/build/codeql-extractor-go/tools/autobuild.sh] in /private/tmp/x.
[2020-08-13 12:57:50] [build-err] 2020/08/13 12:57:50 Autobuilder was built with go1.14.4, environment has go1.14.4
[2020-08-13 12:57:50] [build-err] 2020/08/13 12:57:50 LGTM_SRC is /tmp/x
[2020-08-13 12:57:50] [build-err] 2020/08/13 12:57:50 Import path is 'chriskindrepos.org/myorg/myproj'
[2020-08-13 12:57:50] [build-err] 2020/08/13 12:57:50 Temporary directory is /tmp/x/scratch382870414.
[2020-08-13 12:57:50] [build-err] 2020/08/13 12:57:50 Moving /tmp/x/test.go to /tmp/x/scratch382870414/test.go.
[2020-08-13 12:57:50] [build-err] 2020/08/13 12:57:50 Moving /tmp/x/test2.go to /tmp/x/scratch382870414/test2.go.
[2020-08-13 12:57:50] [build-err] 2020/08/13 12:57:50 Moving /tmp/x/somedir to /tmp/x/scratch382870414/somedir.
[2020-08-13 12:57:50] [build-err] 2020/08/13 12:57:50 Moving /tmp/x/scratch382870414 to /tmp/x/root/src/chriskindrepos.org/myorg/myproj.
[2020-08-13 12:57:50] [build-err] 2020/08/13 12:57:50 GOPATH set to /tmp/x/root.
[2020-08-13 12:57:50] [build-err] 2020/08/13 12:57:50 Installing dependencies using `go get -v ./...`.
[2020-08-13 12:57:50] [build-err] chriskindrepos.org/myorg/myproj/somedir
[2020-08-13 12:57:50] [build-err] chriskindrepos.org/myorg/myproj
[2020-08-13 12:57:50] [build-err] 2020/08/13 12:57:50 Running extractor command '/Users/chris/codeql-home/codeql-go/build/codeql-extractor-go/tools/osx64/go-extractor ./...' from directory '/private/tmp/x/root/src/chriskindrepos.org/myorg/myproj'.
[2020-08-13 12:57:51] [build-err] 2020/08/13 12:57:51 Extracting /private/tmp/x/root/src/chriskindrepos.org/myorg/myproj/test.go
[2020-08-13 12:57:51] [build-err] 2020/08/13 12:57:51 Extracting /private/tmp/x/root/src/chriskindrepos.org/myorg/myproj/test2.go
[2020-08-13 12:57:51] [build-err] 2020/08/13 12:57:51 Extracting /private/tmp/x/root/src/chriskindrepos.org/myorg/myproj/somedir/test3.go
[2020-08-13 12:57:51] [build-err] 2020/08/13 12:57:51 Done extracting /private/tmp/x/root/src/chriskindrepos.org/myorg/myproj/test2.go (2ms)
[2020-08-13 12:57:51] [build-err] 2020/08/13 12:57:51 Done extracting /private/tmp/x/root/src/chriskindrepos.org/myorg/myproj/somedir/test3.go (2ms)
[2020-08-13 12:57:51] [build-err] 2020/08/13 12:57:51 Done extracting /private/tmp/x/root/src/chriskindrepos.org/myorg/myproj/test.go (2ms)
[2020-08-13 12:57:51] [build-err] 2020/08/13 12:57:51 Restoring /tmp/x/root/src/chriskindrepos.org/myorg/myproj/test.go to /tmp/x/test.go.
[2020-08-13 12:57:51] [build-err] 2020/08/13 12:57:51 Restoring /tmp/x/root/src/chriskindrepos.org/myorg/myproj/test2.go to /tmp/x/test2.go.
[2020-08-13 12:57:51] [build-err] 2020/08/13 12:57:51 Restoring /tmp/x/root/src/chriskindrepos.org/myorg/myproj/somedir to /tmp/x/somedir.
Finalizing database at /private/tmp/y.
Successfully created database at /private/tmp/y.
```

I have no idea how to test this in the real world: I'd need code-scanning or lgtm to use my pre-release autobuilder instead of the shipped one.