### PR TITLE
Cache TControlFlowNode

### DIFF
--- a/ql/src/semmle/go/controlflow/ControlFlowGraphImpl.qll
+++ b/ql/src/semmle/go/controlflow/ControlFlowGraphImpl.qll
@@ -61,6 +61,7 @@ private predicate isCond(Expr e) {
  *        respectively, of the execution of the function and the loading of the file;
  *      - Skip nodes that are semantic no-ops, but make CFG construction easier.
  */
+cached
 newtype TControlFlowNode =
   /**
    * A control-flow node that represents the evaluation of an expression.

--- a/ql/src/semmle/go/controlflow/IR.qll
+++ b/ql/src/semmle/go/controlflow/IR.qll
@@ -662,7 +662,7 @@ module IR {
       )
       or
       exists(TypeAssertExpr tae | getBase() = evalExprInstruction(tae) |
-        result = tae.getType().(TupleType).getComponentType(i)
+        result = tae.getType().(TupleType).getComponentType(pragma[only_bind_into](i))
       )
       or
       exists(Type rangeType | rangeType = s.(RangeStmt).getDomain().getType().getUnderlyingType() |

--- a/ql/src/semmle/go/controlflow/IR.qll
+++ b/ql/src/semmle/go/controlflow/IR.qll
@@ -654,14 +654,14 @@ module IR {
     }
 
     /** Holds if this extracts the `idx`th value of the result of `base`. */
-    predicate extractsElement(Instruction base, int idx) { base = getBase() and idx = i }
+    predicate extractsElement(Instruction base, int idx) { base = this.getBase() and idx = i }
 
     override Type getResultType() {
-      exists(CallExpr c | getBase() = evalExprInstruction(c) |
+      exists(CallExpr c | this.getBase() = evalExprInstruction(c) |
         result = c.getTarget().getResultType(i)
       )
       or
-      exists(TypeAssertExpr tae | getBase() = evalExprInstruction(tae) |
+      exists(TypeAssertExpr tae | this.getBase() = evalExprInstruction(tae) |
         result = tae.getType().(TupleType).getComponentType(pragma[only_bind_into](i))
       )
       or


### PR DESCRIPTION
With the included fix for the bad join order, caching TControlFlowNode is an unalloyed benefit, reducing runtime by 10-20% for all the big projects and not increasing it for any:
https://github.com/github/codeql-dist-compare-reports/blob/owen-mc/cache-tcontrolflownode-2_1615845668088/README.md