### PR TITLE
Add a query suite for new experimental "developer happiness" queries

### DIFF
--- a/ql/src/codeql-suites/go-developer-happiness.qls
+++ b/ql/src/codeql-suites/go-developer-happiness.qls
@@ -1,0 +1,6 @@
+- description: Experimental queries showing how we use CodeQL internally for developer happiness
+- qlpack: codeql-go
+- include:
+    id: go/examples/database-call-in-loop
+    id: go/examples/deferinloop
+    id: go/examples/gorm-error-not-checked

--- a/ql/src/codeql-suites/go-developer-happiness.qls
+++ b/ql/src/codeql-suites/go-developer-happiness.qls
@@ -2,5 +2,7 @@
 - qlpack: codeql-go
 - include:
     id: go/examples/database-call-in-loop
+- include:
     id: go/examples/deferinloop
+- include:
     id: go/examples/gorm-error-not-checked


### PR DESCRIPTION
These are the queries added in https://github.com/github/codeql-go/pull/558.

Note that when the qlpack name changes, this suite will need updating.

I wasn't sure if this was testable prior to merging, so any suggestions there welcome.