### PR TITLE
LGTM: add Metrics/FLinesOfComment.ql to go-lgtm-full.qls

### DIFF
--- a/ql/src/codeql-suites/go-lgtm-full.qls
+++ b/ql/src/codeql-suites/go-lgtm-full.qls
@@ -8,4 +8,4 @@
       - ide-contextual-queries/local-definitions
       - ide-contextual-queries/local-references
 - query: Metrics/FLinesOfCode.ql
-
+- query: Metrics/FLinesOfComment.ql


### PR DESCRIPTION
The `go-lgtm-full.qls` should match the query suite as run by LGTM. The `Metrics/FLinesOfComment.ql ` query was missing.