### PR TITLE
Make PathContainmentCheck more specific

### DIFF
--- a/ql/src/semmle/go/security/TaintedPathCustomizations.qll
+++ b/ql/src/semmle/go/security/TaintedPathCustomizations.qll
@@ -85,7 +85,7 @@ module TaintedPath {
    * }
    * ```
    */
-  class PathContainmentCheck extends SanitizerGuard {
+  class PathContainmentCheck extends SanitizerGuard, DataFlow::EqualityTestNode {
     DataFlow::Node path;
     boolean outcome;
 


### PR DESCRIPTION
Recent changes to Property.checkOn mean that in the code
```err == nil && <unrelated-condition>```
PathContainmentCheck matches the first condition and the whole `&&`
expression. Originally it would have only matched the first condition,
and this commit restores that behaviour. This pattern appears 3 times in
the tests, which all still pass.