### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,4 @@
 * @github/codeql-go
 
-# Documentation
-**/*.qhelp @shati-patel
 # Exclude experimental
 **/experimental/**/*.qhelp @github/codeql-go

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,1 @@
 * @github/codeql-go
-
-# Exclude experimental
-**/experimental/**/*.qhelp @github/codeql-go


### PR DESCRIPTION
I'm no longer on the docs team, so I've removed my CODEOWNERS ping! Once the qhelp is ready to be reviewed, you can add the `ready-for-docs-review` label to send the PR over for docs review 😃

(Using a label instead of CODEOWNERS is to avoid automatically pinging the docs team too early in the reviewing process, e.g. when the query/qhelp is still under development.)