### PR TITLE
Add change note for Gin framework

### DIFF
--- a/change-notes/2020-08-19-gin-model.md
+++ b/change-notes/2020-08-19-gin-model.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Basic support for the [Gin](https://github.com/gin-gonic/gin) HTTP library has been added (extending UntrustedFlowSource), which may lead to more results from the security queries.


### PR DESCRIPTION
This was originally put in too early because the Gin framework was
accidentally not added to the default includes.

This reverts commit 41e98d6afc0d4ef7be25c8545231eb6589c8bb58.