### PR TITLE
Remove duplicate models (the end)

### DIFF
--- a/change-notes/2020-09-23-stdlib.md
+++ b/change-notes/2020-09-23-stdlib.md
@@ -1,2 +1,2 @@
 lgtm,codescanning
-* Add/improve taint-tracking models for 60 Go standard library packages (for which taint-modelling makes sense).
+* Add/improve taint-tracking models for 60 Go standard library packages. This means that all queries that track tainted data may produce more results; these include queries scanning for cross-site scripting vulnerabilities and SQL injection vulnerabilities among others.

--- a/change-notes/2020-09-23-stdlib.md
+++ b/change-notes/2020-09-23-stdlib.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Add/improve taint-tracking models for most of the Go standard library packages (for which taint-modelling makes sense).

--- a/change-notes/2020-09-23-stdlib.md
+++ b/change-notes/2020-09-23-stdlib.md
@@ -1,2 +1,2 @@
 lgtm,codescanning
-* Add/improve taint-tracking models for most of the Go standard library packages (for which taint-modelling makes sense).
+* Add/improve taint-tracking models for 60 Go standard library packages (for which taint-modelling makes sense).

--- a/change-notes/2020-09-23-stdlib.md
+++ b/change-notes/2020-09-23-stdlib.md
@@ -1,2 +1,2 @@
 lgtm,codescanning
-* Add/improve taint-tracking models for 60 Go standard library packages. This means that all queries that track tainted data may produce more results; these include queries scanning for cross-site scripting vulnerabilities and SQL injection vulnerabilities among others.
+* Add/improve taint-tracking models for 63 Go standard library packages. This means that all queries that track tainted data may produce more results; these include queries scanning for cross-site scripting vulnerabilities and SQL injection vulnerabilities among others.

--- a/ql/src/semmle/go/frameworks/stdlib/ArchiveTar.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/ArchiveTar.qll
@@ -36,23 +36,15 @@ module ArchiveTar {
     MethodModels() {
       // Methods:
       // signature: func (*Header).FileInfo() os.FileInfo
-      this.(Method).hasQualifiedName("archive/tar", "Header", "FileInfo") and
+      hasQualifiedName("archive/tar", "Header", "FileInfo") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Reader).Next() (*Header, error)
-      this.(Method).hasQualifiedName("archive/tar", "Reader", "Next") and
+      hasQualifiedName("archive/tar", "Reader", "Next") and
       (inp.isReceiver() and outp.isResult(0))
       or
-      // signature: func (*Reader).Read(b []byte) (int, error)
-      this.(Method).hasQualifiedName("archive/tar", "Reader", "Read") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
-      // signature: func (*Writer).Write(b []byte) (int, error)
-      this.(Method).hasQualifiedName("archive/tar", "Writer", "Write") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
       // signature: func (*Writer).WriteHeader(hdr *Header) error
-      this.(Method).hasQualifiedName("archive/tar", "Writer", "WriteHeader") and
+      hasQualifiedName("archive/tar", "Writer", "WriteHeader") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/ArchiveZip.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/ArchiveZip.qll
@@ -38,17 +38,16 @@ module ArchiveZip {
     FunctionOutput outp;
 
     MethodModels() {
-      // Methods:
       // signature: func (*File).Open() (io.ReadCloser, error)
-      this.(Method).hasQualifiedName("archive/zip", "File", "Open") and
+      hasQualifiedName("archive/zip", "File", "Open") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Writer).Create(name string) (io.Writer, error)
-      this.(Method).hasQualifiedName("archive/zip", "Writer", "Create") and
+      hasQualifiedName("archive/zip", "Writer", "Create") and
       (inp.isResult(0) and outp.isReceiver())
       or
       // signature: func (*Writer).CreateHeader(fh *FileHeader) (io.Writer, error)
-      this.(Method).hasQualifiedName("archive/zip", "Writer", "CreateHeader") and
+      hasQualifiedName("archive/zip", "Writer", "CreateHeader") and
       (inp.isResult(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Bufio.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Bufio.qll
@@ -10,7 +10,7 @@ module Bufio {
    * The function `bufio.NewScanner`.
    */
   class NewScanner extends Function {
-    NewScanner() { this.hasQualifiedName("bufio", "NewScanner") }
+    NewScanner() { hasQualifiedName("bufio", "NewScanner") }
 
     /**
      * Gets the input corresponding to the `io.Reader`
@@ -80,39 +80,39 @@ module Bufio {
 
     MethodModels() {
       // signature: func (*Reader).Peek(n int) ([]byte, error)
-      this.hasQualifiedName("bufio", "Reader", "Peek") and
+      hasQualifiedName("bufio", "Reader", "Peek") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadBytes(delim byte) ([]byte, error)
-      this.hasQualifiedName("bufio", "Reader", "ReadBytes") and
+      hasQualifiedName("bufio", "Reader", "ReadBytes") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadLine() (line []byte, isPrefix bool, err error)
-      this.hasQualifiedName("bufio", "Reader", "ReadLine") and
+      hasQualifiedName("bufio", "Reader", "ReadLine") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadSlice(delim byte) (line []byte, err error)
-      this.hasQualifiedName("bufio", "Reader", "ReadSlice") and
+      hasQualifiedName("bufio", "Reader", "ReadSlice") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadString(delim byte) (string, error)
-      this.hasQualifiedName("bufio", "Reader", "ReadString") and
+      hasQualifiedName("bufio", "Reader", "ReadString") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).Reset(r io.Reader)
-      this.hasQualifiedName("bufio", "Reader", "Reset") and
+      hasQualifiedName("bufio", "Reader", "Reset") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*Scanner).Bytes() []byte
-      this.hasQualifiedName("bufio", "Scanner", "Bytes") and
+      hasQualifiedName("bufio", "Scanner", "Bytes") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Scanner).Text() string
-      this.hasQualifiedName("bufio", "Scanner", "Text") and
+      hasQualifiedName("bufio", "Scanner", "Text") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Writer).Reset(w io.Writer)
-      this.hasQualifiedName("bufio", "Writer", "Reset") and
+      hasQualifiedName("bufio", "Writer", "Reset") and
       (inp.isReceiver() and outp.isParameter(0))
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Bufio.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Bufio.qll
@@ -103,10 +103,6 @@ module Bufio {
       this.hasQualifiedName("bufio", "Reader", "Reset") and
       (inp.isParameter(0) and outp.isReceiver())
       or
-      // signature: func (*Reader).WriteTo(w io.Writer) (n int64, err error)
-      this.hasQualifiedName("bufio", "Reader", "WriteTo") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
       // signature: func (*Scanner).Bytes() []byte
       this.hasQualifiedName("bufio", "Scanner", "Bytes") and
       (inp.isReceiver() and outp.isResult())
@@ -115,21 +111,9 @@ module Bufio {
       this.hasQualifiedName("bufio", "Scanner", "Text") and
       (inp.isReceiver() and outp.isResult())
       or
-      // signature: func (*Writer).ReadFrom(r io.Reader) (n int64, err error)
-      this.hasQualifiedName("bufio", "Writer", "ReadFrom") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
       // signature: func (*Writer).Reset(w io.Writer)
       this.hasQualifiedName("bufio", "Writer", "Reset") and
       (inp.isReceiver() and outp.isParameter(0))
-      or
-      // signature: func (*Writer).Write(p []byte) (nn int, err error)
-      this.hasQualifiedName("bufio", "Writer", "Write") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
-      // signature: func (*Writer).WriteString(s string) (int, error)
-      this.hasQualifiedName("bufio", "Writer", "WriteString") and
-      (inp.isParameter(0) and outp.isReceiver())
     }
 
     override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {

--- a/ql/src/semmle/go/frameworks/stdlib/Bytes.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Bytes.qll
@@ -151,52 +151,24 @@ module Bytes {
 
     MethodModels() {
       // signature: func (*Buffer).Bytes() []byte
-      this.hasQualifiedName("bytes", "Buffer", "Bytes") and
+      hasQualifiedName("bytes", "Buffer", "Bytes") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Buffer).Next(n int) []byte
-      this.hasQualifiedName("bytes", "Buffer", "Next") and
+      hasQualifiedName("bytes", "Buffer", "Next") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Buffer).ReadBytes(delim byte) (line []byte, err error)
-      this.hasQualifiedName("bytes", "Buffer", "ReadBytes") and
+      hasQualifiedName("bytes", "Buffer", "ReadBytes") and
       (inp.isReceiver() and outp.isResult(0))
-      or
-      // signature: func (*Buffer).ReadFrom(r io.Reader) (n int64, err error)
-      this.hasQualifiedName("bytes", "Buffer", "ReadFrom") and
-      (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*Buffer).ReadString(delim byte) (line string, err error)
-      this.hasQualifiedName("bytes", "Buffer", "ReadString") and
+      hasQualifiedName("bytes", "Buffer", "ReadString") and
       (inp.isReceiver() and outp.isResult(0))
       or
-      // signature: func (*Buffer).String() string
-      this.hasQualifiedName("bytes", "Buffer", "String") and
-      (inp.isReceiver() and outp.isResult())
-      or
-      // signature: func (*Buffer).Write(p []byte) (n int, err error)
-      this.hasQualifiedName("bytes", "Buffer", "Write") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
-      // signature: func (*Buffer).WriteString(s string) (n int, err error)
-      this.hasQualifiedName("bytes", "Buffer", "WriteString") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
-      // signature: func (*Buffer).WriteTo(w io.Writer) (n int64, err error)
-      this.hasQualifiedName("bytes", "Buffer", "WriteTo") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
-      // signature: func (*Reader).ReadAt(b []byte, off int64) (n int, err error)
-      this.hasQualifiedName("bytes", "Reader", "ReadAt") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
       // signature: func (*Reader).Reset(b []byte)
-      this.hasQualifiedName("bytes", "Reader", "Reset") and
+      hasQualifiedName("bytes", "Reader", "Reset") and
       (inp.isParameter(0) and outp.isReceiver())
-      or
-      // signature: func (*Reader).WriteTo(w io.Writer) (n int64, err error)
-      this.hasQualifiedName("bytes", "Reader", "WriteTo") and
-      (inp.isReceiver() and outp.isParameter(0))
     }
 
     override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {

--- a/ql/src/semmle/go/frameworks/stdlib/CompressFlate.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/CompressFlate.qll
@@ -39,11 +39,11 @@ module CompressFlate {
 
     MethodModels() {
       // signature: func (*Writer).Reset(dst io.Writer)
-      this.hasQualifiedName("compress/flate", "Writer", "Reset") and
+      hasQualifiedName("compress/flate", "Writer", "Reset") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (Resetter).Reset(r io.Reader, dict []byte) error
-      this.implements("compress/flate", "Resetter", "Reset") and
+      implements("compress/flate", "Resetter", "Reset") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/CompressFlate.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/CompressFlate.qll
@@ -42,10 +42,6 @@ module CompressFlate {
       this.hasQualifiedName("compress/flate", "Writer", "Reset") and
       (inp.isReceiver() and outp.isParameter(0))
       or
-      // signature: func (*Writer).Write(data []byte) (n int, err error)
-      this.hasQualifiedName("compress/flate", "Writer", "Write") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
       // signature: func (Resetter).Reset(r io.Reader, dict []byte) error
       this.implements("compress/flate", "Resetter", "Reset") and
       (inp.isParameter(0) and outp.isReceiver())

--- a/ql/src/semmle/go/frameworks/stdlib/CompressGzip.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/CompressGzip.qll
@@ -35,11 +35,11 @@ module CompressGzip {
 
     MethodModels() {
       // signature: func (*Reader).Reset(r io.Reader) error
-      this.hasQualifiedName("compress/gzip", "Reader", "Reset") and
+      hasQualifiedName("compress/gzip", "Reader", "Reset") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*Writer).Reset(w io.Writer)
-      this.hasQualifiedName("compress/gzip", "Writer", "Reset") and
+      hasQualifiedName("compress/gzip", "Writer", "Reset") and
       (inp.isReceiver() and outp.isParameter(0))
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/CompressGzip.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/CompressGzip.qll
@@ -41,10 +41,6 @@ module CompressGzip {
       // signature: func (*Writer).Reset(w io.Writer)
       this.hasQualifiedName("compress/gzip", "Writer", "Reset") and
       (inp.isReceiver() and outp.isParameter(0))
-      or
-      // signature: func (*Writer).Write(p []byte) (int, error)
-      this.hasQualifiedName("compress/gzip", "Writer", "Write") and
-      (inp.isParameter(0) and outp.isReceiver())
     }
 
     override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {

--- a/ql/src/semmle/go/frameworks/stdlib/CompressZlib.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/CompressZlib.qll
@@ -43,11 +43,11 @@ module CompressZlib {
 
     MethodModels() {
       // signature: func (*Writer).Reset(w io.Writer)
-      this.hasQualifiedName("compress/zlib", "Writer", "Reset") and
+      hasQualifiedName("compress/zlib", "Writer", "Reset") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (Resetter).Reset(r io.Reader, dict []byte) error
-      this.implements("compress/zlib", "Resetter", "Reset") and
+      implements("compress/zlib", "Resetter", "Reset") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/CompressZlib.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/CompressZlib.qll
@@ -46,10 +46,6 @@ module CompressZlib {
       this.hasQualifiedName("compress/zlib", "Writer", "Reset") and
       (inp.isReceiver() and outp.isParameter(0))
       or
-      // signature: func (*Writer).Write(p []byte) (n int, err error)
-      this.hasQualifiedName("compress/zlib", "Writer", "Write") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
       // signature: func (Resetter).Reset(r io.Reader, dict []byte) error
       this.implements("compress/zlib", "Resetter", "Reset") and
       (inp.isParameter(0) and outp.isReceiver())

--- a/ql/src/semmle/go/frameworks/stdlib/ContainerHeap.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/ContainerHeap.qll
@@ -35,11 +35,11 @@ module ContainerHeap {
 
     MethodModels() {
       // signature: func (Interface).Pop() interface{}
-      this.implements("container/heap", "Interface", "Pop") and
+      implements("container/heap", "Interface", "Pop") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Interface).Push(x interface{})
-      this.implements("container/heap", "Interface", "Push") and
+      implements("container/heap", "Interface", "Push") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/ContainerList.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/ContainerList.qll
@@ -12,79 +12,79 @@ module ContainerList {
 
     MethodModels() {
       // signature: func (*Element).Next() *Element
-      this.hasQualifiedName("container/list", "Element", "Next") and
+      hasQualifiedName("container/list", "Element", "Next") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Element).Prev() *Element
-      this.hasQualifiedName("container/list", "Element", "Prev") and
+      hasQualifiedName("container/list", "Element", "Prev") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*List).Back() *Element
-      this.hasQualifiedName("container/list", "List", "Back") and
+      hasQualifiedName("container/list", "List", "Back") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*List).Front() *Element
-      this.hasQualifiedName("container/list", "List", "Front") and
+      hasQualifiedName("container/list", "List", "Front") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*List).Init() *List
-      this.hasQualifiedName("container/list", "List", "Init") and
+      hasQualifiedName("container/list", "List", "Init") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*List).InsertAfter(v interface{}, mark *Element) *Element
-      this.hasQualifiedName("container/list", "List", "InsertAfter") and
+      hasQualifiedName("container/list", "List", "InsertAfter") and
       (
         inp.isParameter(0) and
         (outp.isReceiver() or outp.isResult())
       )
       or
       // signature: func (*List).InsertBefore(v interface{}, mark *Element) *Element
-      this.hasQualifiedName("container/list", "List", "InsertBefore") and
+      hasQualifiedName("container/list", "List", "InsertBefore") and
       (
         inp.isParameter(0) and
         (outp.isReceiver() or outp.isResult())
       )
       or
       // signature: func (*List).MoveAfter(e *Element, mark *Element)
-      this.hasQualifiedName("container/list", "List", "MoveAfter") and
+      hasQualifiedName("container/list", "List", "MoveAfter") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*List).MoveBefore(e *Element, mark *Element)
-      this.hasQualifiedName("container/list", "List", "MoveBefore") and
+      hasQualifiedName("container/list", "List", "MoveBefore") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*List).MoveToBack(e *Element)
-      this.hasQualifiedName("container/list", "List", "MoveToBack") and
+      hasQualifiedName("container/list", "List", "MoveToBack") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*List).MoveToFront(e *Element)
-      this.hasQualifiedName("container/list", "List", "MoveToFront") and
+      hasQualifiedName("container/list", "List", "MoveToFront") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*List).PushBack(v interface{}) *Element
-      this.hasQualifiedName("container/list", "List", "PushBack") and
+      hasQualifiedName("container/list", "List", "PushBack") and
       (
         inp.isParameter(0) and
         (outp.isReceiver() or outp.isResult())
       )
       or
       // signature: func (*List).PushBackList(other *List)
-      this.hasQualifiedName("container/list", "List", "PushBackList") and
+      hasQualifiedName("container/list", "List", "PushBackList") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*List).PushFront(v interface{}) *Element
-      this.hasQualifiedName("container/list", "List", "PushFront") and
+      hasQualifiedName("container/list", "List", "PushFront") and
       (
         inp.isParameter(0) and
         (outp.isReceiver() or outp.isResult())
       )
       or
       // signature: func (*List).PushFrontList(other *List)
-      this.hasQualifiedName("container/list", "List", "PushFrontList") and
+      hasQualifiedName("container/list", "List", "PushFrontList") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*List).Remove(e *Element) interface{}
-      this.hasQualifiedName("container/list", "List", "Remove") and
+      hasQualifiedName("container/list", "List", "Remove") and
       (inp.isParameter(0) and outp.isResult())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/ContainerRing.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/ContainerRing.qll
@@ -12,23 +12,23 @@ module ContainerRing {
 
     MethodModels() {
       // signature: func (*Ring).Link(s *Ring) *Ring
-      this.hasQualifiedName("container/ring", "Ring", "Link") and
+      hasQualifiedName("container/ring", "Ring", "Link") and
       (inp.isParameter(0) and outp.isResult())
       or
       // signature: func (*Ring).Move(n int) *Ring
-      this.hasQualifiedName("container/ring", "Ring", "Move") and
+      hasQualifiedName("container/ring", "Ring", "Move") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Ring).Next() *Ring
-      this.hasQualifiedName("container/ring", "Ring", "Next") and
+      hasQualifiedName("container/ring", "Ring", "Next") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Ring).Prev() *Ring
-      this.hasQualifiedName("container/ring", "Ring", "Prev") and
+      hasQualifiedName("container/ring", "Ring", "Prev") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Ring).Unlink(n int) *Ring
-      this.hasQualifiedName("container/ring", "Ring", "Unlink") and
+      hasQualifiedName("container/ring", "Ring", "Unlink") and
       (inp.isReceiver() and outp.isResult())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Context.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Context.qll
@@ -39,7 +39,7 @@ module Context {
 
     MethodModels() {
       // signature: func (Context).Value(key interface{}) interface{}
-      this.implements("context", "Context", "Value") and
+      implements("context", "Context", "Value") and
       (inp.isReceiver() and outp.isResult())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Crypto.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Crypto.qll
@@ -12,7 +12,7 @@ module Crypto {
 
     MethodModels() {
       // signature: func (Decrypter).Decrypt(rand io.Reader, msg []byte, opts DecrypterOpts) (plaintext []byte, err error)
-      this.implements("crypto", "Decrypter", "Decrypt") and
+      implements("crypto", "Decrypter", "Decrypt") and
       (inp.isParameter(1) and outp.isResult(0))
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/CryptoCipher.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/CryptoCipher.qll
@@ -12,11 +12,11 @@ module CryptoCipher {
 
     MethodModels() {
       // signature: func (Block).Decrypt(dst []byte, src []byte)
-      this.implements("crypto/cipher", "Block", "Decrypt") and
+      implements("crypto/cipher", "Block", "Decrypt") and
       (inp.isParameter(1) and outp.isParameter(0))
       or
       // signature: func (AEAD).Open(dst []byte, nonce []byte, ciphertext []byte, additionalData []byte) ([]byte, error)
-      this.implements("crypto/cipher", "AEAD", "Open") and
+      implements("crypto/cipher", "AEAD", "Open") and
       (
         inp.isParameter(2) and
         (outp.isParameter(0) or outp.isResult(0))

--- a/ql/src/semmle/go/frameworks/stdlib/CryptoRsa.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/CryptoRsa.qll
@@ -31,7 +31,7 @@ module CryptoRsa {
 
     MethodModels() {
       // signature: func (*PrivateKey).Decrypt(rand io.Reader, ciphertext []byte, opts crypto.DecrypterOpts) (plaintext []byte, err error)
-      this.hasQualifiedName("crypto/rsa", "PrivateKey", "Decrypt") and
+      hasQualifiedName("crypto/rsa", "PrivateKey", "Decrypt") and
       (inp.isParameter(1) and outp.isResult(0))
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Encoding.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Encoding.qll
@@ -12,19 +12,19 @@ module Encoding {
 
     MethodModels() {
       // signature: func (BinaryMarshaler).MarshalBinary() (data []byte, err error)
-      this.implements("encoding", "BinaryMarshaler", "MarshalBinary") and
+      implements("encoding", "BinaryMarshaler", "MarshalBinary") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (TextMarshaler).MarshalText() (text []byte, err error)
-      this.implements("encoding", "TextMarshaler", "MarshalText") and
+      implements("encoding", "TextMarshaler", "MarshalText") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (BinaryUnmarshaler).UnmarshalBinary(data []byte) error
-      this.implements("encoding", "BinaryUnmarshaler", "UnmarshalBinary") and
+      implements("encoding", "BinaryUnmarshaler", "UnmarshalBinary") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (TextUnmarshaler).UnmarshalText(text []byte) error
-      this.implements("encoding", "TextUnmarshaler", "UnmarshalText") and
+      implements("encoding", "TextUnmarshaler", "UnmarshalText") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/EncodingBase32.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/EncodingBase32.qll
@@ -27,11 +27,11 @@ module EncodingBase32 {
 
     MethodModels() {
       // signature: func (*Encoding).Decode(dst []byte, src []byte) (n int, err error)
-      this.hasQualifiedName("encoding/base32", "Encoding", "Decode") and
+      hasQualifiedName("encoding/base32", "Encoding", "Decode") and
       (inp.isParameter(1) and outp.isParameter(0))
       or
       // signature: func (*Encoding).DecodeString(s string) ([]byte, error)
-      this.hasQualifiedName("encoding/base32", "Encoding", "DecodeString") and
+      hasQualifiedName("encoding/base32", "Encoding", "DecodeString") and
       (inp.isParameter(0) and outp.isResult(0))
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/EncodingBase64.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/EncodingBase64.qll
@@ -27,11 +27,11 @@ module EncodingBase64 {
 
     MethodModels() {
       // signature: func (*Encoding).Decode(dst []byte, src []byte) (n int, err error)
-      this.hasQualifiedName("encoding/base64", "Encoding", "Decode") and
+      hasQualifiedName("encoding/base64", "Encoding", "Decode") and
       (inp.isParameter(1) and outp.isParameter(0))
       or
       // signature: func (*Encoding).DecodeString(s string) ([]byte, error)
-      this.hasQualifiedName("encoding/base64", "Encoding", "DecodeString") and
+      hasQualifiedName("encoding/base64", "Encoding", "DecodeString") and
       (inp.isParameter(0) and outp.isResult(0))
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/EncodingCsv.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/EncodingCsv.qll
@@ -31,19 +31,19 @@ module EncodingCsv {
 
     MethodModels() {
       // signature: func (*Reader).Read() (record []string, err error)
-      this.hasQualifiedName("encoding/csv", "Reader", "Read") and
+      hasQualifiedName("encoding/csv", "Reader", "Read") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadAll() (records [][]string, err error)
-      this.hasQualifiedName("encoding/csv", "Reader", "ReadAll") and
+      hasQualifiedName("encoding/csv", "Reader", "ReadAll") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Writer).Write(record []string) error
-      this.hasQualifiedName("encoding/csv", "Writer", "Write") and
+      hasQualifiedName("encoding/csv", "Writer", "Write") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*Writer).WriteAll(records [][]string) error
-      this.hasQualifiedName("encoding/csv", "Writer", "WriteAll") and
+      hasQualifiedName("encoding/csv", "Writer", "WriteAll") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/EncodingGob.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/EncodingGob.qll
@@ -31,27 +31,27 @@ module EncodingGob {
 
     MethodModels() {
       // signature: func (*Decoder).Decode(e interface{}) error
-      this.hasQualifiedName("encoding/gob", "Decoder", "Decode") and
+      hasQualifiedName("encoding/gob", "Decoder", "Decode") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*Decoder).DecodeValue(v reflect.Value) error
-      this.hasQualifiedName("encoding/gob", "Decoder", "DecodeValue") and
+      hasQualifiedName("encoding/gob", "Decoder", "DecodeValue") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*Encoder).Encode(e interface{}) error
-      this.hasQualifiedName("encoding/gob", "Encoder", "Encode") and
+      hasQualifiedName("encoding/gob", "Encoder", "Encode") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*Encoder).EncodeValue(value reflect.Value) error
-      this.hasQualifiedName("encoding/gob", "Encoder", "EncodeValue") and
+      hasQualifiedName("encoding/gob", "Encoder", "EncodeValue") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (GobDecoder).GobDecode([]byte) error
-      this.implements("encoding/gob", "GobDecoder", "GobDecode") and
+      implements("encoding/gob", "GobDecoder", "GobDecode") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (GobEncoder).GobEncode() ([]byte, error)
-      this.implements("encoding/gob", "GobEncoder", "GobEncode") and
+      implements("encoding/gob", "GobEncoder", "GobEncode") and
       (inp.isReceiver() and outp.isResult(0))
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/EncodingJson.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/EncodingJson.qll
@@ -85,39 +85,39 @@ module EncodingJson {
 
     MethodModels() {
       // signature: func (*Decoder).Buffered() io.Reader
-      this.hasQualifiedName("encoding/json", "Decoder", "Buffered") and
+      hasQualifiedName("encoding/json", "Decoder", "Buffered") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Decoder).Decode(v interface{}) error
-      this.hasQualifiedName("encoding/json", "Decoder", "Decode") and
+      hasQualifiedName("encoding/json", "Decoder", "Decode") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*Decoder).Token() (Token, error)
-      this.hasQualifiedName("encoding/json", "Decoder", "Token") and
+      hasQualifiedName("encoding/json", "Decoder", "Token") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Encoder).Encode(v interface{}) error
-      this.hasQualifiedName("encoding/json", "Encoder", "Encode") and
+      hasQualifiedName("encoding/json", "Encoder", "Encode") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*Encoder).SetIndent(prefix string, indent string)
-      this.hasQualifiedName("encoding/json", "Encoder", "SetIndent") and
+      hasQualifiedName("encoding/json", "Encoder", "SetIndent") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (RawMessage).MarshalJSON() ([]byte, error)
-      this.hasQualifiedName("encoding/json", "RawMessage", "MarshalJSON") and
+      hasQualifiedName("encoding/json", "RawMessage", "MarshalJSON") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*RawMessage).UnmarshalJSON(data []byte) error
-      this.hasQualifiedName("encoding/json", "RawMessage", "UnmarshalJSON") and
+      hasQualifiedName("encoding/json", "RawMessage", "UnmarshalJSON") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (Marshaler).MarshalJSON() ([]byte, error)
-      this.implements("encoding/json", "Marshaler", "MarshalJSON") and
+      implements("encoding/json", "Marshaler", "MarshalJSON") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (Unmarshaler).UnmarshalJSON([]byte) error
-      this.implements("encoding/json", "Unmarshaler", "UnmarshalJSON") and
+      implements("encoding/json", "Unmarshaler", "UnmarshalJSON") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/EncodingXml.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/EncodingXml.qll
@@ -9,8 +9,8 @@ module EncodingXml {
   /** The `Marshal` or `MarshalIndent` function in the `encoding/xml` package. */
   private class MarshalFunction extends MarshalingFunction::Range {
     MarshalFunction() {
-      this.hasQualifiedName("encoding/xml", "Marshal") or
-      this.hasQualifiedName("encoding/xml", "MarshalIndent")
+      hasQualifiedName("encoding/xml", "Marshal") or
+      hasQualifiedName("encoding/xml", "MarshalIndent")
     }
 
     override FunctionInput getAnInput() { result.isParameter(0) }
@@ -21,7 +21,7 @@ module EncodingXml {
   }
 
   private class UnmarshalFunction extends UnmarshalingFunction::Range {
-    UnmarshalFunction() { this.hasQualifiedName("encoding/xml", "Unmarshal") }
+    UnmarshalFunction() { hasQualifiedName("encoding/xml", "Unmarshal") }
 
     override FunctionInput getAnInput() { result.isParameter(0) }
 
@@ -83,55 +83,55 @@ module EncodingXml {
 
     MethodModels() {
       // signature: func (CharData).Copy() CharData
-      this.hasQualifiedName("encoding/xml", "CharData", "Copy") and
+      hasQualifiedName("encoding/xml", "CharData", "Copy") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Comment).Copy() Comment
-      this.hasQualifiedName("encoding/xml", "Comment", "Copy") and
+      hasQualifiedName("encoding/xml", "Comment", "Copy") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Decoder).Decode(v interface{}) error
-      this.hasQualifiedName("encoding/xml", "Decoder", "Decode") and
+      hasQualifiedName("encoding/xml", "Decoder", "Decode") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*Decoder).DecodeElement(v interface{}, start *StartElement) error
-      this.hasQualifiedName("encoding/xml", "Decoder", "DecodeElement") and
+      hasQualifiedName("encoding/xml", "Decoder", "DecodeElement") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*Decoder).RawToken() (Token, error)
-      this.hasQualifiedName("encoding/xml", "Decoder", "RawToken") and
+      hasQualifiedName("encoding/xml", "Decoder", "RawToken") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Decoder).Token() (Token, error)
-      this.hasQualifiedName("encoding/xml", "Decoder", "Token") and
+      hasQualifiedName("encoding/xml", "Decoder", "Token") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (Directive).Copy() Directive
-      this.hasQualifiedName("encoding/xml", "Directive", "Copy") and
+      hasQualifiedName("encoding/xml", "Directive", "Copy") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Encoder).Encode(v interface{}) error
-      this.hasQualifiedName("encoding/xml", "Encoder", "Encode") and
+      hasQualifiedName("encoding/xml", "Encoder", "Encode") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*Encoder).EncodeElement(v interface{}, start StartElement) error
-      this.hasQualifiedName("encoding/xml", "Encoder", "EncodeElement") and
+      hasQualifiedName("encoding/xml", "Encoder", "EncodeElement") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*Encoder).EncodeToken(t Token) error
-      this.hasQualifiedName("encoding/xml", "Encoder", "EncodeToken") and
+      hasQualifiedName("encoding/xml", "Encoder", "EncodeToken") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*Encoder).Indent(prefix string, indent string)
-      this.hasQualifiedName("encoding/xml", "Encoder", "Indent") and
+      hasQualifiedName("encoding/xml", "Encoder", "Indent") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (ProcInst).Copy() ProcInst
-      this.hasQualifiedName("encoding/xml", "ProcInst", "Copy") and
+      hasQualifiedName("encoding/xml", "ProcInst", "Copy") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (StartElement).Copy() StartElement
-      this.hasQualifiedName("encoding/xml", "StartElement", "Copy") and
+      hasQualifiedName("encoding/xml", "StartElement", "Copy") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Marshaler).MarshalXML(e *Encoder, start StartElement) error

--- a/ql/src/semmle/go/frameworks/stdlib/Expvar.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Expvar.qll
@@ -12,27 +12,27 @@ module Expvar {
 
     MethodModels() {
       // signature: func (Func).Value() interface{}
-      this.hasQualifiedName("expvar", "Func", "Value") and
+      hasQualifiedName("expvar", "Func", "Value") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Map).Get(key string) Var
-      this.hasQualifiedName("expvar", "Map", "Get") and
+      hasQualifiedName("expvar", "Map", "Get") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Map).Set(key string, av Var)
-      this.hasQualifiedName("expvar", "Map", "Set") and
+      hasQualifiedName("expvar", "Map", "Set") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (*String).Set(value string)
-      this.hasQualifiedName("expvar", "String", "Set") and
+      hasQualifiedName("expvar", "String", "Set") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*String).Value() string
-      this.hasQualifiedName("expvar", "String", "Value") and
+      hasQualifiedName("expvar", "String", "Value") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Var).String() string
-      this.implements("expvar", "Var", "String") and
+      implements("expvar", "Var", "String") and
       (inp.isReceiver() and outp.isResult())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Expvar.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Expvar.qll
@@ -23,17 +23,9 @@ module Expvar {
       this.hasQualifiedName("expvar", "Map", "Set") and
       (inp.isParameter(_) and outp.isReceiver())
       or
-      // signature: func (*Map).String() string
-      this.hasQualifiedName("expvar", "Map", "String") and
-      (inp.isReceiver() and outp.isResult())
-      or
       // signature: func (*String).Set(value string)
       this.hasQualifiedName("expvar", "String", "Set") and
       (inp.isParameter(0) and outp.isReceiver())
-      or
-      // signature: func (*String).String() string
-      this.hasQualifiedName("expvar", "String", "String") and
-      (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*String).Value() string
       this.hasQualifiedName("expvar", "String", "Value") and

--- a/ql/src/semmle/go/frameworks/stdlib/Fmt.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Fmt.qll
@@ -138,19 +138,19 @@ module Fmt {
 
     MethodModels() {
       // signature: func (GoStringer).GoString() string
-      this.implements("fmt", "GoStringer", "GoString") and
+      implements("fmt", "GoStringer", "GoString") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (ScanState).Read(buf []byte) (n int, err error)
-      this.implements("fmt", "ScanState", "Read") and
+      implements("fmt", "ScanState", "Read") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (Stringer).String() string
-      this.implements("fmt", "Stringer", "String") and
+      implements("fmt", "Stringer", "String") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (ScanState).Token(skipSpace bool, f func(rune) bool) (token []byte, err error)
-      this.implements("fmt", "ScanState", "Token") and
+      implements("fmt", "ScanState", "Token") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (State).Write(b []byte) (n int, err error)

--- a/ql/src/semmle/go/frameworks/stdlib/HtmlTemplate.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/HtmlTemplate.qll
@@ -17,7 +17,7 @@ module HtmlTemplate {
         or
         fn.matches("URLQueryEscape%") and kind = "url"
       |
-        this.hasQualifiedName("html/template", fn)
+        hasQualifiedName("html/template", fn)
       )
     }
 
@@ -69,11 +69,11 @@ module HtmlTemplate {
 
     MethodModels() {
       // signature: func (*Template).Execute(wr io.Writer, data interface{}) error
-      this.hasQualifiedName("html/template", "Template", "Execute") and
+      hasQualifiedName("html/template", "Template", "Execute") and
       (inp.isParameter(1) and outp.isParameter(0))
       or
       // signature: func (*Template).ExecuteTemplate(wr io.Writer, name string, data interface{}) error
-      this.hasQualifiedName("html/template", "Template", "ExecuteTemplate") and
+      hasQualifiedName("html/template", "Template", "ExecuteTemplate") and
       (inp.isParameter(2) and outp.isParameter(0))
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Io.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Io.qll
@@ -74,31 +74,31 @@ module Io {
 
     MethodModels() {
       // signature: func (Reader).Read(p []byte) (n int, err error)
-      this.implements("io", "Reader", "Read") and
+      implements("io", "Reader", "Read") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (ReaderAt).ReadAt(p []byte, off int64) (n int, err error)
-      this.implements("io", "ReaderAt", "ReadAt") and
+      implements("io", "ReaderAt", "ReadAt") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (ReaderFrom).ReadFrom(r Reader) (n int64, err error)
-      this.implements("io", "ReaderFrom", "ReadFrom") and
+      implements("io", "ReaderFrom", "ReadFrom") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (Writer).Write(p []byte) (n int, err error)
-      this.implements("io", "Writer", "Write") and
+      implements("io", "Writer", "Write") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (WriterAt).WriteAt(p []byte, off int64) (n int, err error)
-      this.implements("io", "WriterAt", "WriteAt") and
+      implements("io", "WriterAt", "WriteAt") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (StringWriter).WriteString(s string) (n int, err error)
-      this.implements("io", "StringWriter", "WriteString") and
+      implements("io", "StringWriter", "WriteString") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (WriterTo).WriteTo(w Writer) (n int64, err error)
-      this.implements("io", "WriterTo", "WriteTo") and
+      implements("io", "WriterTo", "WriteTo") and
       (inp.isReceiver() and outp.isParameter(0))
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Log.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Log.qll
@@ -52,51 +52,51 @@ module Log {
 
     MethodModels() {
       // signature: func (*Logger).Fatal(v ...interface{})
-      this.hasQualifiedName("log", "Logger", "Fatal") and
+      hasQualifiedName("log", "Logger", "Fatal") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (*Logger).Fatalf(format string, v ...interface{})
-      this.hasQualifiedName("log", "Logger", "Fatalf") and
+      hasQualifiedName("log", "Logger", "Fatalf") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (*Logger).Fatalln(v ...interface{})
-      this.hasQualifiedName("log", "Logger", "Fatalln") and
+      hasQualifiedName("log", "Logger", "Fatalln") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (*Logger).Panic(v ...interface{})
-      this.hasQualifiedName("log", "Logger", "Panic") and
+      hasQualifiedName("log", "Logger", "Panic") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (*Logger).Panicf(format string, v ...interface{})
-      this.hasQualifiedName("log", "Logger", "Panicf") and
+      hasQualifiedName("log", "Logger", "Panicf") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (*Logger).Panicln(v ...interface{})
-      this.hasQualifiedName("log", "Logger", "Panicln") and
+      hasQualifiedName("log", "Logger", "Panicln") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (*Logger).Print(v ...interface{})
-      this.hasQualifiedName("log", "Logger", "Print") and
+      hasQualifiedName("log", "Logger", "Print") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (*Logger).Printf(format string, v ...interface{})
-      this.hasQualifiedName("log", "Logger", "Printf") and
+      hasQualifiedName("log", "Logger", "Printf") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (*Logger).Println(v ...interface{})
-      this.hasQualifiedName("log", "Logger", "Println") and
+      hasQualifiedName("log", "Logger", "Println") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (*Logger).SetOutput(w io.Writer)
-      this.hasQualifiedName("log", "Logger", "SetOutput") and
+      hasQualifiedName("log", "Logger", "SetOutput") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*Logger).SetPrefix(prefix string)
-      this.hasQualifiedName("log", "Logger", "SetPrefix") and
+      hasQualifiedName("log", "Logger", "SetPrefix") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*Logger).Writer() io.Writer
-      this.hasQualifiedName("log", "Logger", "Writer") and
+      hasQualifiedName("log", "Logger", "Writer") and
       (inp.isReceiver() and outp.isResult())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Mime.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Mime.qll
@@ -31,15 +31,15 @@ module Mime {
 
     MethodModels() {
       // signature: func (*WordDecoder).Decode(word string) (string, error)
-      this.hasQualifiedName("mime", "WordDecoder", "Decode") and
+      hasQualifiedName("mime", "WordDecoder", "Decode") and
       (inp.isParameter(0) and outp.isResult(0))
       or
       // signature: func (*WordDecoder).DecodeHeader(header string) (string, error)
-      this.hasQualifiedName("mime", "WordDecoder", "DecodeHeader") and
+      hasQualifiedName("mime", "WordDecoder", "DecodeHeader") and
       (inp.isParameter(0) and outp.isResult(0))
       or
       // signature: func (WordEncoder).Encode(charset string, s string) string
-      this.hasQualifiedName("mime", "WordEncoder", "Encode") and
+      hasQualifiedName("mime", "WordEncoder", "Encode") and
       (inp.isParameter(1) and outp.isResult())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/MimeMultipart.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/MimeMultipart.qll
@@ -34,10 +34,6 @@ module MimeMultipart {
       this.hasQualifiedName("mime/multipart", "FileHeader", "Open") and
       (inp.isReceiver() and outp.isResult(0))
       or
-      // signature: func (*Part).Read(d []byte) (n int, err error)
-      this.hasQualifiedName("mime/multipart", "Part", "Read") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
       // signature: func (*Reader).NextPart() (*Part, error)
       this.hasQualifiedName("mime/multipart", "Reader", "NextPart") and
       (inp.isReceiver() and outp.isResult(0))

--- a/ql/src/semmle/go/frameworks/stdlib/MimeMultipart.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/MimeMultipart.qll
@@ -31,35 +31,35 @@ module MimeMultipart {
 
     MethodModels() {
       // signature: func (*FileHeader).Open() (File, error)
-      this.hasQualifiedName("mime/multipart", "FileHeader", "Open") and
+      hasQualifiedName("mime/multipart", "FileHeader", "Open") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).NextPart() (*Part, error)
-      this.hasQualifiedName("mime/multipart", "Reader", "NextPart") and
+      hasQualifiedName("mime/multipart", "Reader", "NextPart") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).NextRawPart() (*Part, error)
-      this.hasQualifiedName("mime/multipart", "Reader", "NextRawPart") and
+      hasQualifiedName("mime/multipart", "Reader", "NextRawPart") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadForm(maxMemory int64) (*Form, error)
-      this.hasQualifiedName("mime/multipart", "Reader", "ReadForm") and
+      hasQualifiedName("mime/multipart", "Reader", "ReadForm") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Writer).CreateFormField(fieldname string) (io.Writer, error)
-      this.hasQualifiedName("mime/multipart", "Writer", "CreateFormField") and
+      hasQualifiedName("mime/multipart", "Writer", "CreateFormField") and
       (inp.isResult(0) and outp.isReceiver())
       or
       // signature: func (*Writer).CreateFormFile(fieldname string, filename string) (io.Writer, error)
-      this.hasQualifiedName("mime/multipart", "Writer", "CreateFormFile") and
+      hasQualifiedName("mime/multipart", "Writer", "CreateFormFile") and
       (inp.isResult(0) and outp.isReceiver())
       or
       // signature: func (*Writer).CreatePart(header net/textproto.MIMEHeader) (io.Writer, error)
-      this.hasQualifiedName("mime/multipart", "Writer", "CreatePart") and
+      hasQualifiedName("mime/multipart", "Writer", "CreatePart") and
       (inp.isResult(0) and outp.isReceiver())
       or
       // signature: func (*Writer).WriteField(fieldname string, value string) error
-      this.hasQualifiedName("mime/multipart", "Writer", "WriteField") and
+      hasQualifiedName("mime/multipart", "Writer", "WriteField") and
       (inp.isParameter(_) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/MimeQuotedprintable.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/MimeQuotedprintable.qll
@@ -24,23 +24,4 @@ module MimeQuotedprintable {
       input = inp and output = outp
     }
   }
-
-  private class MethodModels extends TaintTracking::FunctionModel, Method {
-    FunctionInput inp;
-    FunctionOutput outp;
-
-    MethodModels() {
-      // signature: func (*Reader).Read(p []byte) (n int, err error)
-      this.hasQualifiedName("mime/quotedprintable", "Reader", "Read") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
-      // signature: func (*Writer).Write(p []byte) (n int, err error)
-      this.hasQualifiedName("mime/quotedprintable", "Writer", "Write") and
-      (inp.isParameter(0) and outp.isReceiver())
-    }
-
-    override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
-      input = inp and output = outp
-    }
-  }
 }

--- a/ql/src/semmle/go/frameworks/stdlib/Net.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Net.qll
@@ -55,15 +55,15 @@ module Net {
 
     MethodModels() {
       // signature: func (*IPConn).ReadFromIP(b []byte) (int, *IPAddr, error)
-      this.hasQualifiedName("net", "IPConn", "ReadFromIP") and
+      hasQualifiedName("net", "IPConn", "ReadFromIP") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*IPConn).ReadMsgIP(b []byte, oob []byte) (n int, oobn int, flags int, addr *IPAddr, err error)
-      this.hasQualifiedName("net", "IPConn", "ReadMsgIP") and
+      hasQualifiedName("net", "IPConn", "ReadMsgIP") and
       (inp.isReceiver() and outp.isParameter(_))
       or
       // signature: func (*IPConn).SyscallConn() (syscall.RawConn, error)
-      this.hasQualifiedName("net", "IPConn", "SyscallConn") and
+      hasQualifiedName("net", "IPConn", "SyscallConn") and
       (
         inp.isReceiver() and outp.isResult(0)
         or
@@ -71,15 +71,15 @@ module Net {
       )
       or
       // signature: func (*IPConn).WriteMsgIP(b []byte, oob []byte, addr *IPAddr) (n int, oobn int, err error)
-      this.hasQualifiedName("net", "IPConn", "WriteMsgIP") and
+      hasQualifiedName("net", "IPConn", "WriteMsgIP") and
       (inp.isParameter([0, 1]) and outp.isReceiver())
       or
       // signature: func (*IPConn).WriteToIP(b []byte, addr *IPAddr) (int, error)
-      this.hasQualifiedName("net", "IPConn", "WriteToIP") and
+      hasQualifiedName("net", "IPConn", "WriteToIP") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*TCPConn).SyscallConn() (syscall.RawConn, error)
-      this.hasQualifiedName("net", "TCPConn", "SyscallConn") and
+      hasQualifiedName("net", "TCPConn", "SyscallConn") and
       (
         inp.isReceiver() and outp.isResult(0)
         or
@@ -87,7 +87,7 @@ module Net {
       )
       or
       // signature: func (*TCPListener).File() (f *os.File, err error)
-      this.hasQualifiedName("net", "TCPListener", "File") and
+      hasQualifiedName("net", "TCPListener", "File") and
       (
         inp.isReceiver() and outp.isResult(0)
         or
@@ -95,7 +95,7 @@ module Net {
       )
       or
       // signature: func (*TCPListener).SyscallConn() (syscall.RawConn, error)
-      this.hasQualifiedName("net", "TCPListener", "SyscallConn") and
+      hasQualifiedName("net", "TCPListener", "SyscallConn") and
       (
         inp.isReceiver() and outp.isResult(0)
         or
@@ -103,15 +103,15 @@ module Net {
       )
       or
       // signature: func (*UDPConn).ReadFromUDP(b []byte) (int, *UDPAddr, error)
-      this.hasQualifiedName("net", "UDPConn", "ReadFromUDP") and
+      hasQualifiedName("net", "UDPConn", "ReadFromUDP") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*UDPConn).ReadMsgUDP(b []byte, oob []byte) (n int, oobn int, flags int, addr *UDPAddr, err error)
-      this.hasQualifiedName("net", "UDPConn", "ReadMsgUDP") and
+      hasQualifiedName("net", "UDPConn", "ReadMsgUDP") and
       (inp.isReceiver() and outp.isParameter(_))
       or
       // signature: func (*UDPConn).SyscallConn() (syscall.RawConn, error)
-      this.hasQualifiedName("net", "UDPConn", "SyscallConn") and
+      hasQualifiedName("net", "UDPConn", "SyscallConn") and
       (
         inp.isReceiver() and outp.isResult(0)
         or
@@ -119,23 +119,23 @@ module Net {
       )
       or
       // signature: func (*UDPConn).WriteMsgUDP(b []byte, oob []byte, addr *UDPAddr) (n int, oobn int, err error)
-      this.hasQualifiedName("net", "UDPConn", "WriteMsgUDP") and
+      hasQualifiedName("net", "UDPConn", "WriteMsgUDP") and
       (inp.isParameter([0, 1]) and outp.isReceiver())
       or
       // signature: func (*UDPConn).WriteToUDP(b []byte, addr *UDPAddr) (int, error)
-      this.hasQualifiedName("net", "UDPConn", "WriteToUDP") and
+      hasQualifiedName("net", "UDPConn", "WriteToUDP") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*UnixConn).ReadFromUnix(b []byte) (int, *UnixAddr, error)
-      this.hasQualifiedName("net", "UnixConn", "ReadFromUnix") and
+      hasQualifiedName("net", "UnixConn", "ReadFromUnix") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*UnixConn).ReadMsgUnix(b []byte, oob []byte) (n int, oobn int, flags int, addr *UnixAddr, err error)
-      this.hasQualifiedName("net", "UnixConn", "ReadMsgUnix") and
+      hasQualifiedName("net", "UnixConn", "ReadMsgUnix") and
       (inp.isReceiver() and outp.isParameter(_))
       or
       // signature: func (*UnixConn).SyscallConn() (syscall.RawConn, error)
-      this.hasQualifiedName("net", "UnixConn", "SyscallConn") and
+      hasQualifiedName("net", "UnixConn", "SyscallConn") and
       (
         inp.isReceiver() and outp.isResult(0)
         or
@@ -143,15 +143,15 @@ module Net {
       )
       or
       // signature: func (*UnixConn).WriteMsgUnix(b []byte, oob []byte, addr *UnixAddr) (n int, oobn int, err error)
-      this.hasQualifiedName("net", "UnixConn", "WriteMsgUnix") and
+      hasQualifiedName("net", "UnixConn", "WriteMsgUnix") and
       (inp.isParameter([0, 1]) and outp.isReceiver())
       or
       // signature: func (*UnixConn).WriteToUnix(b []byte, addr *UnixAddr) (int, error)
-      this.hasQualifiedName("net", "UnixConn", "WriteToUnix") and
+      hasQualifiedName("net", "UnixConn", "WriteToUnix") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*UnixListener).File() (f *os.File, err error)
-      this.hasQualifiedName("net", "UnixListener", "File") and
+      hasQualifiedName("net", "UnixListener", "File") and
       (
         inp.isReceiver() and outp.isResult(0)
         or
@@ -159,7 +159,7 @@ module Net {
       )
       or
       // signature: func (*UnixListener).SyscallConn() (syscall.RawConn, error)
-      this.hasQualifiedName("net", "UnixListener", "SyscallConn") and
+      hasQualifiedName("net", "UnixListener", "SyscallConn") and
       (
         inp.isReceiver() and outp.isResult(0)
         or
@@ -167,23 +167,23 @@ module Net {
       )
       or
       // signature: func (Conn).Read(b []byte) (n int, err error)
-      this.implements("net", "Conn", "Read") and
+      implements("net", "Conn", "Read") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (PacketConn).ReadFrom(p []byte) (n int, addr Addr, err error)
-      this.implements("net", "PacketConn", "ReadFrom") and
+      implements("net", "PacketConn", "ReadFrom") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (Addr).String() string
-      this.implements("net", "Addr", "String") and
+      implements("net", "Addr", "String") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Conn).Write(b []byte) (n int, err error)
-      this.implements("net", "Conn", "Write") and
+      implements("net", "Conn", "Write") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (PacketConn).WriteTo(p []byte, addr Addr) (n int, err error)
-      this.implements("net", "PacketConn", "WriteTo") and
+      implements("net", "PacketConn", "WriteTo") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Net.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Net.qll
@@ -54,18 +54,6 @@ module Net {
     FunctionOutput outp;
 
     MethodModels() {
-      // signature: func (*Buffers).Read(p []byte) (n int, err error)
-      this.hasQualifiedName("net", "Buffers", "Read") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
-      // signature: func (*Buffers).WriteTo(w io.Writer) (n int64, err error)
-      this.hasQualifiedName("net", "Buffers", "WriteTo") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
-      // signature: func (*IPConn).ReadFrom(b []byte) (int, Addr, error)
-      this.hasQualifiedName("net", "IPConn", "ReadFrom") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
       // signature: func (*IPConn).ReadFromIP(b []byte) (int, *IPAddr, error)
       this.hasQualifiedName("net", "IPConn", "ReadFromIP") and
       (inp.isReceiver() and outp.isParameter(0))
@@ -86,16 +74,8 @@ module Net {
       this.hasQualifiedName("net", "IPConn", "WriteMsgIP") and
       (inp.isParameter([0, 1]) and outp.isReceiver())
       or
-      // signature: func (*IPConn).WriteTo(b []byte, addr Addr) (int, error)
-      this.hasQualifiedName("net", "IPConn", "WriteTo") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
       // signature: func (*IPConn).WriteToIP(b []byte, addr *IPAddr) (int, error)
       this.hasQualifiedName("net", "IPConn", "WriteToIP") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
-      // signature: func (*TCPConn).ReadFrom(r io.Reader) (int64, error)
-      this.hasQualifiedName("net", "TCPConn", "ReadFrom") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*TCPConn).SyscallConn() (syscall.RawConn, error)
@@ -122,10 +102,6 @@ module Net {
         inp.isResult(0) and outp.isReceiver()
       )
       or
-      // signature: func (*UDPConn).ReadFrom(b []byte) (int, Addr, error)
-      this.hasQualifiedName("net", "UDPConn", "ReadFrom") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
       // signature: func (*UDPConn).ReadFromUDP(b []byte) (int, *UDPAddr, error)
       this.hasQualifiedName("net", "UDPConn", "ReadFromUDP") and
       (inp.isReceiver() and outp.isParameter(0))
@@ -146,17 +122,9 @@ module Net {
       this.hasQualifiedName("net", "UDPConn", "WriteMsgUDP") and
       (inp.isParameter([0, 1]) and outp.isReceiver())
       or
-      // signature: func (*UDPConn).WriteTo(b []byte, addr Addr) (int, error)
-      this.hasQualifiedName("net", "UDPConn", "WriteTo") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
       // signature: func (*UDPConn).WriteToUDP(b []byte, addr *UDPAddr) (int, error)
       this.hasQualifiedName("net", "UDPConn", "WriteToUDP") and
       (inp.isParameter(0) and outp.isReceiver())
-      or
-      // signature: func (*UnixConn).ReadFrom(b []byte) (int, Addr, error)
-      this.hasQualifiedName("net", "UnixConn", "ReadFrom") and
-      (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*UnixConn).ReadFromUnix(b []byte) (int, *UnixAddr, error)
       this.hasQualifiedName("net", "UnixConn", "ReadFromUnix") and
@@ -177,10 +145,6 @@ module Net {
       // signature: func (*UnixConn).WriteMsgUnix(b []byte, oob []byte, addr *UnixAddr) (n int, oobn int, err error)
       this.hasQualifiedName("net", "UnixConn", "WriteMsgUnix") and
       (inp.isParameter([0, 1]) and outp.isReceiver())
-      or
-      // signature: func (*UnixConn).WriteTo(b []byte, addr Addr) (int, error)
-      this.hasQualifiedName("net", "UnixConn", "WriteTo") and
-      (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*UnixConn).WriteToUnix(b []byte, addr *UnixAddr) (int, error)
       this.hasQualifiedName("net", "UnixConn", "WriteToUnix") and

--- a/ql/src/semmle/go/frameworks/stdlib/NetHttp.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/NetHttp.qll
@@ -284,63 +284,63 @@ module NetHttp {
 
     MethodModels() {
       // signature: func (Header).Add(key string, value string)
-      this.hasQualifiedName("net/http", "Header", "Add") and
+      hasQualifiedName("net/http", "Header", "Add") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (Header).Clone() Header
-      this.hasQualifiedName("net/http", "Header", "Clone") and
+      hasQualifiedName("net/http", "Header", "Clone") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Header).Get(key string) string
-      this.hasQualifiedName("net/http", "Header", "Get") and
+      hasQualifiedName("net/http", "Header", "Get") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Header).Set(key string, value string)
-      this.hasQualifiedName("net/http", "Header", "Set") and
+      hasQualifiedName("net/http", "Header", "Set") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (Header).Values(key string) []string
-      this.hasQualifiedName("net/http", "Header", "Values") and
+      hasQualifiedName("net/http", "Header", "Values") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Header).Write(w io.Writer) error
-      this.hasQualifiedName("net/http", "Header", "Write") and
+      hasQualifiedName("net/http", "Header", "Write") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (Header).WriteSubset(w io.Writer, exclude map[string]bool) error
-      this.hasQualifiedName("net/http", "Header", "WriteSubset") and
+      hasQualifiedName("net/http", "Header", "WriteSubset") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*Request).AddCookie(c *Cookie)
-      this.hasQualifiedName("net/http", "Request", "AddCookie") and
+      hasQualifiedName("net/http", "Request", "AddCookie") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*Request).Clone(ctx context.Context) *Request
-      this.hasQualifiedName("net/http", "Request", "Clone") and
+      hasQualifiedName("net/http", "Request", "Clone") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Request).Write(w io.Writer) error
-      this.hasQualifiedName("net/http", "Request", "Write") and
+      hasQualifiedName("net/http", "Request", "Write") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*Request).WriteProxy(w io.Writer) error
-      this.hasQualifiedName("net/http", "Request", "WriteProxy") and
+      hasQualifiedName("net/http", "Request", "WriteProxy") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*Response).Write(w io.Writer) error
-      this.hasQualifiedName("net/http", "Response", "Write") and
+      hasQualifiedName("net/http", "Response", "Write") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*Transport).Clone() *Transport
-      this.hasQualifiedName("net/http", "Transport", "Clone") and
+      hasQualifiedName("net/http", "Transport", "Clone") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Hijacker).Hijack() (net.Conn, *bufio.ReadWriter, error)
-      this.implements("net/http", "Hijacker", "Hijack") and
+      implements("net/http", "Hijacker", "Hijack") and
       (inp.isReceiver() and outp.isResult([0, 1]))
       or
       // signature: func (ResponseWriter).Write([]byte) (int, error)
-      this.implements("net/http", "ResponseWriter", "Write") and
+      implements("net/http", "ResponseWriter", "Write") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/NetHttpHttputil.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/NetHttpHttputil.qll
@@ -59,7 +59,7 @@ module NetHttpHttputil {
 
     MethodModels() {
       // signature: func (*ClientConn).Hijack() (c net.Conn, r *bufio.Reader)
-      this.hasQualifiedName("net/http/httputil", "ClientConn", "Hijack") and
+      hasQualifiedName("net/http/httputil", "ClientConn", "Hijack") and
       (
         inp.isReceiver() and outp.isResult(_)
         or
@@ -67,7 +67,7 @@ module NetHttpHttputil {
       )
       or
       // signature: func (*ServerConn).Hijack() (net.Conn, *bufio.Reader)
-      this.hasQualifiedName("net/http/httputil", "ServerConn", "Hijack") and
+      hasQualifiedName("net/http/httputil", "ServerConn", "Hijack") and
       (
         inp.isReceiver() and outp.isResult(_)
         or
@@ -75,11 +75,11 @@ module NetHttpHttputil {
       )
       or
       // signature: func (BufferPool).Get() []byte
-      this.implements("net/http/httputil", "BufferPool", "Get") and
+      implements("net/http/httputil", "BufferPool", "Get") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (BufferPool).Put([]byte)
-      this.implements("net/http/httputil", "BufferPool", "Put") and
+      implements("net/http/httputil", "BufferPool", "Put") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/NetMail.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/NetMail.qll
@@ -35,15 +35,15 @@ module NetMail {
 
     MethodModels() {
       // signature: func (*AddressParser).Parse(address string) (*Address, error)
-      this.hasQualifiedName("net/mail", "AddressParser", "Parse") and
+      hasQualifiedName("net/mail", "AddressParser", "Parse") and
       (inp.isParameter(0) and outp.isResult(0))
       or
       // signature: func (*AddressParser).ParseList(list string) ([]*Address, error)
-      this.hasQualifiedName("net/mail", "AddressParser", "ParseList") and
+      hasQualifiedName("net/mail", "AddressParser", "ParseList") and
       (inp.isParameter(0) and outp.isResult(0))
       or
       // signature: func (Header).Get(key string) string
-      this.hasQualifiedName("net/mail", "Header", "Get") and
+      hasQualifiedName("net/mail", "Header", "Get") and
       (inp.isReceiver() and outp.isResult())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/NetTextproto.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/NetTextproto.qll
@@ -51,67 +51,67 @@ module NetTextproto {
 
     MethodModels() {
       // signature: func (MIMEHeader).Add(key string, value string)
-      this.hasQualifiedName("net/textproto", "MIMEHeader", "Add") and
+      hasQualifiedName("net/textproto", "MIMEHeader", "Add") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (MIMEHeader).Get(key string) string
-      this.hasQualifiedName("net/textproto", "MIMEHeader", "Get") and
+      hasQualifiedName("net/textproto", "MIMEHeader", "Get") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (MIMEHeader).Set(key string, value string)
-      this.hasQualifiedName("net/textproto", "MIMEHeader", "Set") and
+      hasQualifiedName("net/textproto", "MIMEHeader", "Set") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (MIMEHeader).Values(key string) []string
-      this.hasQualifiedName("net/textproto", "MIMEHeader", "Values") and
+      hasQualifiedName("net/textproto", "MIMEHeader", "Values") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Reader).DotReader() io.Reader
-      this.hasQualifiedName("net/textproto", "Reader", "DotReader") and
+      hasQualifiedName("net/textproto", "Reader", "DotReader") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Reader).ReadCodeLine(expectCode int) (code int, message string, err error)
-      this.hasQualifiedName("net/textproto", "Reader", "ReadCodeLine") and
+      hasQualifiedName("net/textproto", "Reader", "ReadCodeLine") and
       (inp.isReceiver() and outp.isResult(1))
       or
       // signature: func (*Reader).ReadContinuedLine() (string, error)
-      this.hasQualifiedName("net/textproto", "Reader", "ReadContinuedLine") and
+      hasQualifiedName("net/textproto", "Reader", "ReadContinuedLine") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadContinuedLineBytes() ([]byte, error)
-      this.hasQualifiedName("net/textproto", "Reader", "ReadContinuedLineBytes") and
+      hasQualifiedName("net/textproto", "Reader", "ReadContinuedLineBytes") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadDotBytes() ([]byte, error)
-      this.hasQualifiedName("net/textproto", "Reader", "ReadDotBytes") and
+      hasQualifiedName("net/textproto", "Reader", "ReadDotBytes") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadDotLines() ([]string, error)
-      this.hasQualifiedName("net/textproto", "Reader", "ReadDotLines") and
+      hasQualifiedName("net/textproto", "Reader", "ReadDotLines") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadLine() (string, error)
-      this.hasQualifiedName("net/textproto", "Reader", "ReadLine") and
+      hasQualifiedName("net/textproto", "Reader", "ReadLine") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadLineBytes() ([]byte, error)
-      this.hasQualifiedName("net/textproto", "Reader", "ReadLineBytes") and
+      hasQualifiedName("net/textproto", "Reader", "ReadLineBytes") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadMIMEHeader() (MIMEHeader, error)
-      this.hasQualifiedName("net/textproto", "Reader", "ReadMIMEHeader") and
+      hasQualifiedName("net/textproto", "Reader", "ReadMIMEHeader") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Reader).ReadResponse(expectCode int) (code int, message string, err error)
-      this.hasQualifiedName("net/textproto", "Reader", "ReadResponse") and
+      hasQualifiedName("net/textproto", "Reader", "ReadResponse") and
       (inp.isReceiver() and outp.isResult(1))
       or
       // signature: func (*Writer).DotWriter() io.WriteCloser
-      this.hasQualifiedName("net/textproto", "Writer", "DotWriter") and
+      hasQualifiedName("net/textproto", "Writer", "DotWriter") and
       (inp.isResult() and outp.isReceiver())
       or
       // signature: func (*Writer).PrintfLine(format string, args ...interface{}) error
-      this.hasQualifiedName("net/textproto", "Writer", "PrintfLine") and
+      hasQualifiedName("net/textproto", "Writer", "PrintfLine") and
       (inp.isParameter(_) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Os.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Os.qll
@@ -99,11 +99,11 @@ module Os {
 
     MethodModels() {
       // signature: func (*File).Fd() uintptr
-      this.hasQualifiedName("os", "File", "Fd") and
+      hasQualifiedName("os", "File", "Fd") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*File).SyscallConn() (syscall.RawConn, error)
-      this.hasQualifiedName("os", "File", "SyscallConn") and
+      hasQualifiedName("os", "File", "SyscallConn") and
       (
         inp.isReceiver() and outp.isResult(0)
         or

--- a/ql/src/semmle/go/frameworks/stdlib/Os.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Os.qll
@@ -102,14 +102,6 @@ module Os {
       this.hasQualifiedName("os", "File", "Fd") and
       (inp.isReceiver() and outp.isResult())
       or
-      // signature: func (*File).Read(b []byte) (n int, err error)
-      this.hasQualifiedName("os", "File", "Read") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
-      // signature: func (*File).ReadAt(b []byte, off int64) (n int, err error)
-      this.hasQualifiedName("os", "File", "ReadAt") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
       // signature: func (*File).SyscallConn() (syscall.RawConn, error)
       this.hasQualifiedName("os", "File", "SyscallConn") and
       (
@@ -117,18 +109,6 @@ module Os {
         or
         inp.isResult(0) and outp.isReceiver()
       )
-      or
-      // signature: func (*File).Write(b []byte) (n int, err error)
-      this.hasQualifiedName("os", "File", "Write") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
-      // signature: func (*File).WriteAt(b []byte, off int64) (n int, err error)
-      this.hasQualifiedName("os", "File", "WriteAt") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
-      // signature: func (*File).WriteString(s string) (n int, err error)
-      this.hasQualifiedName("os", "File", "WriteString") and
-      (inp.isParameter(0) and outp.isReceiver())
     }
 
     override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {

--- a/ql/src/semmle/go/frameworks/stdlib/Reflect.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Reflect.qll
@@ -43,139 +43,139 @@ module Reflect {
 
     MethodModels() {
       // signature: func (*MapIter).Key() Value
-      this.hasQualifiedName("reflect", "MapIter", "Key") and
+      hasQualifiedName("reflect", "MapIter", "Key") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*MapIter).Value() Value
-      this.hasQualifiedName("reflect", "MapIter", "Value") and
+      hasQualifiedName("reflect", "MapIter", "Value") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (StructTag).Get(key string) string
-      this.hasQualifiedName("reflect", "StructTag", "Get") and
+      hasQualifiedName("reflect", "StructTag", "Get") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (StructTag).Lookup(key string) (value string, ok bool)
-      this.hasQualifiedName("reflect", "StructTag", "Lookup") and
+      hasQualifiedName("reflect", "StructTag", "Lookup") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (Value).Addr() Value
-      this.hasQualifiedName("reflect", "Value", "Addr") and
+      hasQualifiedName("reflect", "Value", "Addr") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).Bytes() []byte
-      this.hasQualifiedName("reflect", "Value", "Bytes") and
+      hasQualifiedName("reflect", "Value", "Bytes") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).Convert(t Type) Value
-      this.hasQualifiedName("reflect", "Value", "Convert") and
+      hasQualifiedName("reflect", "Value", "Convert") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).Elem() Value
-      this.hasQualifiedName("reflect", "Value", "Elem") and
+      hasQualifiedName("reflect", "Value", "Elem") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).Field(i int) Value
-      this.hasQualifiedName("reflect", "Value", "Field") and
+      hasQualifiedName("reflect", "Value", "Field") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).FieldByIndex(index []int) Value
-      this.hasQualifiedName("reflect", "Value", "FieldByIndex") and
+      hasQualifiedName("reflect", "Value", "FieldByIndex") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).FieldByName(name string) Value
-      this.hasQualifiedName("reflect", "Value", "FieldByName") and
+      hasQualifiedName("reflect", "Value", "FieldByName") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).FieldByNameFunc(match func(string) bool) Value
-      this.hasQualifiedName("reflect", "Value", "FieldByNameFunc") and
+      hasQualifiedName("reflect", "Value", "FieldByNameFunc") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).Index(i int) Value
-      this.hasQualifiedName("reflect", "Value", "Index") and
+      hasQualifiedName("reflect", "Value", "Index") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).Interface() (i interface{})
-      this.hasQualifiedName("reflect", "Value", "Interface") and
+      hasQualifiedName("reflect", "Value", "Interface") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).InterfaceData() [2]uintptr
-      this.hasQualifiedName("reflect", "Value", "InterfaceData") and
+      hasQualifiedName("reflect", "Value", "InterfaceData") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).MapIndex(key Value) Value
-      this.hasQualifiedName("reflect", "Value", "MapIndex") and
+      hasQualifiedName("reflect", "Value", "MapIndex") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).MapKeys() []Value
-      this.hasQualifiedName("reflect", "Value", "MapKeys") and
+      hasQualifiedName("reflect", "Value", "MapKeys") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).MapRange() *MapIter
-      this.hasQualifiedName("reflect", "Value", "MapRange") and
+      hasQualifiedName("reflect", "Value", "MapRange") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).Method(i int) Value
-      this.hasQualifiedName("reflect", "Value", "Method") and
+      hasQualifiedName("reflect", "Value", "Method") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).MethodByName(name string) Value
-      this.hasQualifiedName("reflect", "Value", "MethodByName") and
+      hasQualifiedName("reflect", "Value", "MethodByName") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).Pointer() uintptr
-      this.hasQualifiedName("reflect", "Value", "Pointer") and
+      hasQualifiedName("reflect", "Value", "Pointer") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).Recv() (x Value, ok bool)
-      this.hasQualifiedName("reflect", "Value", "Recv") and
+      hasQualifiedName("reflect", "Value", "Recv") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (Value).Send(x Value)
-      this.hasQualifiedName("reflect", "Value", "Send") and
+      hasQualifiedName("reflect", "Value", "Send") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (Value).Set(x Value)
-      this.hasQualifiedName("reflect", "Value", "Set") and
+      hasQualifiedName("reflect", "Value", "Set") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (Value).SetBytes(x []byte)
-      this.hasQualifiedName("reflect", "Value", "SetBytes") and
+      hasQualifiedName("reflect", "Value", "SetBytes") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (Value).SetMapIndex(key Value, elem Value)
-      this.hasQualifiedName("reflect", "Value", "SetMapIndex") and
+      hasQualifiedName("reflect", "Value", "SetMapIndex") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (Value).SetPointer(x unsafe.Pointer)
-      this.hasQualifiedName("reflect", "Value", "SetPointer") and
+      hasQualifiedName("reflect", "Value", "SetPointer") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (Value).SetString(x string)
-      this.hasQualifiedName("reflect", "Value", "SetString") and
+      hasQualifiedName("reflect", "Value", "SetString") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (Value).Slice(i int, j int) Value
-      this.hasQualifiedName("reflect", "Value", "Slice") and
+      hasQualifiedName("reflect", "Value", "Slice") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).Slice3(i int, j int, k int) Value
-      this.hasQualifiedName("reflect", "Value", "Slice3") and
+      hasQualifiedName("reflect", "Value", "Slice3") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).String() string
-      this.hasQualifiedName("reflect", "Value", "String") and
+      hasQualifiedName("reflect", "Value", "String") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (Value).TryRecv() (x Value, ok bool)
-      this.hasQualifiedName("reflect", "Value", "TryRecv") and
+      hasQualifiedName("reflect", "Value", "TryRecv") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (Value).TrySend(x Value) bool
-      this.hasQualifiedName("reflect", "Value", "TrySend") and
+      hasQualifiedName("reflect", "Value", "TrySend") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (Value).UnsafeAddr() uintptr
-      this.hasQualifiedName("reflect", "Value", "UnsafeAddr") and
+      hasQualifiedName("reflect", "Value", "UnsafeAddr") and
       (inp.isReceiver() and outp.isResult())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Regexp.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Regexp.qll
@@ -32,9 +32,7 @@ module Regexp {
   }
 
   private class MatchFunction extends RegexpMatchFunction::Range, Function {
-    MatchFunction() {
-      exists(string fn | fn.matches("Match%") | this.hasQualifiedName("regexp", fn))
-    }
+    MatchFunction() { exists(string fn | fn.matches("Match%") | hasQualifiedName("regexp", fn)) }
 
     override FunctionInput getRegexpArg() { result.isParameter(0) }
 
@@ -45,7 +43,7 @@ module Regexp {
 
   private class MatchMethod extends RegexpMatchFunction::Range, Method {
     MatchMethod() {
-      exists(string fn | fn.matches("Match%") | this.hasQualifiedName("regexp", "Regexp", fn))
+      exists(string fn | fn.matches("Match%") | hasQualifiedName("regexp", "Regexp", fn))
     }
 
     override FunctionInput getRegexpArg() { result.isReceiver() }
@@ -57,7 +55,7 @@ module Regexp {
 
   private class ReplaceFunction extends RegexpReplaceFunction::Range, Method {
     ReplaceFunction() {
-      exists(string fn | fn.matches("ReplaceAll%") | this.hasQualifiedName("regexp", "Regexp", fn))
+      exists(string fn | fn.matches("ReplaceAll%") | hasQualifiedName("regexp", "Regexp", fn))
     }
 
     override FunctionInput getRegexpArg() { result.isReceiver() }
@@ -88,77 +86,77 @@ module Regexp {
 
     MethodModels() {
       // signature: func (*Regexp).Expand(dst []byte, template []byte, src []byte, match []int) []byte
-      this.hasQualifiedName("regexp", "Regexp", "Expand") and
+      hasQualifiedName("regexp", "Regexp", "Expand") and
       (
         inp.isParameter([1, 2]) and
         (outp.isParameter(0) or outp.isResult())
       )
       or
       // signature: func (*Regexp).ExpandString(dst []byte, template string, src string, match []int) []byte
-      this.hasQualifiedName("regexp", "Regexp", "ExpandString") and
+      hasQualifiedName("regexp", "Regexp", "ExpandString") and
       (
         inp.isParameter([1, 2]) and
         (outp.isParameter(0) or outp.isResult())
       )
       or
       // signature: func (*Regexp).Find(b []byte) []byte
-      this.hasQualifiedName("regexp", "Regexp", "Find") and
+      hasQualifiedName("regexp", "Regexp", "Find") and
       (inp.isParameter(0) and outp.isResult())
       or
       // signature: func (*Regexp).FindAll(b []byte, n int) [][]byte
-      this.hasQualifiedName("regexp", "Regexp", "FindAll") and
+      hasQualifiedName("regexp", "Regexp", "FindAll") and
       (inp.isParameter(0) and outp.isResult())
       or
       // signature: func (*Regexp).FindAllString(s string, n int) []string
-      this.hasQualifiedName("regexp", "Regexp", "FindAllString") and
+      hasQualifiedName("regexp", "Regexp", "FindAllString") and
       (inp.isParameter(0) and outp.isResult())
       or
       // signature: func (*Regexp).FindAllStringSubmatch(s string, n int) [][]string
-      this.hasQualifiedName("regexp", "Regexp", "FindAllStringSubmatch") and
+      hasQualifiedName("regexp", "Regexp", "FindAllStringSubmatch") and
       (inp.isParameter(0) and outp.isResult())
       or
       // signature: func (*Regexp).FindAllSubmatch(b []byte, n int) [][][]byte
-      this.hasQualifiedName("regexp", "Regexp", "FindAllSubmatch") and
+      hasQualifiedName("regexp", "Regexp", "FindAllSubmatch") and
       (inp.isParameter(0) and outp.isResult())
       or
       // signature: func (*Regexp).FindString(s string) string
-      this.hasQualifiedName("regexp", "Regexp", "FindString") and
+      hasQualifiedName("regexp", "Regexp", "FindString") and
       (inp.isParameter(0) and outp.isResult())
       or
       // signature: func (*Regexp).FindStringSubmatch(s string) []string
-      this.hasQualifiedName("regexp", "Regexp", "FindStringSubmatch") and
+      hasQualifiedName("regexp", "Regexp", "FindStringSubmatch") and
       (inp.isParameter(0) and outp.isResult())
       or
       // signature: func (*Regexp).FindSubmatch(b []byte) [][]byte
-      this.hasQualifiedName("regexp", "Regexp", "FindSubmatch") and
+      hasQualifiedName("regexp", "Regexp", "FindSubmatch") and
       (inp.isParameter(0) and outp.isResult())
       or
       // signature: func (*Regexp).ReplaceAll(src []byte, repl []byte) []byte
-      this.hasQualifiedName("regexp", "Regexp", "ReplaceAll") and
+      hasQualifiedName("regexp", "Regexp", "ReplaceAll") and
       (inp.isParameter(_) and outp.isResult())
       or
       // signature: func (*Regexp).ReplaceAllFunc(src []byte, repl func([]byte) []byte) []byte
-      this.hasQualifiedName("regexp", "Regexp", "ReplaceAllFunc") and
+      hasQualifiedName("regexp", "Regexp", "ReplaceAllFunc") and
       (inp.isParameter(_) and outp.isResult())
       or
       // signature: func (*Regexp).ReplaceAllLiteral(src []byte, repl []byte) []byte
-      this.hasQualifiedName("regexp", "Regexp", "ReplaceAllLiteral") and
+      hasQualifiedName("regexp", "Regexp", "ReplaceAllLiteral") and
       (inp.isParameter(_) and outp.isResult())
       or
       // signature: func (*Regexp).ReplaceAllLiteralString(src string, repl string) string
-      this.hasQualifiedName("regexp", "Regexp", "ReplaceAllLiteralString") and
+      hasQualifiedName("regexp", "Regexp", "ReplaceAllLiteralString") and
       (inp.isParameter(_) and outp.isResult())
       or
       // signature: func (*Regexp).ReplaceAllString(src string, repl string) string
-      this.hasQualifiedName("regexp", "Regexp", "ReplaceAllString") and
+      hasQualifiedName("regexp", "Regexp", "ReplaceAllString") and
       (inp.isParameter(_) and outp.isResult())
       or
       // signature: func (*Regexp).ReplaceAllStringFunc(src string, repl func(string) string) string
-      this.hasQualifiedName("regexp", "Regexp", "ReplaceAllStringFunc") and
+      hasQualifiedName("regexp", "Regexp", "ReplaceAllStringFunc") and
       (inp.isParameter(_) and outp.isResult())
       or
       // signature: func (*Regexp).Split(s string, n int) []string
-      this.hasQualifiedName("regexp", "Regexp", "Split") and
+      hasQualifiedName("regexp", "Regexp", "Split") and
       (inp.isParameter(0) and outp.isResult())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Strings.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Strings.qll
@@ -143,15 +143,15 @@ module Strings {
 
     MethodModels() {
       // signature: func (*Reader).Reset(s string)
-      this.hasQualifiedName("strings", "Reader", "Reset") and
+      hasQualifiedName("strings", "Reader", "Reset") and
       (inp.isParameter(0) and outp.isReceiver())
       or
       // signature: func (*Replacer).Replace(s string) string
-      this.hasQualifiedName("strings", "Replacer", "Replace") and
+      hasQualifiedName("strings", "Replacer", "Replace") and
       (inp.isParameter(0) and outp.isResult())
       or
       // signature: func (*Replacer).WriteString(w io.Writer, s string) (n int, err error)
-      this.hasQualifiedName("strings", "Replacer", "WriteString") and
+      hasQualifiedName("strings", "Replacer", "WriteString") and
       (inp.isParameter(1) and outp.isParameter(0))
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Strings.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Strings.qll
@@ -142,33 +142,9 @@ module Strings {
     FunctionOutput outp;
 
     MethodModels() {
-      // signature: func (*Builder).String() string
-      this.hasQualifiedName("strings", "Builder", "String") and
-      (inp.isReceiver() and outp.isResult())
-      or
-      // signature: func (*Builder).Write(p []byte) (int, error)
-      this.hasQualifiedName("strings", "Builder", "Write") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
-      // signature: func (*Builder).WriteString(s string) (int, error)
-      this.hasQualifiedName("strings", "Builder", "WriteString") and
-      (inp.isParameter(0) and outp.isReceiver())
-      or
-      // signature: func (*Reader).Read(b []byte) (n int, err error)
-      this.hasQualifiedName("strings", "Reader", "Read") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
-      // signature: func (*Reader).ReadAt(b []byte, off int64) (n int, err error)
-      this.hasQualifiedName("strings", "Reader", "ReadAt") and
-      (inp.isReceiver() and outp.isParameter(0))
-      or
       // signature: func (*Reader).Reset(s string)
       this.hasQualifiedName("strings", "Reader", "Reset") and
       (inp.isParameter(0) and outp.isReceiver())
-      or
-      // signature: func (*Reader).WriteTo(w io.Writer) (n int64, err error)
-      this.hasQualifiedName("strings", "Reader", "WriteTo") and
-      (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (*Replacer).Replace(s string) string
       this.hasQualifiedName("strings", "Replacer", "Replace") and

--- a/ql/src/semmle/go/frameworks/stdlib/Sync.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Sync.qll
@@ -12,11 +12,11 @@ module Sync {
 
     MethodModels() {
       // signature: func (*Map).Load(key interface{}) (value interface{}, ok bool)
-      this.hasQualifiedName("sync", "Map", "Load") and
+      hasQualifiedName("sync", "Map", "Load") and
       (inp.isReceiver() and outp.isResult(0))
       or
       // signature: func (*Map).LoadOrStore(key interface{}, value interface{}) (actual interface{}, loaded bool)
-      this.hasQualifiedName("sync", "Map", "LoadOrStore") and
+      hasQualifiedName("sync", "Map", "LoadOrStore") and
       (
         inp.isReceiver() and outp.isResult(0)
         or
@@ -25,15 +25,15 @@ module Sync {
       )
       or
       // signature: func (*Map).Store(key interface{}, value interface{})
-      this.hasQualifiedName("sync", "Map", "Store") and
+      hasQualifiedName("sync", "Map", "Store") and
       (inp.isParameter(_) and outp.isReceiver())
       or
       // signature: func (*Pool).Get() interface{}
-      this.hasQualifiedName("sync", "Pool", "Get") and
+      hasQualifiedName("sync", "Pool", "Get") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Pool).Put(x interface{})
-      this.hasQualifiedName("sync", "Pool", "Put") and
+      hasQualifiedName("sync", "Pool", "Put") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/SyncAtomic.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/SyncAtomic.qll
@@ -70,11 +70,11 @@ module SyncAtomic {
 
     MethodModels() {
       // signature: func (*Value).Load() (x interface{})
-      this.hasQualifiedName("sync/atomic", "Value", "Load") and
+      hasQualifiedName("sync/atomic", "Value", "Load") and
       (inp.isReceiver() and outp.isResult())
       or
       // signature: func (*Value).Store(x interface{})
-      this.hasQualifiedName("sync/atomic", "Value", "Store") and
+      hasQualifiedName("sync/atomic", "Value", "Store") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/Syscall.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/Syscall.qll
@@ -43,11 +43,11 @@ module Syscall {
 
     MethodModels() {
       // signature: func (RawConn).Read(f func(fd uintptr) (done bool)) error
-      this.implements("syscall", "RawConn", "Read") and
+      implements("syscall", "RawConn", "Read") and
       (inp.isReceiver() and outp.isParameter(0))
       or
       // signature: func (Conn).SyscallConn() (RawConn, error)
-      this.implements("syscall", "Conn", "SyscallConn") and
+      implements("syscall", "Conn", "SyscallConn") and
       (
         inp.isReceiver() and outp.isResult(0)
         or
@@ -55,7 +55,7 @@ module Syscall {
       )
       or
       // signature: func (RawConn).Write(f func(fd uintptr) (done bool)) error
-      this.implements("syscall", "RawConn", "Write") and
+      implements("syscall", "RawConn", "Write") and
       (inp.isParameter(0) and outp.isReceiver())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/TextScanner.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/TextScanner.qll
@@ -12,14 +12,14 @@ module TextScanner {
 
     MethodModels() {
       // signature: func (*Scanner).Init(src io.Reader) *Scanner
-      this.hasQualifiedName("text/scanner", "Scanner", "Init") and
+      hasQualifiedName("text/scanner", "Scanner", "Init") and
       (
         inp.isParameter(0) and
         (outp.isReceiver() or outp.isResult())
       )
       or
       // signature: func (*Scanner).TokenText() string
-      this.hasQualifiedName("text/scanner", "Scanner", "TokenText") and
+      hasQualifiedName("text/scanner", "Scanner", "TokenText") and
       (inp.isReceiver() and outp.isResult())
     }
 

--- a/ql/src/semmle/go/frameworks/stdlib/TextTabwriter.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/TextTabwriter.qll
@@ -27,7 +27,7 @@ module TextTabwriter {
 
     MethodModels() {
       // signature: func (*Writer).Init(output io.Writer, minwidth int, tabwidth int, padding int, padchar byte, flags uint) *Writer
-      this.hasQualifiedName("text/tabwriter", "Writer", "Init") and
+      hasQualifiedName("text/tabwriter", "Writer", "Init") and
       (
         (inp.isReceiver() or inp.isResult()) and
         outp.isParameter(0)

--- a/ql/src/semmle/go/frameworks/stdlib/TextTabwriter.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/TextTabwriter.qll
@@ -32,10 +32,6 @@ module TextTabwriter {
         (inp.isReceiver() or inp.isResult()) and
         outp.isParameter(0)
       )
-      or
-      // signature: func (*Writer).Write(buf []byte) (n int, err error)
-      this.hasQualifiedName("text/tabwriter", "Writer", "Write") and
-      (inp.isParameter(0) and outp.isReceiver())
     }
 
     override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {

--- a/ql/src/semmle/go/frameworks/stdlib/TextTemplate.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/TextTemplate.qll
@@ -88,11 +88,11 @@ module TextTemplate {
 
     MethodModels() {
       // signature: func (*Template).Execute(wr io.Writer, data interface{}) error
-      this.hasQualifiedName("text/template", "Template", "Execute") and
+      hasQualifiedName("text/template", "Template", "Execute") and
       (inp.isParameter(1) and outp.isParameter(0))
       or
       // signature: func (*Template).ExecuteTemplate(wr io.Writer, name string, data interface{}) error
-      this.hasQualifiedName("text/template", "Template", "ExecuteTemplate") and
+      hasQualifiedName("text/template", "Template", "ExecuteTemplate") and
       (inp.isParameter(2) and outp.isParameter(0))
     }
 


### PR DESCRIPTION
This PR removes models for methods that are already covered by their interface models.

Also, a minor stylistic fix: remove the `this.` for generated method and interface models (functions already did not have it).

---

:confetti_ball: :partying_face: :partying_face: :partying_face: :confetti_ball:   This is the **last** part of #167 :confetti_ball:  :partying_face: :partying_face: :partying_face: :confetti_ball: 

Thanks @smowton @max-schaefer !