### PR TITLE
Performance: Remove `pragma[noopt]`

### DIFF
--- a/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/src/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -1163,25 +1163,22 @@ abstract class BarrierGuard extends Node {
    * Holds if `guard` markes a point in the control-flow graph where this node
    * is known to validate `nd`.
    */
-  pragma[noopt]
   private predicate guards(ControlFlow::ConditionGuardNode guard, Node nd) {
-    exists(boolean branch, Expr expr |
-      expr = nd.asExpr() and
-      this.checks(expr, branch) and
+    exists(boolean branch |
+      this.checks(nd.asExpr(), branch) and
       guard.ensures(this, branch)
     )
     or
     exists(
       Function f, FunctionInput inp, FunctionOutput outp, DataFlow::Property p, CallNode c,
-      Node resNode, Node check, boolean outcome, Node functionOutput
+      Node resNode, Node check, boolean outcome
     |
       guardingFunction(f, inp, outp, p) and
       c = f.getACall() and
       nd = inp.getNode(c) and
-      functionOutput = outp.getNode(c) and
-      localFlow(functionOutput, resNode) and
+      localFlow(pragma[only_bind_into](outp.getNode(c)), resNode) and
       p.checkOn(check, outcome, resNode) and
-      guard.ensures(check, outcome)
+      guard.ensures(pragma[only_bind_into](check), outcome)
     )
   }
 


### PR DESCRIPTION
As @adityasharad pointed out on Slack, my solution of adding `pragma[noopt]` on https://github.com/github/codeql-go/pull/547 was perhaps a bit too drastic a way to get the right join order. This changes to use `pragma[only_bind_into]` instead, which means that other potential optimisations that the compiler might want to do will not be inhibited, and we still get the desired join order with the new optimiser.

cc. @github/codeql-core 