### PR TITLE
Add Action to build and upload qhelp

### DIFF
--- a/.github/workflows/codeqltest.yml
+++ b/.github/workflows/codeqltest.yml
@@ -20,7 +20,7 @@ jobs:
         echo "Done"
         cd $HOME
         echo "Downloading CodeQL CLI..."
-        curl https://github.com/github/codeql-cli-binaries/releases/download/v2.2.5/codeql.zip -L -o codeql.zip
+        curl https://github.com/github/codeql-cli-binaries/releases/download/v2.3.0/codeql.zip -L -o codeql.zip
         echo "Done"
         echo "Unpacking CodeQL CLI..."
         unzip -q codeql.zip
@@ -35,6 +35,15 @@ jobs:
 
     - name: Check that all QL and Go code is autoformatted
       run: env PATH=$PATH:$HOME/codeql make check-formatting
+
+    - name: Compile qhelp files to markdown
+      run: env PATH=$PATH:$HOME/codeql QHELP_OUT_DIR=qhelp-out make qhelp-to-markdown
+
+    - name: Upload qhelp markdown
+      uses: actions/upload-artifact@v2
+      with:
+        name: qhelp-markdown
+        path: qhelp-out/**/*.md
 
     - name: Test
       run: env PATH=$PATH:$HOME/codeql make test

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,14 @@ check-formatting:
 	find ql/src -name "*.ql" -or -name "*.qll" | xargs codeql query format --check-only
 	test -z "$$(git ls-files | grep \\.go$ | grep -v ^vendor/ | xargs grep -L "//\s*autoformat-ignore" | xargs gofmt -l)"
 
+ifeq ($(QHELP_OUT_DIR),)
+# If not otherwise specified, compile qhelp to markdown in place
+QHELP_OUT_DIR := ql/src
+endif
+
+qhelp-to-markdown:
+	scripts/qhelp-to-markdown.sh ql/src "$(QHELP_OUT_DIR)"
+
 tools: $(addsuffix $(EXE),$(addprefix tools/bin/,$(BINARIES))) tools/tokenizer.jar
 
 .PHONY: $(addsuffix $(EXE),$(addprefix tools/bin/,$(BINARIES)))

--- a/scripts/qhelp-to-markdown.sh
+++ b/scripts/qhelp-to-markdown.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -ne 2 ]; then
+  echo "Usage: qhelp-to-markdown.sh qhelp-directory out-directory"
+  exit 1
+fi
+
+for qh in $(find $1 -name "*.qhelp"); do 
+  mkdir -p $2/$(dirname $qh)
+  codeql generate query-help --format=markdown $qh > $2/${qh/qhelp/md}
+done


### PR DESCRIPTION
This tests that qhelp builds to markdown, and uploads an artefact containing the built help. I punted on determining which qhelp files you consider changed in a local checkout / push build / PR build since the total build time is about 10 seconds and the artefact is 40KB.