### PR TITLE
Make comment on BarrierGuard more specific

### DIFF
--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -1115,7 +1115,10 @@ predicate localFlow(Node source, Node sink) { localFlowStep*(source, sink) }
  * characteristic predicate precisely specifying the guard, and override
  * `checks` to specify what is being validated and in which branch.
  *
- * It is important that all extending classes in scope are disjoint.
+ * When using a data-flow or taint-flow configuration `cfg`, it is important
+ * that any classes extending BarrierGuard in scope which are not used in `cfg`
+ * are disjoint from any classes extending BarrierGuard in scope which are used
+ * in `cfg`.
  */
 abstract class BarrierGuard extends Node {
   /** Holds if this guard validates `e` upon evaluating to `branch`. */


### PR DESCRIPTION
The problem that this comment is trying to warn about is the following:
say you have two subclasses of BarrierGuard BG1 and BG2, both of which
contain some node g. Also assume that you have a configuration C which
specifies BG1 as a barrier guard, but not BG2. Because g is contained in
both classes, you will then still get the barrier guard definition from
BG2 due to the way dynamic dispatch works in QL.