### PR TITLE
Revert "Revert "autobuilder: Add support for GITHUB_REPOSITORY environment variable""

### DIFF
--- a/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -34,7 +34,7 @@ This behavior can be further customized using environment variables: setting LGT
 to 'false' disables the GOPATH set-up, CODEQL_EXTRACTOR_GO_BUILD_COMMAND (or alternatively
 LGTM_INDEX_BUILD_COMMAND), can be set to a newline-separated list of commands to run in order to
 install dependencies, and LGTM_INDEX_IMPORT_PATH can be used to override the package import path,
-which is otherwise inferred from the SEMMLE_REPO_URL environment variable.
+which is otherwise inferred from the SEMMLE_REPO_URL or GITHUB_REPOSITORY environment variables.
 
 In resource-constrained environments, the environment variable CODEQL_EXTRACTOR_GO_MAX_GOROUTINES
 (or its legacy alias SEMMLE_MAX_GOROUTINES) can be used to limit the number of parallel goroutines
@@ -100,13 +100,19 @@ func getImportPath() (importpath string) {
 	if importpath == "" {
 		repourl := os.Getenv("SEMMLE_REPO_URL")
 		if repourl == "" {
-			log.Printf("Unable to determine import path, as neither LGTM_INDEX_IMPORT_PATH nor SEMMLE_REPO_URL is set\n")
-			return ""
-		}
-		importpath = getImportPathFromRepoURL(repourl)
-		if importpath == "" {
-			log.Printf("Failed to determine import path from SEMMLE_REPO_URL '%s'\n", repourl)
-			return
+			githubrepo := os.Getenv("GITHUB_REPOSITORY")
+			if githubrepo == "" {
+				log.Printf("Unable to determine import path, as neither LGTM_INDEX_IMPORT_PATH nor GITHUB_REPOSITORY is set\n")
+				return ""
+			} else {
+				importpath = "github.com/" + githubrepo
+			}
+		} else {
+			importpath = getImportPathFromRepoURL(repourl)
+			if importpath == "" {
+				log.Printf("Failed to determine import path from SEMMLE_REPO_URL '%s'\n", repourl)
+				return
+			}
 		}
 	}
 	log.Printf("Import path is '%s'\n", importpath)


### PR DESCRIPTION
This reverts commit ccfccb4828cf5b2b90035ab2b22d2098418c43ea, effectively reinstating #165. This should be safe now that https://github.com/github/codeql-go/pull/287 has been merged.