### PR TITLE
Highlight error messages in CI

### DIFF
--- a/.github/problem-matchers/codeql-query-format.json
+++ b/.github/problem-matchers/codeql-query-format.json
@@ -1,0 +1,14 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "codeql-query-format",
+            "pattern": [
+                {
+                    "regexp": "^((.*) would change by autoformatting\\.)$",
+                    "file": 2,
+                    "message": 1
+                }
+            ]
+        }
+    ]
+}

--- a/.github/problem-matchers/codeql-syntax-check.json
+++ b/.github/problem-matchers/codeql-syntax-check.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "codeql-syntax-check",
+            "pattern": [
+                {
+                    "regexp": "^((ERROR|WARNING): .* \\((.*):(\\d+),(\\d+)-\\d+\\))$",
+                    "message": 1,
+                    "file": 3,
+                    "line": 4,
+                    "col": 5,
+                    "severity": 2
+                }
+            ]
+        }
+    ]
+}

--- a/.github/problem-matchers/codeql-test-run.json
+++ b/.github/problem-matchers/codeql-test-run.json
@@ -1,0 +1,14 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "codeql-test-run",
+            "pattern": [
+                {
+                    "regexp": "(\\[.*\\] FAILED\\((RESULT|COMPILATION)\\) (.*))$",
+                    "file": 3,
+                    "message": 1
+                }
+            ]
+        }
+    ]
+}

--- a/.github/problem-matchers/make.json
+++ b/.github/problem-matchers/make.json
@@ -1,0 +1,13 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "make",
+            "pattern": [
+                {
+                    "regexp": "^(make: \\*\\*\\* .*)$",
+                    "message": 1
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/codeqltest.yml
+++ b/.github/workflows/codeqltest.yml
@@ -30,6 +30,10 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
+    - name: Enable problem matchers in repository
+      shell: bash
+      run: 'find .github/problem-matchers -name \*.json -exec echo "::add-matcher::{}" \;'
+
     - name: Build
       run: env PATH=$PATH:$HOME/codeql make
 
@@ -75,6 +79,10 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
+    - name: Enable problem matchers in repository
+      shell: bash
+      run: 'find .github/problem-matchers -name \*.json -exec echo "::add-matcher::{}" \;'
+
     - name: Build
       run: env PATH=$PATH:$HOME/codeql make
 
@@ -107,6 +115,10 @@ jobs:
 
     - name: Check out code
       uses: actions/checkout@v2
+
+    - name: Enable problem matchers in repository
+      shell: bash
+      run: 'find .github/problem-matchers -name \*.json -exec echo "::add-matcher::{}" \;'
 
     - name: Build
       run: |


### PR DESCRIPTION
Copied problem-matchers from github/semmle-code, which is used for
running CI for github/codeql.