### PR TITLE
Update bad / good message for CWE 079

### DIFF
--- a/ql/src/Security/CWE-079/ReflectedXssGood.go
+++ b/ql/src/Security/CWE-079/ReflectedXssGood.go
@@ -11,7 +11,7 @@ func serve1() {
 		r.ParseForm()
 		username := r.Form.Get("username")
 		if !isValidUsername(username) {
-			// BAD: a request parameter is incorporated without validation into the response
+			// GOOD: a request parameter is escaped before being put into the response
 			fmt.Fprintf(w, "%q is an unknown user", html.EscapeString(username))
 		} else {
 			// TODO: do something exciting

--- a/ql/test/query-tests/Security/CWE-079/ReflectedXssGood.go
+++ b/ql/test/query-tests/Security/CWE-079/ReflectedXssGood.go
@@ -11,7 +11,7 @@ func serve1() {
 		r.ParseForm()
 		username := r.Form.Get("username")
 		if !isValidUsername(username) {
-			// BAD: a request parameter is incorporated without validation into the response
+			// GOOD: a request parameter is escaped before being put into the response
 			fmt.Fprintf(w, "%q is an unknown user", html.EscapeString(username))
 		} else {
 			// TODO: do something exciting


### PR DESCRIPTION
Previously, the "good" example still had the "BAD: " comment in it which was confusing.

This change updates the good example to have a "GOOD: " comment instead.