### PR TITLE
Note that `fmt.Errorf` returns non-nil

### DIFF
--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -1285,6 +1285,8 @@ private predicate certainlyReturnsNonNil(Function f, FunctionOutput output) {
   (
     f.hasQualifiedName("errors", "New")
     or
+    f.hasQualifiedName("fmt", "Errorf")
+    or
     f in [Builtin::new(), Builtin::make()]
     or
     exists(FuncDecl fd | fd = f.getFuncDecl() |


### PR DESCRIPTION
This enables recognising more guarding functions that return nil/non-nil conditional on a barrier guard.