### PR TITLE
Improve extractor logging and a minor readability fix

### DIFF
--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -32,6 +32,12 @@ func Extract(patterns []string) error {
 
 // ExtractWithFlags extracts the packages specified by the given patterns and build flags
 func ExtractWithFlags(buildFlags []string, patterns []string) error {
+	modEnabled := os.Getenv("GO111MODULE") != "off"
+	if !modEnabled {
+		log.Println("Go module mode disabled.")
+	}
+
+	log.Println("Running packages.Load.")
 	cfg := &packages.Config{
 		Mode: packages.NeedName | packages.NeedFiles |
 			packages.NeedCompiledGoFiles |
@@ -52,12 +58,15 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 	if err != nil {
 		return err
 	}
+	log.Println("Done running packages.Load.")
 
 	if len(pkgs) == 0 {
-		log.Printf("No packages found.")
+		log.Println("No packages found.")
 	}
 
+	log.Println("Extracting universe scope.")
 	extractUniverseScope()
+	log.Println("Done extracting universe scope.")
 
 	// a map of package path to package root directory (currently the module root or the source directory)
 	pkgRoots := make(map[string]string)
@@ -72,6 +81,8 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 	packages.Visit(pkgs, func(pkg *packages.Package) bool {
 		return true
 	}, func(pkg *packages.Package) {
+		log.Printf("Processing package %s.", pkg.PkgPath)
+
 		if _, ok := pkgRoots[pkg.PkgPath]; !ok {
 			mdir := util.GetModDir(pkg.PkgPath, modFlags...)
 			pdir := util.GetPkgDir(pkg.PkgPath, modFlags...)
@@ -83,6 +94,8 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 			pkgRoots[pkg.PkgPath] = mdir
 			pkgDirs[pkg.PkgPath] = pdir
 		}
+
+		log.Printf("Extracting types for package %s.", pkg.PkgPath)
 
 		tw, err := trap.NewWriter(pkg.PkgPath, pkg)
 		if err != nil {
@@ -102,6 +115,7 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 				extractError(tw, err, lbl, i)
 			}
 		}
+		log.Printf("Done extracting types for package %s.", pkg.PkgPath)
 	})
 
 	for _, pkg := range pkgs {
@@ -110,6 +124,10 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 		}
 		wantedRoots[pkgRoots[pkg.PkgPath]] = true
 	}
+
+	log.Println("Done processing dependencies.")
+
+	log.Println("Starting to extract packages.")
 
 	// this sets the number of threads that the Go runtime will spawn; this is separate
 	// from the number of goroutines that the program spawns, which are scheduled into
@@ -163,9 +181,14 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 			extractPackage(pkg, &wg, goroutineSem, fdSem)
 			return
 		}
+
+		log.Printf("Skipping dependency package %s.", pkg.PkgPath)
 	})
 
 	wg.Wait()
+
+	log.Println("Done extracting packages.")
+	log.Println("Starting to extract go.mod files.")
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -203,6 +226,8 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 		end := time.Since(start)
 		log.Printf("Done extracting %s (%dms)", path, end.Nanoseconds()/1000000)
 	}
+
+	log.Println("Done extracting go.mod files.")
 
 	return nil
 }

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -37,6 +37,13 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 		log.Println("Go module mode disabled.")
 	}
 
+	modFlags := make([]string, 0, 1)
+	for _, flag := range buildFlags {
+		if strings.HasPrefix(flag, "-mod=") {
+			modFlags = append(modFlags, flag)
+		}
+	}
+
 	log.Println("Running packages.Load.")
 	cfg := &packages.Config{
 		Mode: packages.NeedName | packages.NeedFiles |
@@ -47,14 +54,6 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 		BuildFlags: buildFlags,
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
-
-	modFlags := make([]string, 0, 1)
-	for _, flag := range buildFlags {
-		if strings.HasPrefix(flag, "-mod=") {
-			modFlags = append(modFlags, flag)
-		}
-	}
-
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
These changes are mostly changes that were for Kubernetes.

 - Package directory as a wanted root
  
   This makes the extractor actually extract vendor packages when they're explicitly passed to a build command; before the wanted root would be the mod directory, and so the all the files would because the relative path to the root includes `vendor`. I'm not 100% sure we should do this, but that was my intention when I made the original changes, so I've changed this.

 - Enable Go modules while determining module directory

   This force enables modules while running `go list -f {{.Module}} ...` so that even if `GO111MODULE=off` is set manually, we can still detect module directory. This is done by Kubernetes, and the change increases the coverage of the database significantly.

 - Improve extractor logging

   Added a bunch of miscellaneous logging. I've discovered that a lot of the time spent extracting is actually spent in the single-threaded bit where we walk dependencies and extract types; ideally we'd be able to parallelize that a bit with a topological sort or something similar.