### PR TITLE
Improve variable names in example code

### DIFF
--- a/ql/src/Security/CWE-020/SuspiciousCharacterInRegexp.go
+++ b/ql/src/Security/CWE-020/SuspiciousCharacterInRegexp.go
@@ -3,8 +3,8 @@ package main
 import "regexp"
 
 func broken(hostNames []byte) string {
-	var htmlRe = regexp.MustCompile("\bforbidden.host.org")
-	if htmlRe.Match(hostNames) {
+	var hostRe = regexp.MustCompile("\bforbidden.host.org")
+	if hostRe.Match(hostNames) {
 		return "Must not target forbidden.host.org"
 	} else {
 		// This will be reached even if hostNames is exactly "forbidden.host.org",

--- a/ql/src/Security/CWE-020/SuspiciousCharacterInRegexpGood.go
+++ b/ql/src/Security/CWE-020/SuspiciousCharacterInRegexpGood.go
@@ -3,8 +3,8 @@ package main
 import "regexp"
 
 func fixed(hostNames []byte) string {
-	var htmlRe = regexp.MustCompile("\\bforbidden.host.org")
-	if htmlRe.Match(hostNames) {
+	var hostRe = regexp.MustCompile("\\bforbidden.host.org")
+	if hostRe.Match(hostNames) {
 		return "Must not target forbidden.host.org"
 	} else {
 		// hostNames definitely doesn't contain a word "forbidden.host.org", as "\\b"


### PR DESCRIPTION
These were inherited from the JS version of the example, which concerns HTML.