### PR TITLE
Check dependencies before skipping dependency installation

### DIFF
--- a/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -455,8 +455,15 @@ func main() {
 		// try to build the project
 		buildSucceeded := autobuilder.Autobuild()
 
+		// Build failed or there are still dependency errors; we'll try to install dependencies
+		// ourselves
 		if !buildSucceeded {
-			// Build failed; we'll try to install dependencies ourselves
+			log.Println("Build failed, continuing to install dependencies.")
+
+			shouldInstallDependencies = true
+		} else if util.DepErrors("./...", modMode.argsForGoVersion(getEnvGoSemVer())...) {
+			log.Println("Dependencies are still not resolving after the build, continuing to install dependencies.")
+
 			shouldInstallDependencies = true
 		}
 	} else {

--- a/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -293,12 +293,14 @@ func main() {
 		log.Println("Found glide.yaml, enabling go modules")
 	}
 
-	// if a vendor/modules.txt file exists, we assume that there are vendored Go dependencies, and
-	// skip the dependency installation step and run the extractor with `-mod=vendor`
-	if util.FileExists("vendor/modules.txt") {
-		modMode = ModVendor
-	} else if util.DirExists("vendor") {
-		modMode = ModMod
+	if depMode == GoGetWithModules {
+		// if a vendor/modules.txt file exists, we assume that there are vendored Go dependencies, and
+		// skip the dependency installation step and run the extractor with `-mod=vendor`
+		if util.FileExists("vendor/modules.txt") {
+			modMode = ModVendor
+		} else if util.DirExists("vendor") {
+			modMode = ModMod
+		}
 	}
 
 	if modMode == ModVendor {

--- a/extractor/util/util.go
+++ b/extractor/util/util.go
@@ -90,6 +90,18 @@ func GetPkgDir(pkgpath string, flags ...string) string {
 	return abs
 }
 
+// DepErrors checks there are any errors resolving dependencies for `pkgpath`. It passes the `go
+// list` command the flags specified by `flags`.
+func DepErrors(pkgpath string, flags ...string) bool {
+	out, err := runGoList("{{if .DepsErrors}}{{else}}error{{end}}", pkgpath, flags...)
+	if err != nil {
+		// if go list failed, assume dependencies are broken
+		return false
+	}
+
+	return out != ""
+}
+
 // FileExists tests whether the file at `filename` exists and is not a directory.
 func FileExists(filename string) bool {
 	info, err := os.Stat(filename)


### PR DESCRIPTION
Ran into some issues when testing a few projects where builds were unrelated to Go / exited 0 despite failing, so I wrote this quick change.