### PR TITLE
Add PostUpdateNodes for nested structs and arrays

### DIFF
--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -416,6 +416,15 @@ class ReceiverNode extends ParameterNode {
   predicate isReceiverOf(MethodDecl m) { parm.isReceiverOf(m) }
 }
 
+private Node getADirectlyWrittenNode() {
+  exists(Write w | w.writesField(result, _, _) or w.writesElement(result, _, _))
+}
+
+private Node getAWrittenNode() {
+  result = getADirectlyWrittenNode() or
+  result = getADirectlyWrittenNode().(ComponentReadNode).getBase+()
+}
+
 /**
  * A node associated with an object after an operation that might have
  * changed its state.
@@ -439,12 +448,10 @@ class PostUpdateNode extends Node {
       or
       preupd = any(PointerDereferenceNode deref).getOperand()
       or
-      exists(Write w, DataFlow::Node base |
-        w.writesField(base, _, _) or w.writesElement(base, _, _)
-      |
-        preupd = base
+      exists(Node written | written = getAWrittenNode() |
+        preupd = written
         or
-        preupd = base.(PointerDereferenceNode).getOperand()
+        preupd = written.(PointerDereferenceNode).getOperand()
       )
       or
       preupd instanceof ArgumentNode and

--- a/ql/test/library-tests/semmle/go/frameworks/Protobuf/TaintFlows.expected
+++ b/ql/test/library-tests/semmle/go/frameworks/Protobuf/TaintFlows.expected
@@ -12,6 +12,7 @@
 | testDeprecatedApi.go:143:20:143:39 | call to getUntrustedString : string | testDeprecatedApi.go:148:12:148:21 | serialized |
 | testDeprecatedApi.go:152:25:152:43 | call to getUntrustedBytes : slice type | testDeprecatedApi.go:157:13:157:36 | index expression |
 | testDeprecatedApi.go:161:25:161:43 | call to getUntrustedBytes : slice type | testDeprecatedApi.go:168:13:168:25 | index expression |
+| testDeprecatedApi.go:176:24:176:43 | call to getUntrustedString : string | testDeprecatedApi.go:180:12:180:21 | serialized |
 | testModernApi.go:11:22:11:41 | call to getUntrustedString : string | testModernApi.go:15:12:15:21 | serialized |
 | testModernApi.go:20:22:20:41 | call to getUntrustedString : string | testModernApi.go:26:12:26:21 | serialized |
 | testModernApi.go:30:25:30:43 | call to getUntrustedBytes : slice type | testModernApi.go:34:13:34:29 | selection of Description |
@@ -29,3 +30,4 @@
 | testModernApi.go:200:20:200:39 | call to getUntrustedString : string | testModernApi.go:205:12:205:21 | serialized |
 | testModernApi.go:209:25:209:43 | call to getUntrustedBytes : slice type | testModernApi.go:214:13:214:36 | index expression |
 | testModernApi.go:218:25:218:43 | call to getUntrustedBytes : slice type | testModernApi.go:225:13:225:25 | index expression |
+| testModernApi.go:233:24:233:43 | call to getUntrustedString : string | testModernApi.go:237:12:237:21 | serialized |

--- a/ql/test/query-tests/Security/CWE-601/OpenUrlRedirect/OpenUrlRedirect.expected
+++ b/ql/test/query-tests/Security/CWE-601/OpenUrlRedirect/OpenUrlRedirect.expected
@@ -6,6 +6,44 @@ edges
 | stdlib.go:44:13:44:18 | selection of Form : Values | stdlib.go:46:23:46:28 | target |
 | stdlib.go:64:13:64:18 | selection of Form : Values | stdlib.go:67:23:67:40 | ...+... |
 | stdlib.go:89:13:89:18 | selection of Form : Values | stdlib.go:92:23:92:28 | target |
+| stdlib.go:107:54:107:54 | definition of r [pointer, URL, ... (3)] | stdlib.go:112:4:112:4 | r [pointer, URL, ... (3)] |
+| stdlib.go:107:54:107:54 | definition of r [pointer, URL, ... (3)] | stdlib.go:112:4:112:4 | r [pointer, URL, ... (3)] |
+| stdlib.go:107:54:107:54 | definition of r [pointer, URL] | stdlib.go:112:4:112:4 | r [pointer, URL] |
+| stdlib.go:107:54:107:54 | definition of r [pointer, URL] | stdlib.go:112:4:112:4 | r [pointer, URL] |
+| stdlib.go:107:54:107:54 | definition of r [pointer, URL] | stdlib.go:113:24:113:24 | r [pointer, URL] |
+| stdlib.go:107:54:107:54 | definition of r [pointer, URL] | stdlib.go:113:24:113:24 | r [pointer, URL] |
+| stdlib.go:112:4:112:4 | implicit dereference [URL, pointer] | stdlib.go:107:54:107:54 | definition of r [pointer, URL, ... (3)] |
+| stdlib.go:112:4:112:4 | implicit dereference [URL, pointer] | stdlib.go:107:54:107:54 | definition of r [pointer, URL, ... (3)] |
+| stdlib.go:112:4:112:4 | implicit dereference [URL, pointer] | stdlib.go:112:4:112:8 | selection of URL [pointer] : URL |
+| stdlib.go:112:4:112:4 | implicit dereference [URL, pointer] | stdlib.go:112:4:112:8 | selection of URL [pointer] : URL |
+| stdlib.go:112:4:112:4 | implicit dereference [URL] : pointer type | stdlib.go:107:54:107:54 | definition of r [pointer, URL] |
+| stdlib.go:112:4:112:4 | implicit dereference [URL] : pointer type | stdlib.go:107:54:107:54 | definition of r [pointer, URL] |
+| stdlib.go:112:4:112:4 | implicit dereference [URL] : pointer type | stdlib.go:112:4:112:8 | selection of URL : pointer type |
+| stdlib.go:112:4:112:4 | implicit dereference [URL] : pointer type | stdlib.go:112:4:112:8 | selection of URL : pointer type |
+| stdlib.go:112:4:112:4 | r [pointer, URL, ... (3)] | stdlib.go:112:4:112:4 | implicit dereference [URL, pointer] |
+| stdlib.go:112:4:112:4 | r [pointer, URL, ... (3)] | stdlib.go:112:4:112:4 | implicit dereference [URL, pointer] |
+| stdlib.go:112:4:112:4 | r [pointer, URL] | stdlib.go:112:4:112:4 | implicit dereference [URL] : pointer type |
+| stdlib.go:112:4:112:4 | r [pointer, URL] | stdlib.go:112:4:112:4 | implicit dereference [URL] : pointer type |
+| stdlib.go:112:4:112:8 | implicit dereference : URL | stdlib.go:112:4:112:8 | implicit dereference : URL |
+| stdlib.go:112:4:112:8 | implicit dereference : URL | stdlib.go:112:4:112:8 | implicit dereference : URL |
+| stdlib.go:112:4:112:8 | implicit dereference : URL | stdlib.go:112:4:112:8 | selection of URL : pointer type |
+| stdlib.go:112:4:112:8 | implicit dereference : URL | stdlib.go:112:4:112:8 | selection of URL : pointer type |
+| stdlib.go:112:4:112:8 | implicit dereference : URL | stdlib.go:112:4:112:8 | selection of URL [pointer] : URL |
+| stdlib.go:112:4:112:8 | implicit dereference : URL | stdlib.go:112:4:112:8 | selection of URL [pointer] : URL |
+| stdlib.go:112:4:112:8 | selection of URL : pointer type | stdlib.go:112:4:112:4 | implicit dereference [URL] : pointer type |
+| stdlib.go:112:4:112:8 | selection of URL : pointer type | stdlib.go:112:4:112:4 | implicit dereference [URL] : pointer type |
+| stdlib.go:112:4:112:8 | selection of URL : pointer type | stdlib.go:112:4:112:8 | implicit dereference : URL |
+| stdlib.go:112:4:112:8 | selection of URL : pointer type | stdlib.go:112:4:112:8 | implicit dereference : URL |
+| stdlib.go:112:4:112:8 | selection of URL : pointer type | stdlib.go:112:4:112:8 | selection of URL : pointer type |
+| stdlib.go:112:4:112:8 | selection of URL : pointer type | stdlib.go:112:4:112:8 | selection of URL : pointer type |
+| stdlib.go:112:4:112:8 | selection of URL [pointer] : URL | stdlib.go:112:4:112:4 | implicit dereference [URL, pointer] |
+| stdlib.go:112:4:112:8 | selection of URL [pointer] : URL | stdlib.go:112:4:112:4 | implicit dereference [URL, pointer] |
+| stdlib.go:112:4:112:8 | selection of URL [pointer] : URL | stdlib.go:112:4:112:8 | implicit dereference : URL |
+| stdlib.go:112:4:112:8 | selection of URL [pointer] : URL | stdlib.go:112:4:112:8 | implicit dereference : URL |
+| stdlib.go:113:24:113:24 | implicit dereference [URL] : pointer type | stdlib.go:113:24:113:28 | selection of URL : pointer type |
+| stdlib.go:113:24:113:24 | implicit dereference [URL] : pointer type | stdlib.go:113:24:113:28 | selection of URL : pointer type |
+| stdlib.go:113:24:113:24 | r [pointer, URL] | stdlib.go:113:24:113:24 | implicit dereference [URL] : pointer type |
+| stdlib.go:113:24:113:24 | r [pointer, URL] | stdlib.go:113:24:113:24 | implicit dereference [URL] : pointer type |
 | stdlib.go:113:24:113:28 | selection of URL : pointer type | stdlib.go:113:24:113:37 | call to String |
 | stdlib.go:113:24:113:28 | selection of URL : pointer type | stdlib.go:113:24:113:37 | call to String |
 | stdlib.go:146:13:146:18 | selection of Form : Values | stdlib.go:152:23:152:28 | target |
@@ -37,6 +75,28 @@ nodes
 | stdlib.go:67:23:67:40 | ...+... | semmle.label | ...+... |
 | stdlib.go:89:13:89:18 | selection of Form : Values | semmle.label | selection of Form : Values |
 | stdlib.go:92:23:92:28 | target | semmle.label | target |
+| stdlib.go:107:54:107:54 | definition of r [pointer, URL, ... (3)] | semmle.label | definition of r [pointer, URL, ... (3)] |
+| stdlib.go:107:54:107:54 | definition of r [pointer, URL, ... (3)] | semmle.label | definition of r [pointer, URL, ... (3)] |
+| stdlib.go:107:54:107:54 | definition of r [pointer, URL] | semmle.label | definition of r [pointer, URL] |
+| stdlib.go:107:54:107:54 | definition of r [pointer, URL] | semmle.label | definition of r [pointer, URL] |
+| stdlib.go:112:4:112:4 | implicit dereference [URL, pointer] | semmle.label | implicit dereference [URL, pointer] |
+| stdlib.go:112:4:112:4 | implicit dereference [URL, pointer] | semmle.label | implicit dereference [URL, pointer] |
+| stdlib.go:112:4:112:4 | implicit dereference [URL] : pointer type | semmle.label | implicit dereference [URL] : pointer type |
+| stdlib.go:112:4:112:4 | implicit dereference [URL] : pointer type | semmle.label | implicit dereference [URL] : pointer type |
+| stdlib.go:112:4:112:4 | r [pointer, URL, ... (3)] | semmle.label | r [pointer, URL, ... (3)] |
+| stdlib.go:112:4:112:4 | r [pointer, URL, ... (3)] | semmle.label | r [pointer, URL, ... (3)] |
+| stdlib.go:112:4:112:4 | r [pointer, URL] | semmle.label | r [pointer, URL] |
+| stdlib.go:112:4:112:4 | r [pointer, URL] | semmle.label | r [pointer, URL] |
+| stdlib.go:112:4:112:8 | implicit dereference : URL | semmle.label | implicit dereference : URL |
+| stdlib.go:112:4:112:8 | implicit dereference : URL | semmle.label | implicit dereference : URL |
+| stdlib.go:112:4:112:8 | selection of URL : pointer type | semmle.label | selection of URL : pointer type |
+| stdlib.go:112:4:112:8 | selection of URL : pointer type | semmle.label | selection of URL : pointer type |
+| stdlib.go:112:4:112:8 | selection of URL [pointer] : URL | semmle.label | selection of URL [pointer] : URL |
+| stdlib.go:112:4:112:8 | selection of URL [pointer] : URL | semmle.label | selection of URL [pointer] : URL |
+| stdlib.go:113:24:113:24 | implicit dereference [URL] : pointer type | semmle.label | implicit dereference [URL] : pointer type |
+| stdlib.go:113:24:113:24 | implicit dereference [URL] : pointer type | semmle.label | implicit dereference [URL] : pointer type |
+| stdlib.go:113:24:113:24 | r [pointer, URL] | semmle.label | r [pointer, URL] |
+| stdlib.go:113:24:113:24 | r [pointer, URL] | semmle.label | r [pointer, URL] |
 | stdlib.go:113:24:113:28 | selection of URL : pointer type | semmle.label | selection of URL : pointer type |
 | stdlib.go:113:24:113:28 | selection of URL : pointer type | semmle.label | selection of URL : pointer type |
 | stdlib.go:113:24:113:37 | call to String | semmle.label | call to String |


### PR DESCRIPTION
This creates a PostUpdateNode for x in the contexts `x.field[element]`, `x.field.otherfield`, `x[element].field` and so on.

Most uses of PostUpdateNode implicitly assume its old definition, but our protobuf model benefits.