### PR TITLE
Revert "Downgrade to checkout@v1 to work around https://github.com/actions/checkout/issues/237"

### DIFF
--- a/.github/workflows/codeqltest.yml
+++ b/.github/workflows/codeqltest.yml
@@ -28,7 +28,7 @@ jobs:
         echo "Done"
 
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build
       run: env PATH=$PATH:$HOME/codeql make
@@ -64,7 +64,7 @@ jobs:
         echo "Done"
 
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build
       run: env PATH=$PATH:$HOME/codeql make
@@ -97,7 +97,7 @@ jobs:
         echo "Done"
 
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build
       run: |


### PR DESCRIPTION
This reverts commit 8aaa7c89252ae7a4aca91b03ac1a3e703eb2b1de.

The bug it was working around (if it ever did) has been fixed.