### PR TITLE
Explicitly set GO111MODULE to auto

### DIFF
--- a/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -281,6 +281,9 @@ func main() {
 	depMode := GoGetNoModules
 	modMode := ModUnset
 	needGopath := true
+	if _, present := os.LookupEnv("GO111MODULE"); !present {
+		os.Setenv("GO111MODULE", "auto")
+	}
 	if util.FileExists("go.mod") {
 		depMode = GoGetWithModules
 		needGopath = false


### PR DESCRIPTION
This fixes a bug I ran into while extracting a project that used `dep`; because go modules defaults to on now it doesn't do what we want.