### PR TITLE
Prevent misoptimisation in `StringOps`.

### DIFF
--- a/ql/src/semmle/go/StringOps.qll
+++ b/ql/src/semmle/go/StringOps.qll
@@ -67,7 +67,7 @@ module StringOps {
     }
 
     /**
-     * An expression of form `strings.HasPrefix(A, B)`.
+     * An expression of the form `strings.HasPrefix(A, B)`.
      */
     private class StringsHasPrefix extends Range, DataFlow::CallNode {
       StringsHasPrefix() { getTarget().hasQualifiedName("strings", "HasPrefix") }
@@ -89,7 +89,7 @@ module StringOps {
     }
 
     /**
-     * An expression of form `strings.Index(A, B) == 0`.
+     * An expression of the form `strings.Index(A, B) == 0`.
      */
     private class HasPrefix_IndexOfEquals extends Range, DataFlow::EqualityTestNode {
       DataFlow::CallNode indexOf;
@@ -122,7 +122,7 @@ module StringOps {
     }
 
     /**
-     * A comparison of form `x[0] == 'k'` for some rune literal `k`.
+     * A comparison of the form `x[0] == 'k'` for some rune literal `k`.
      */
     private class HasPrefix_FirstCharacter extends Range, DataFlow::EqualityTestNode {
       DataFlow::Node base;
@@ -138,7 +138,7 @@ module StringOps {
     }
 
     /**
-     * A comparison of form `x[:len(y)] === y`.
+     * A comparison of the form `x[:len(y)] == y`.
      */
     private class HasPrefix_Substring extends Range, DataFlow::EqualityTestNode {
       DataFlow::SliceNode slice;

--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -669,6 +669,13 @@ class BinaryOperationNode extends Node {
 
   /** Gets the operator of this operation. */
   string getOperator() { result = op }
+
+  /** Holds if `x` and `y` are the operands of this operation, in either order. */
+  predicate hasOperands(Node x, Node y) {
+    x = getAnOperand() and
+    y = getAnOperand() and
+    x != y
+  }
 }
 
 /**


### PR DESCRIPTION
This is a regression relative to 1.24, hence a hotfix.