### PR TITLE
Add new module path for beego and xmlpath

### DIFF
--- a/ql/src/semmle/go/frameworks/Beego.qll
+++ b/ql/src/semmle/go/frameworks/Beego.qll
@@ -1,6 +1,6 @@
 /**
  * Provides classes for working with untrusted flow sources, sinks and taint propagators
- * from the `github.com/astaxie/beego` package.
+ * from the `github.com/beego/beego` package.
  */
 
 import go
@@ -8,21 +8,25 @@ import semmle.go.security.Xss
 private import semmle.go.security.SafeUrlFlowCustomizations
 
 module Beego {
-  /** Gets the package name `github.com/astaxie/beego`. */
+  /** Gets the module path `github.com/astaxie/beego` or `github.com/beego/beego`. */
   bindingset[result]
-  string packagePath() { result = package("github.com/astaxie/beego", "") }
+  string modulePath() { result = ["github.com/astaxie/beego", "github.com/beego/beego"] }
 
-  /** Gets the context subpackage name `github.com/astaxie/beego/context`. */
+  /** Gets the path for the root package of beego. */
   bindingset[result]
-  string contextPackagePath() { result = package("github.com/astaxie/beego", "context") }
+  string packagePath() { result = package(modulePath(), "") }
 
-  /** Gets the logs subpackage name `github.com/astaxie/beego/logs`. */
+  /** Gets the path for the context package of beego. */
   bindingset[result]
-  string logsPackagePath() { result = package("github.com/astaxie/beego", "logs") }
+  string contextPackagePath() { result = package(modulePath(), "context") }
 
-  /** Gets the utils subpackage name `github.com/astaxie/beego/utils`. */
+  /** Gets the path for the logs package of beego. */
   bindingset[result]
-  string utilsPackagePath() { result = package("github.com/astaxie/beego", "utils") }
+  string logsPackagePath() { result = package(modulePath(), "logs") }
+
+  /** Gets the path for the utils package of beego. */
+  bindingset[result]
+  string utilsPackagePath() { result = package(modulePath(), "utils") }
 
   /**
    * `BeegoInput` sources of untrusted data.

--- a/ql/src/semmle/go/frameworks/GoRestfulHttp.qll
+++ b/ql/src/semmle/go/frameworks/GoRestfulHttp.qll
@@ -1,7 +1,7 @@
 import go
 
 /**
- * Provides models of the go-restful library (`https://github.com/emicklei/go-restful`).
+ * Provides models of the [go-restful library](https://github.com/emicklei/go-restful).
  */
 private module GoRestfulHttp {
   /** Gets the package name `github.com/emicklei/go-restful`. */

--- a/ql/src/semmle/go/frameworks/SQL.qll
+++ b/ql/src/semmle/go/frameworks/SQL.qll
@@ -206,7 +206,7 @@ module SQL {
   private class SqlxSink extends SQL::QueryString::Range {
     SqlxSink() {
       exists(Method meth, string name, int n |
-        meth.hasQualifiedName(package("github.com/jmoiron", "sqlx"), ["DB", "Tx"], name) and
+        meth.hasQualifiedName(package("github.com/jmoiron/sqlx", ""), ["DB", "Tx"], name) and
         this = meth.getACall().getArgument(n)
       |
         name = ["Select", "Get"] and n = 1

--- a/ql/src/semmle/go/frameworks/WebSocket.qll
+++ b/ql/src/semmle/go/frameworks/WebSocket.qll
@@ -319,5 +319,5 @@ module NhooyrWebSocket {
 module GobwasWs {
   /** Gets the package name `github.com/gobwas/ws`. */
   bindingset[result]
-  string packagePath() { result = package("github.com/gobwas", "ws") }
+  string packagePath() { result = package("github.com/gobwas/ws", "") }
 }

--- a/ql/src/semmle/go/frameworks/XPath.qll
+++ b/ql/src/semmle/go/frameworks/XPath.qll
@@ -28,7 +28,10 @@ module XPath {
      */
     abstract class Range extends DataFlow::Node { }
 
-    /** An XPath expression string used in an API function of the https://github.com/antchfx/xpath package. */
+    /**
+     * An XPath expression string used in an API function of the
+     * [XPath](https://github.com/antchfx/xpath) package.
+     */
     private class AntchfxXpathXPathExpressionString extends Range {
       AntchfxXpathXPathExpressionString() {
         exists(Function f, string name | name.matches("Compile%") |
@@ -48,7 +51,10 @@ module XPath {
       }
     }
 
-    /** An XPath expression string used in an API function of the https://github.com/antchfx/htmlquery package. */
+    /**
+     * An XPath expression string used in an API function of the
+     * [htmlquery](https://github.com/antchfx/htmlquery) package.
+     */
     private class AntchfxHtmlqueryXPathExpressionString extends Range {
       AntchfxHtmlqueryXPathExpressionString() {
         exists(Function f, string name | name.matches("Find%") |
@@ -63,7 +69,10 @@ module XPath {
       }
     }
 
-    /** An XPath expression string used in an API function of the https://github.com/antchfx/xmlquery package. */
+    /**
+     * An XPath expression string used in an API function of the
+     * [xmlquery](https://github.com/antchfx/xmlquery) package.
+     */
     private class AntchfxXmlqueryXPathExpressionString extends Range {
       AntchfxXmlqueryXPathExpressionString() {
         exists(Function f, string name | name.matches("Find%") |
@@ -83,7 +92,10 @@ module XPath {
       }
     }
 
-    /** An XPath expression string used in an API function of the https://github.com/antchfx/jsonquery package. */
+    /**
+     * An XPath expression string used in an API function of the
+     * [jsonquery](https://github.com/antchfx/jsonquery) package.
+     */
     private class AntchfxJsonqueryXPathExpressionString extends Range {
       AntchfxJsonqueryXPathExpressionString() {
         exists(Function f, string name | name.matches("Find%") |
@@ -98,7 +110,10 @@ module XPath {
       }
     }
 
-    /** An XPath expression string used in an API function of the https://github.com/go-xmlpath/xmlpath package. */
+    /**
+     * An XPath expression string used in an API function of the
+     * [xmlpath](https://github.com/go-xmlpath/xmlpath) package.
+     */
     private class GoXmlpathXmlpathXPathExpressionString extends Range {
       GoXmlpathXmlpathXPathExpressionString() {
         exists(Function f, string name | name.matches("Compile%") |
@@ -113,7 +128,10 @@ module XPath {
       }
     }
 
-    /** An XPath expression string used in an API function of the https://github.com/ChrisTrenkamp/goxpath package. */
+    /**
+     * An XPath expression string used in an API function of the
+     * [goxpath](https://github.com/ChrisTrenkamp/goxpath) package.
+     */
     private class ChrisTrenkampGoxpathXPathExpressionString extends Range {
       ChrisTrenkampGoxpathXPathExpressionString() {
         exists(Function f, string name | name.matches("Parse%") |
@@ -128,7 +146,10 @@ module XPath {
       }
     }
 
-    /** An XPath expression string used in an API function of the https://github.com/santhosh-tekuri/xpathparser package. */
+    /**
+     * An XPath expression string used in an API function of the
+     * [xpathparser](https://github.com/santhosh-tekuri/xpathparser) package.
+     */
     private class SanthoshTekuriXpathparserXPathExpressionString extends Range {
       SanthoshTekuriXpathparserXPathExpressionString() {
         exists(Function f, string name | name.matches("Parse%") |
@@ -143,7 +164,10 @@ module XPath {
       }
     }
 
-    /** An XPath expression string used in an API function of the https://github.com/jbowtie/gokogiri package. */
+    /**
+     * An XPath expression string used in an API function of the
+     * [gokogiri]https://github.com/jbowtie/gokogiri) package.
+     */
     private class JbowtieGokogiriXPathExpressionString extends Range {
       JbowtieGokogiriXPathExpressionString() {
         exists(Function f, string name | name.matches("Compile%") |

--- a/ql/src/semmle/go/frameworks/XPath.qll
+++ b/ql/src/semmle/go/frameworks/XPath.qll
@@ -102,12 +102,12 @@ module XPath {
     private class GoXmlpathXmlpathXPathExpressionString extends Range {
       GoXmlpathXmlpathXPathExpressionString() {
         exists(Function f, string name | name.matches("Compile%") |
-          f.hasQualifiedName(package("github.com/go-xmlpath/xmlpath", ""), name) and
+          f.hasQualifiedName(XmlPath::packagePath(), name) and
           this = f.getACall().getArgument(0)
         )
         or
         exists(Function f, string name | name.matches("MustCompile%") |
-          f.hasQualifiedName(package("github.com/go-xmlpath/xmlpath", ""), name) and
+          f.hasQualifiedName(XmlPath::packagePath(), name) and
           this = f.getACall().getArgument(0)
         )
       }
@@ -162,5 +162,13 @@ module XPath {
         )
       }
     }
+  }
+}
+
+module XmlPath {
+  /** Gets the package name `github.com/go-xmlpath/xmlpath` or `gopkg.in/xmlpath`. */
+  bindingset[result]
+  string packagePath() {
+    result = package(["github.com/go-xmlpath/xmlpath", "gopkg.in/xmlpath"], "")
   }
 }

--- a/ql/src/semmle/go/security/ExternalAPIs.qll
+++ b/ql/src/semmle/go/security/ExternalAPIs.qll
@@ -17,9 +17,7 @@ private import Logrus
 abstract class SafeExternalAPIFunction extends Function { }
 
 private predicate isDefaultSafePackage(Package package) {
-  package.getPath() in [
-      "time", "unicode/utf8", package("http://gopkg.in/go-playground/validator", "")
-    ]
+  package.getPath() in ["time", "unicode/utf8", package("gopkg.in/go-playground/validator", "")]
 }
 
 /** The default set of "safe" external APIs. */


### PR DESCRIPTION
Beego moved from astaxie/beego to beego/beego on 13 Dec 2020. The
old location still works but is not being updated.