### PR TITLE
Remove models for html/template execution

### DIFF
--- a/ql/src/semmle/go/frameworks/stdlib/HtmlTemplate.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/HtmlTemplate.qll
@@ -62,23 +62,4 @@ module HtmlTemplate {
       input = inp and output = outp
     }
   }
-
-  private class MethodModels extends TaintTracking::FunctionModel, Method {
-    FunctionInput inp;
-    FunctionOutput outp;
-
-    MethodModels() {
-      // signature: func (*Template).Execute(wr io.Writer, data interface{}) error
-      hasQualifiedName("html/template", "Template", "Execute") and
-      (inp.isParameter(1) and outp.isParameter(0))
-      or
-      // signature: func (*Template).ExecuteTemplate(wr io.Writer, name string, data interface{}) error
-      hasQualifiedName("html/template", "Template", "ExecuteTemplate") and
-      (inp.isParameter(2) and outp.isParameter(0))
-    }
-
-    override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
-      input = inp and output = outp
-    }
-  }
 }

--- a/ql/test/library-tests/semmle/go/frameworks/StdlibTaintFlow/HtmlTemplate.go
+++ b/ql/test/library-tests/semmle/go/frameworks/StdlibTaintFlow/HtmlTemplate.go
@@ -51,22 +51,6 @@ func TaintStepTest_HtmlTemplateURLQueryEscaper_B0I0O0(sourceCQL interface{}) int
 	return intoString584
 }
 
-func TaintStepTest_HtmlTemplateTemplateExecute_B0I0O0(sourceCQL interface{}) interface{} {
-	fromInterface991 := sourceCQL.(interface{})
-	var intoWriter881 io.Writer
-	var mediumObjCQL template.Template
-	mediumObjCQL.Execute(intoWriter881, fromInterface991)
-	return intoWriter881
-}
-
-func TaintStepTest_HtmlTemplateTemplateExecuteTemplate_B0I0O0(sourceCQL interface{}) interface{} {
-	fromInterface186 := sourceCQL.(interface{})
-	var intoWriter284 io.Writer
-	var mediumObjCQL template.Template
-	mediumObjCQL.ExecuteTemplate(intoWriter284, "", fromInterface186)
-	return intoWriter284
-}
-
 func RunAllTaints_HtmlTemplate() {
 	{
 		source := newSource(0)
@@ -102,15 +86,5 @@ func RunAllTaints_HtmlTemplate() {
 		source := newSource(6)
 		out := TaintStepTest_HtmlTemplateURLQueryEscaper_B0I0O0(source)
 		sink(6, out)
-	}
-	{
-		source := newSource(7)
-		out := TaintStepTest_HtmlTemplateTemplateExecute_B0I0O0(source)
-		sink(7, out)
-	}
-	{
-		source := newSource(8)
-		out := TaintStepTest_HtmlTemplateTemplateExecuteTemplate_B0I0O0(source)
-		sink(8, out)
 	}
 }


### PR DESCRIPTION
These escape HTML and JavaScript anyhow; because they don't write to their return value they don't quite fit the form of EscapeFunction, so to be expedient I've simply removed their models entirely. Presumably the case where someone HTML-templates something and then uses it for a purpose where HTML sanitisation is insufficient is very rare anyhow.