### PR TITLE
Unify two implementations of GetExtractorPath

### DIFF
--- a/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"golang.org/x/mod/semver"
 	"io/ioutil"
@@ -205,51 +204,6 @@ func checkVendor() bool {
 	}
 
 	return true
-}
-
-func getOsToolsSubdir() (string, error) {
-	switch runtime.GOOS {
-	case "darwin":
-		return "osx64", nil
-	case "linux":
-		return "linux64", nil
-	case "windows":
-		return "win64", nil
-	}
-	return "", errors.New("Unsupported OS: " + runtime.GOOS)
-}
-
-func getExtractorDir() (string, error) {
-	mypath, err := os.Executable()
-	if err == nil {
-		return filepath.Dir(mypath), nil
-	}
-	log.Printf("Could not determine path of autobuilder: %v.\n", err)
-
-	// Fall back to rebuilding our own path from the extractor root:
-	extractorRoot := os.Getenv("CODEQL_EXTRACTOR_GO_ROOT")
-	if extractorRoot == "" {
-		return "", errors.New("CODEQL_EXTRACTOR_GO_ROOT not set.\nThis binary should not be run manually; instead, use the CodeQL CLI or VSCode extension. See https://securitylab.github.com/tools/codeql")
-	}
-
-	osSubdir, err := getOsToolsSubdir()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(extractorRoot, "tools", osSubdir), nil
-}
-
-func getExtractorPath() (string, error) {
-	dirname, err := getExtractorDir()
-	if err != nil {
-		return "", err
-	}
-	extractor := filepath.Join(dirname, "go-extractor")
-	if runtime.GOOS == "windows" {
-		extractor = extractor + ".exe"
-	}
-	return extractor, nil
 }
 
 func main() {
@@ -568,7 +522,7 @@ func main() {
 	}
 
 	// extract
-	extractor, err := getExtractorPath()
+	extractor, err := util.GetExtractorPath()
 	if err != nil {
 		log.Fatalf("Could not determine path of extractor: %v.\n", err)
 	}

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -301,7 +301,11 @@ func NewExtraction(buildFlags []string, patterns []string) *Extraction {
 
 	dbscheme.CompilationsTable.Emit(statWriter, lbl, wd)
 	i = 0
-	dbscheme.CompilationArgsTable.Emit(statWriter, lbl, 0, util.GetExtractorPath())
+	extractorPath, err := util.GetExtractorPath()
+	if err != nil {
+		log.Fatalf("Unable to get extractor path: %s\n", err.Error())
+	}
+	dbscheme.CompilationArgsTable.Emit(statWriter, lbl, 0, extractorPath)
 	i++
 	for _, flag := range buildFlags {
 		dbscheme.CompilationArgsTable.Emit(statWriter, lbl, i, flag)

--- a/extractor/util/util.go
+++ b/extractor/util/util.go
@@ -1,10 +1,12 @@
 package util
 
 import (
+	"errors"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -141,20 +143,51 @@ func RunCmd(cmd *exec.Cmd) bool {
 	return true
 }
 
-func GetExtractorPath() string {
+func getOsToolsSubdir() (string, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return "osx64", nil
+	case "linux":
+		return "linux64", nil
+	case "windows":
+		return "win64", nil
+	}
+	return "", errors.New("Unsupported OS: " + runtime.GOOS)
+}
+
+func getExtractorDir() (string, error) {
+	mypath, err := os.Executable()
+	if err == nil {
+		return filepath.Dir(mypath), nil
+	}
+	log.Printf("Could not determine path of autobuilder: %v.\n", err)
+
+	// Fall back to rebuilding our own path from the extractor root:
+	extractorRoot := os.Getenv("CODEQL_EXTRACTOR_GO_ROOT")
+	if extractorRoot == "" {
+		return "", errors.New("CODEQL_EXTRACTOR_GO_ROOT not set.\nThis binary should not be run manually; instead, use the CodeQL CLI or VSCode extension. See https://securitylab.github.com/tools/codeql")
+	}
+
+	osSubdir, err := getOsToolsSubdir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(extractorRoot, "tools", osSubdir), nil
+}
+
+func GetExtractorPath() (string, error) {
 	if extractorPath != "" {
-		return extractorPath
+		return extractorPath, nil
 	}
 
-	root, set := os.LookupEnv("CODEQL_EXTRACTOR_GO_ROOT")
-	if !set {
-		log.Fatal("CODEQL_EXTRACTOR_GO_ROOT not set; this binary should be run from the `codeql` CLI.")
+	dirname, err := getExtractorDir()
+	if err != nil {
+		return "", err
 	}
-	platform, set := os.LookupEnv("CODEQL_PLATFORM")
-	if !set {
-		log.Fatal("CODEQL_PLATFORM not set; this binary should be run from the `codeql` CLI.")
+	extractorPath := filepath.Join(dirname, "go-extractor")
+	if runtime.GOOS == "windows" {
+		extractorPath = extractorPath + ".exe"
 	}
-
-	extractorPath = filepath.Join(root, "tools", platform, "go-extractor")
-	return extractorPath
+	return extractorPath, nil
 }


### PR DESCRIPTION
This retains both their features:
* The new util.go one cached its result.
* The old go-autobuilder.go one worked under ODASA, where CODEQL_GO_EXTRACTOR_ROOT is unset but os.Executable is a useful substitute.