### PR TITLE
Fix frontend errors in test.

### DIFF
--- a/ql/test/query-tests/Security/CWE-190/tst3.go
+++ b/ql/test/query-tests/Security/CWE-190/tst3.go
@@ -14,7 +14,7 @@ func testSanitizers(s string) {
 
 	{
 		newlength := len(jsonData) + 2 // OK: there is an upper bound check which dominates `make`
-		_ := newlength - 1
+		ignore(newlength - 1)
 		if newlength < 1000 {
 			ignore(make([]byte, newlength))
 		}
@@ -31,7 +31,7 @@ func testSanitizers(s string) {
 	{
 		newlength := len(jsonData) + 4 // NOT OK: there is an upper bound check but it doesn't dominate `make`
 		if newlength < 1000 {
-			_ := newlength + 2
+			ignore(newlength + 2)
 		}
 		ignore(make([]byte, newlength))
 	}


### PR DESCRIPTION
Introduced in https://github.com/github/codeql-go/pull/309, which was based on a version of `master` that didn't have the consistency checks yet.