### PR TITLE
Make EqualityTestGuard a default taint sanitizer guard

### DIFF
--- a/change-notes/2021-01-21-default-sanitizer-guard.md
+++ b/change-notes/2021-01-21-default-sanitizer-guard.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* An equality comparison with a constant value now sanitizes the other value. This was already the case in XSS queries, but it now applies in all queries involving tainted data flow. This should lead to fewer false positive results.

--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -1126,7 +1126,7 @@ abstract class BarrierGuard extends Node {
     exists(ControlFlow::ConditionGuardNode guard, Node nd, SsaWithFields var |
       result = var.getAUse()
     |
-      guards(guard, nd, var) and
+      this.guards(guard, nd, var) and
       guard.dominates(result.getBasicBlock())
     )
   }
@@ -1139,7 +1139,7 @@ abstract class BarrierGuard extends Node {
    */
   pragma[noinline]
   private predicate guards(ControlFlow::ConditionGuardNode guard, Node nd, SsaWithFields ap) {
-    guards(guard, nd) and nd = ap.getAUse()
+    this.guards(guard, nd) and nd = ap.getAUse()
   }
 
   /**

--- a/ql/src/semmle/go/dataflow/internal/TaintTrackingUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/TaintTrackingUtil.qll
@@ -200,3 +200,26 @@ abstract class DefaultTaintSanitizerGuard extends DataFlow::BarrierGuard { }
 predicate isDefaultTaintSanitizerGuard(DataFlow::BarrierGuard guard) {
   guard instanceof DefaultTaintSanitizerGuard
 }
+
+/**
+ * An equality test acting as a sanitizer guard for `nonConstNode` by
+ * restricting it to a known value.
+ *
+ * Note that comparisons to `nil` are excluded. This is needed for performance
+ * reasons.
+ */
+class EqualityTestGuard extends DefaultTaintSanitizerGuard, DataFlow::EqualityTestNode {
+  DataFlow::Node nonConstNode;
+
+  EqualityTestGuard() {
+    this.getAnOperand().isConst() and
+    nonConstNode = this.getAnOperand() and
+    not nonConstNode.isConst() and
+    not this.getAnOperand() = Builtin::nil().getARead()
+  }
+
+  override predicate checks(Expr e, boolean outcome) {
+    e = nonConstNode.asExpr() and
+    outcome = this.getPolarity()
+  }
+}

--- a/ql/src/semmle/go/dataflow/internal/TaintTrackingUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/TaintTrackingUtil.qll
@@ -186,4 +186,4 @@ abstract class DefaultTaintSanitizer extends DataFlow::Node { }
  * Holds if `node` should be a sanitizer in all global taint flow configurations
  * but not in local taint.
  */
-predicate defaultTaintSanitizer(DataFlow::Node node) { node instanceof DefaultTaintSanitizer }
+predicate isDefaultTaintSanitizer(DataFlow::Node node) { node instanceof DefaultTaintSanitizer }

--- a/ql/src/semmle/go/dataflow/internal/TaintTrackingUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/TaintTrackingUtil.qll
@@ -187,3 +187,16 @@ abstract class DefaultTaintSanitizer extends DataFlow::Node { }
  * but not in local taint.
  */
 predicate isDefaultTaintSanitizer(DataFlow::Node node) { node instanceof DefaultTaintSanitizer }
+
+/**
+ * A sanitizer guard in all global taint flow configurations but not in local taint.
+ */
+abstract class DefaultTaintSanitizerGuard extends DataFlow::BarrierGuard { }
+
+/**
+ * Holds if `guard` should be a sanitizer guard in all global taint flow configurations
+ * but not in local taint.
+ */
+predicate isDefaultTaintSanitizerGuard(DataFlow::BarrierGuard guard) {
+  guard instanceof DefaultTaintSanitizerGuard
+}

--- a/ql/src/semmle/go/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/ql/src/semmle/go/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -92,7 +92,9 @@ abstract class Configuration extends DataFlow::Configuration {
   /** Holds if taint propagation through nodes guarded by `guard` is prohibited. */
   predicate isSanitizerGuard(DataFlow::BarrierGuard guard) { none() }
 
-  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) { isSanitizerGuard(guard) }
+  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) {
+    isSanitizerGuard(guard) or isDefaultTaintSanitizerGuard(guard)
+  }
 
   /**
    * Holds if the additional taint propagation step from `node1` to `node2`

--- a/ql/src/semmle/go/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/ql/src/semmle/go/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -76,7 +76,7 @@ abstract class Configuration extends DataFlow::Configuration {
 
   final override predicate isBarrier(DataFlow::Node node) {
     isSanitizer(node) or
-    defaultTaintSanitizer(node)
+    isDefaultTaintSanitizer(node)
   }
 
   /** Holds if taint propagation into `node` is prohibited. */

--- a/ql/src/semmle/go/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/ql/src/semmle/go/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -92,7 +92,9 @@ abstract class Configuration extends DataFlow::Configuration {
   /** Holds if taint propagation through nodes guarded by `guard` is prohibited. */
   predicate isSanitizerGuard(DataFlow::BarrierGuard guard) { none() }
 
-  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) { isSanitizerGuard(guard) }
+  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) {
+    isSanitizerGuard(guard) or isDefaultTaintSanitizerGuard(guard)
+  }
 
   /**
    * Holds if the additional taint propagation step from `node1` to `node2`

--- a/ql/src/semmle/go/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/ql/src/semmle/go/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -76,7 +76,7 @@ abstract class Configuration extends DataFlow::Configuration {
 
   final override predicate isBarrier(DataFlow::Node node) {
     isSanitizer(node) or
-    defaultTaintSanitizer(node)
+    isDefaultTaintSanitizer(node)
   }
 
   /** Holds if taint propagation into `node` is prohibited. */

--- a/ql/src/semmle/go/security/Xss.qll
+++ b/ql/src/semmle/go/security/Xss.qll
@@ -103,15 +103,4 @@ module SharedXss {
       )
     }
   }
-
-  /**
-   * A check against a constant value, considered a barrier for XSS.
-   */
-  class EqualityTestGuard extends SanitizerGuard, DataFlow::EqualityTestNode {
-    override predicate checks(Expr e, boolean outcome) {
-      this.getAnOperand().isConst() and
-      e = this.getAnOperand().asExpr() and
-      outcome = this.getPolarity()
-    }
-  }
 }


### PR DESCRIPTION
Adds the ability to create a taint sanitizer guard that applies in all configurations. (This is already possible for taint sanitizers.)

Also takes EqualityTestGuard from `Xss.qll` and makes it a default taint sanitizer guard. The thinking is that for most configurations, being tainted means being user controlled, and comparing a value to a constant means that it has been checked and found to be an expected value.