### PR TITLE
Fix escaping in Makefile targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,11 @@ DATAFLOW_BRANCH=master
 
 autoformat:
 	find ql/src -name "*.ql" -or -name "*.qll" | xargs codeql query format -qq -i
-	git ls-files | grep \\.go$$ | grep -v ^vendor/ | xargs grep -L "//\s*autoformat-ignore" | xargs gofmt -w
+	git ls-files | grep '\.go$$' | grep -v ^vendor/ | xargs grep -L "//\s*autoformat-ignore" | xargs gofmt -w
 
 check-formatting:
 	find ql/src -name "*.ql" -or -name "*.qll" | xargs codeql query format --check-only
-	test -z "$$(git ls-files | grep \\.go$ | grep -v ^vendor/ | xargs grep -L "//\s*autoformat-ignore" | xargs gofmt -l)"
+	test -z "$$(git ls-files | grep '\.go$$' | grep -v ^vendor/ | xargs grep -L "//\s*autoformat-ignore" | xargs gofmt -l)"
 
 tools: $(addsuffix $(EXE),$(addprefix tools/bin/,$(BINARIES))) tools/tokenizer.jar
 


### PR DESCRIPTION
Previously, invoking `make autoformat` would run a command of this form:

```sh
... | grep \\.go$ | ...
```

Note that the `$` is not escaped. This probably wasn't intended, even though it happens to work anyway, since the shell doesn't try to expand lone `$`s.

More problematically, invoking `make check-formatting` would run a command of this form:

```sh
... | grep \\.go| ...
```

Note that the `$` is gone, so it matches `.go` anywhere in the file name. In particular, it matches `ql/test/library-tests/semmle/go/frameworks/Protobuf/vendor/google.golang.org/protobuf/LICENSE`, which I think is responsible for the somewhat mysterious "expected 'package', found Copyright" errors we occasionally saw in CI. (Though the recently added `grep -v vendor` also fixed that.)

This PR fixes both targets to run

```sh
... | grep '\.go$' | ...
```

Because of the single quotes we only need a single backslash, and the `$` gets left alone.