### PR TITLE
Golang: Add query to detect CSRF vulnerabilities

### DIFF
--- a/ql/src/experimental/CWE-352/Csrf.ql
+++ b/ql/src/experimental/CWE-352/Csrf.ql
@@ -1,0 +1,23 @@
+/**
+ * @name Cross site Request Forgery
+ * @description When a web server is designed to receive a request from a client without any
+ *  mechanism for verifying that it was intentionally sent, then it might be possible for an
+ * attacker to trick a client into making an unintentional request to the web server which
+ * will be treated as an authentic request. This can be done via a URL, image load,
+ * XMLHttpRequest, etc. and can result in exposure of data or unintended code execution.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id go/request-forgery
+ * @tags security
+ *       external/cwe/cwe-918
+ */
+
+import go
+import Csrf::Csrf
+import DataFlow::PathGraph
+
+from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink, source, sink, "This router $@, doesn't add a check for CSRF $@.", source.getNode(),
+  "router ", sink.getNode(), "sink"

--- a/ql/src/experimental/CWE-352/Csrf.qll
+++ b/ql/src/experimental/CWE-352/Csrf.qll
@@ -1,0 +1,44 @@
+/**
+ * Provides a taint-tracking configuration for reasoning about Cross Site Request Forgery
+ * (CSRF) vulnerabilities.
+ *
+ * Note, for performance reasons: only import this file if
+ * `Csrf::Configuration` is needed, otherwise
+ * `CsrfCustomizations` should be imported instead.
+ */
+
+import go
+
+/**
+ * Provides a taint-tracking configuration for reasoning about Cross Site Request Forgery
+ * (CSRF) vulnerabilities.
+ */
+module Csrf {
+  import CsrfCustomizations::Csrf
+
+  /**
+   * A taint-tracking configuration for reasoning about Cross Site Request Forgery
+   * (CSRF) vulnerabilities.
+   */
+  class Configuration extends TaintTracking::Configuration {
+    Configuration() { this = "Cross Site Request Forgery" }
+
+    override predicate isSource(DataFlow::Node source) { source instanceof Source }
+
+    override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+    override predicate isSanitizer(DataFlow::Node node) {
+      super.isSanitizer(node) or
+      node instanceof Sanitizer
+    }
+
+    override predicate isSanitizerOut(DataFlow::Node node) {
+      super.isSanitizerOut(node) or
+      node instanceof SanitizerEdge
+    }
+
+    override predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
+      super.isSanitizerGuard(guard) or guard instanceof SanitizerGuard
+    }
+  }
+}

--- a/ql/src/experimental/CWE-352/CsrfCustomizations.qll
+++ b/ql/src/experimental/CWE-352/CsrfCustomizations.qll
@@ -1,0 +1,86 @@
+/**
+ * Provides classes and predicates used by the Cross Site Request Forgery
+ * (CSRF) query.
+ */
+
+import go
+
+/** Provides classes and predicates for the Cross Site Request Forgery (CSRF) query. */
+module Csrf {
+  /** A data flow source for Cross Site Request Forgery (CSRF) vulnerabilities. */
+  abstract class Source extends DataFlow::Node { }
+
+  /** A data flow sink for Cross Site Request Forgery (CSRF) vulnerabilities. */
+  abstract class Sink extends DataFlow::Node { }
+
+  /** A sanitizer for Cross Site Request Forgery (CSRF) vulnerabilities. */
+  abstract class Sanitizer extends DataFlow::Node { }
+
+  /** An outgoing sanitizer edge for Cross Site Request Forgery (CSRF) vulnerabilities. */
+  abstract class SanitizerEdge extends DataFlow::Node { }
+
+  /**
+   * A sanitizer guard for Cross Site Request Forgery (CSRF) vulnerabilities.
+   */
+  abstract class SanitizerGuard extends DataFlow::BarrierGuard { }
+
+  /**
+   * A gorilla mux router creation expression, considered as a flow source for cross site request forgery (CSRF).
+   */
+  private class MuxRouterCreation extends Source {
+    MuxRouterCreation() {
+      exists(Method m |
+        m.hasQualifiedName("gorilla/mux", "NewRouter") or
+        m.hasQualifiedName("gorilla/mux", "Route", "SubRouter")
+      |
+        m.getACall() = this
+      )
+    }
+  }
+
+  /**
+   * A handler creation expression, considered as a flow source for cross site request forgery (CSRF).
+   */
+  private class HandlerCreation extends Source {
+    HandlerCreation() {
+      exists(Method m | m.hasQualifiedName("net/http", ["Handle", "HandleFunc"]) |
+        m.getACall() = this
+      )
+    }
+  }
+
+  /**
+   * The handler of an HTTP request, viewed as a sink for Cross Site Request Forgery (CSRF) vulnerabilities.
+   */
+  private class HttpHandlerSink extends Sink {
+    HttpHandlerSink() {
+      exists(Method m, int i |
+        m.hasQualifiedName("net/http", _) and
+        m.getParameterType(i).hasQualifiedName("net/http", "Handler") and
+        m.getParameter(i) = this.asParameter()
+      )
+    }
+  }
+  // /**
+  //  * The handler of an HTTP request, viewed as a sink for Cross Site Request Forgery (CSRF) vulnerabilities.
+  //  */
+  // private class GorillaCsrf extends Sanitizer {
+  //   GorillaCsrf() {
+  //     exists(Method csrf, Method protect, int i |
+  //       protect.hasQualifiedName("gorilla/csrf", "Protect") and
+  //       protect.getResult(0) = csrf and
+  //       csrf.getParameter(0) = this.asParameter()
+  //     )
+  //   }
+  // }
+  // private class CustomCsrf extends Sanitizer {
+  //   CustomCsrf() {
+  //     exists(Method csrf, Method handler, int i |
+  //       csrf.getName().regexpMatch(["*csrf*","*xsrf*"]) and
+  //       handler.hasQualifiedName("gorilla/mux", ["Handler", "HandlerFunc"]) |
+  //       handler.getAParameter() = csrf and
+  //       handler.getACall().getTarget() = this.asExpr()
+  //     )
+  //   }
+  // }
+}

--- a/ql/src/experimental/CWE-352/CsrfCustomizations.qll
+++ b/ql/src/experimental/CWE-352/CsrfCustomizations.qll
@@ -61,26 +61,4 @@ module Csrf {
       )
     }
   }
-  // /**
-  //  * The handler of an HTTP request, viewed as a sink for Cross Site Request Forgery (CSRF) vulnerabilities.
-  //  */
-  // private class GorillaCsrf extends Sanitizer {
-  //   GorillaCsrf() {
-  //     exists(Method csrf, Method protect, int i |
-  //       protect.hasQualifiedName("gorilla/csrf", "Protect") and
-  //       protect.getResult(0) = csrf and
-  //       csrf.getParameter(0) = this.asParameter()
-  //     )
-  //   }
-  // }
-  // private class CustomCsrf extends Sanitizer {
-  //   CustomCsrf() {
-  //     exists(Method csrf, Method handler, int i |
-  //       csrf.getName().regexpMatch(["*csrf*","*xsrf*"]) and
-  //       handler.hasQualifiedName("gorilla/mux", ["Handler", "HandlerFunc"]) |
-  //       handler.getAParameter() = csrf and
-  //       handler.getACall().getTarget() = this.asExpr()
-  //     )
-  //   }
-  // }
 }


### PR DESCRIPTION
When a web server is designed to receive a request from a client without any mechanism for verifying that it was intentionally sent, then it might be possible for an attacker to trick a client into making an unintentional request to the web server which will be treated as an authentic request. This can be done via a URL, image load, XMLHttpRequest, etc. and can result in exposure of data or unintended code execution.