### PR TITLE
Replace getEncodedFile with getFileBySourceArchiveName predicate

### DIFF
--- a/ql/src/ideContextual.qll
+++ b/ql/src/ideContextual.qll
@@ -6,7 +6,18 @@
 import go
 
 /**
- * Gets the `File` with encoded name `name`.
+ * Returns the `File` matching the given source file name as encoded by the VS
+ * Code extension.
  */
 cached
-File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }
+File getFileBySourceArchiveName(string name) {
+  // The name provided for a file in the source archive by the VS Code extension
+  // has some differences from the absolute path in the database:
+  // 1. colons are replaced by underscores
+  // 2. there's a leading slash, even for Windows paths: "C:/foo/bar" ->
+  //    "/C_/foo/bar"
+  // 3. double slashes in UNC prefixes are replaced with a single slash
+  // We can handle 2 and 3 together by unconditionally adding a leading slash
+  // before replacing double slashes.
+  name = ("/" + result.getAbsolutePath().replaceAll(":", "_")).replaceAll("//", "/")
+}

--- a/ql/src/localDefinitions.ql
+++ b/ql/src/localDefinitions.ql
@@ -13,5 +13,8 @@ import ideContextual
 external string selectedSourceFile();
 
 from Ident def, Ident use, Entity e
-where use.uses(e) and def.declares(e) and use.getFile() = getEncodedFile(selectedSourceFile())
+where
+  use.uses(e) and
+  def.declares(e) and
+  use.getFile() = getFileBySourceArchiveName(selectedSourceFile())
 select use, def, "V"

--- a/ql/src/localReferences.ql
+++ b/ql/src/localReferences.ql
@@ -13,5 +13,8 @@ import ideContextual
 external string selectedSourceFile();
 
 from Ident def, Ident use, Entity e
-where use.uses(e) and def.declares(e) and def.getFile() = getEncodedFile(selectedSourceFile())
+where
+  use.uses(e) and
+  def.declares(e) and
+  def.getFile() = getFileBySourceArchiveName(selectedSourceFile())
 select use, def, "V"

--- a/ql/src/printAst.ql
+++ b/ql/src/printAst.ql
@@ -22,7 +22,9 @@ external string selectedSourceFile();
 class Cfg extends PrintAstConfiguration {
   override predicate shouldPrintFunction(FuncDecl func) { shouldPrintFile(func.getFile()) }
 
-  override predicate shouldPrintFile(File file) { file = getEncodedFile(selectedSourceFile()) }
+  override predicate shouldPrintFile(File file) {
+    file = getFileBySourceArchiveName(selectedSourceFile())
+  }
 
   override predicate shouldPrintComments(File file) { none() }
 }


### PR DESCRIPTION
While also making it work with paths for databases created on Windows.

This matches the changes in https://github.com/github/codeql/pull/4643