### PR TITLE
Simplify Logrus model

### DIFF
--- a/change-notes/2021-02-15-logrus-updated.md
+++ b/change-notes/2021-02-15-logrus-updated.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Modeling of the `Logrus` logging library has been improved.  This may cause the `go/clear-text-logging` query to return more results when sensitive data is exposed using this library.

--- a/ql/src/semmle/go/frameworks/Logrus.qll
+++ b/ql/src/semmle/go/frameworks/Logrus.qll
@@ -22,12 +22,10 @@ module Logrus {
 
   private class LogCall extends LoggerCall::Range, DataFlow::CallNode {
     LogCall() {
-      this.getTarget().hasQualifiedName(packagePath(), getALogResultName()) or
-      this.getTarget().(Method).hasQualifiedName(packagePath(), "Entry", getALogResultName()) or
-      this.getTarget().hasQualifiedName(packagePath(), getAnEntryUpdatingMethodName()) or
-      this.getTarget()
-          .(Method)
-          .hasQualifiedName(packagePath(), "Entry", getAnEntryUpdatingMethodName())
+      exists(string name | name = getALogResultName() or name = getAnEntryUpdatingMethodName() |
+        this.getTarget().hasQualifiedName(packagePath(), name) or
+        this.getTarget().(Method).hasQualifiedName(packagePath(), "Entry", name)
+      )
     }
 
     override DataFlow::Node getAMessageComponent() { result = this.getAnArgument() }

--- a/ql/test/library-tests/semmle/go/concepts/LoggerCall/logrus.go
+++ b/ql/test/library-tests/semmle/go/concepts/LoggerCall/logrus.go
@@ -5,11 +5,12 @@ package main
 import (
 	"context"
 	"errors"
+
 	"github.com/sirupsen/logrus"
 )
 
 func logSomething(entry *logrus.Entry) {
-	entry.Traceln(text) // $logger=text $f-:logger=fields
+	entry.Traceln(text) // $logger=text
 }
 
 func logrusCalls() {
@@ -17,13 +18,13 @@ func logrusCalls() {
 	var fields logrus.Fields = nil
 	var fn logrus.LogFunction = nil
 	var ctx context.Context
-	tmp := logrus.WithContext(ctx)  //
-	tmp.Debugf(fmt, text)           // $logger=ctx $logger=fmt $logger=text
-	tmp = logrus.WithError(err)     //
-	tmp.Warn(text)                  // $logger=err $logger=text
-	tmp = logrus.WithFields(fields) //
-	tmp.Infoln(text)                // $logger=fields $logger=text
-	tmp = logrus.WithFields(fields) //
+	tmp := logrus.WithContext(ctx)  // $logger=ctx
+	tmp.Debugf(fmt, text)           // $logger=fmt $logger=text
+	tmp = logrus.WithError(err)     // $logger=err
+	tmp.Warn(text)                  // $logger=text
+	tmp = logrus.WithFields(fields) // $logger=fields
+	tmp.Infoln(text)                // $logger=text
+	tmp = logrus.WithFields(fields) // $logger=fields
 	logSomething(tmp)
 
 	logrus.Error(text)       // $logger=text


### PR DESCRIPTION
Make methods which add data to entries sinks in their own right, rather
than trying to track the data flow of the entry to a later logging call.

This may cause some false positives, but only in the situation that
tainted data is added to an entry and that entry is never logged. It will
save us from false negatives when tainted data is added to an entry
which flows across a function boundary to a logging call.