### PR TITLE
Port codeql#4238 (Dataflow: small fixes for naming in taint tracking)…

### DIFF
--- a/ql/src/semmle/go/dataflow/internal/TaintTrackingUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/TaintTrackingUtil.qll
@@ -168,7 +168,7 @@ predicate defaultAdditionalTaintStep(DataFlow::Node src, DataFlow::Node sink) {
 }
 
 /**
- * Holds if `node` should be a barrier in all global taint flow configurations
+ * Holds if `node` should be a sanitizer in all global taint flow configurations
  * but not in local taint.
  */
-predicate defaultTaintBarrier(DataFlow::Node node) { none() }
+predicate defaultTaintSanitizer(DataFlow::Node node) { none() }

--- a/ql/src/semmle/go/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/ql/src/semmle/go/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -76,20 +76,20 @@ abstract class Configuration extends DataFlow::Configuration {
 
   final override predicate isBarrier(DataFlow::Node node) {
     isSanitizer(node) or
-    defaultTaintBarrier(node)
+    defaultTaintSanitizer(node)
   }
 
-  /** Holds if data flow into `node` is prohibited. */
+  /** Holds if taint propagation into `node` is prohibited. */
   predicate isSanitizerIn(DataFlow::Node node) { none() }
 
   final override predicate isBarrierIn(DataFlow::Node node) { isSanitizerIn(node) }
 
-  /** Holds if data flow out of `node` is prohibited. */
+  /** Holds if taint propagation out of `node` is prohibited. */
   predicate isSanitizerOut(DataFlow::Node node) { none() }
 
   final override predicate isBarrierOut(DataFlow::Node node) { isSanitizerOut(node) }
 
-  /** Holds if data flow through nodes guarded by `guard` is prohibited. */
+  /** Holds if taint propagation through nodes guarded by `guard` is prohibited. */
   predicate isSanitizerGuard(DataFlow::BarrierGuard guard) { none() }
 
   final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) { isSanitizerGuard(guard) }


### PR DESCRIPTION
… to Go's local copy of the dataflow libs

Trivial naming-only change