### PR TITLE
Add missing change notes

### DIFF
--- a/change-notes/2021-02-09-html-templates.md
+++ b/change-notes/2021-02-09-html-templates.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* Improved our modelling of Go's builtin `html/template` package to understand that these templates provide context-sensitive escaping of HTML and Javascript special characters. This may reduce false-positive seen by the `go/reflected-xss` query, as well as other queries for which HTML escaping is relevant.
+

--- a/change-notes/2021-02-09-html-templates.md
+++ b/change-notes/2021-02-09-html-templates.md
@@ -1,3 +1,2 @@
 lgtm,codescanning
-* Improved our modelling of Go's builtin `html/template` package to understand that these templates provide context-sensitive escaping of HTML and Javascript special characters. This may reduce false-positive seen by the `go/reflected-xss` query, as well as other queries for which HTML escaping is relevant.
-
+* Improved our modeling of Go's builtin `html/template` package to understand that these templates provide context-sensitive escaping of HTML and Javascript special characters. This may reduce false-positives seen by the `go/reflected-xss` query, as well as other queries for which HTML escaping is relevant.

--- a/change-notes/2021-02-10-cfg-equality-panic-edges.md
+++ b/change-notes/2021-02-10-cfg-equality-panic-edges.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Improved the Go control-flow graph to exclude more edges representing panics due to comparisons when the types of the compared values indicate a panic is impossible (for example, comparing integers cannot panic). This may reduce false-positives or false-negatives for any query for which control-flow is relevant.


### PR DESCRIPTION
I haven't included change-notes for our partial support for Go 1.16 in the expectation we will add that note when it is complete.