### PR TITLE
Autobuilder: always check the vendor directory works and if go.mod exists

### DIFF
--- a/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -244,7 +244,10 @@ func main() {
 	// skip the dependency installation step and run the extractor with `-mod=vendor`
 	if util.FileExists("vendor/modules.txt") {
 		modMode = ModVendor
+	} else if util.DirExists("vendor") {
+		modMode = modModIfSupported()
 	}
+
 	if modMode == ModVendor {
 		// fix go vendor issues with go versions >= 1.14 when no go version is specified in the go.mod
 		// if this is the case, and dependencies were vendored with an old go version (and therefore

--- a/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -508,8 +508,13 @@ func main() {
 	}
 
 	var cmd *exec.Cmd
-	log.Printf("Running extractor command '%s %s ./...' from directory '%s'.\n", extractor, modMode, cwd)
-	cmd = exec.Command(extractor, modMode.String(), "./...")
+	if depMode == GoGetWithModules && modMode.String() != "" {
+		log.Printf("Running extractor command '%s %s ./...' from directory '%s'.\n", extractor, modMode, cwd)
+		cmd = exec.Command(extractor, modMode.String(), "./...")
+	} else {
+		log.Printf("Running extractor command '%s ./...' from directory '%s'.\n", extractor, cwd)
+		cmd = exec.Command(extractor, "./...")
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()

--- a/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -393,16 +393,17 @@ func main() {
 			tryBuild("build", "./build") ||
 			tryBuild("build.sh", "./build.sh")
 
-		if !buildSucceeded {
-			if modMode == ModVendor {
-				// test if running `go` with -mod=vendor works, and if it doesn't, try to fallback to -mod=mod
-				// or not set if the go version < 1.14.
-				if !checkVendor() {
-					modMode = modModIfSupported()
-					log.Println("The vendor directory is not consistent with the go.mod; not using vendored dependencies.")
-				}
+		if modMode == ModVendor {
+			// test if running `go` with -mod=vendor works, and if it doesn't, try to fallback to -mod=mod
+			// or not set if the go version < 1.14. Note we check this post-build in case the build brings
+			// the vendor directory up to date.
+			if !checkVendor() {
+				modMode = modModIfSupported()
+				log.Println("The vendor directory is not consistent with the go.mod; not using vendored dependencies.")
 			}
+		}
 
+		if !buildSucceeded {
 			if modMode == ModVendor {
 				log.Printf("Skipping dependency installation because a Go vendor directory was found.")
 			} else {

--- a/extractor/util/util.go
+++ b/extractor/util/util.go
@@ -91,3 +91,12 @@ func FileExists(filename string) bool {
 	}
 	return err == nil && !info.IsDir()
 }
+
+// DirExists tests whether `filename` exists and is a directory.
+func DirExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if err != nil && !os.IsNotExist(err) {
+		log.Printf("Unable to stat %s: %s\n", filename, err.Error())
+	}
+	return err == nil && info.IsDir()
+}


### PR DESCRIPTION
This is #310 with additions:
* Always check vendor/ is usable if we're about to use it
* Only use `-mod` when go.mod exists
* Factor the paths using `checkVendor` (optional, could drop)

Locally verified this fixes a further 24 projects; proceeding to build a dist and check on all projects.