### PR TITLE
Add getPrimaryQlClasses()

### DIFF
--- a/change-notes/2021-08-23-getPrimaryQlClasses.md
+++ b/change-notes/2021-08-23-getPrimaryQlClasses.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Added `AstNode.getPrimaryQlClasses()` predicate, which gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.

--- a/ql/src/semmle/go/AST.qll
+++ b/ql/src/semmle/go/AST.qll
@@ -82,6 +82,11 @@ class AstNode extends @node, Locatable {
   FuncDef getEnclosingFunction() { result = getParent().parentInSameFunction*() }
 
   /**
+   * Gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.
+   */
+  final string getPrimaryQlClasses() { result = concat(getAPrimaryQlClass(), ",") }
+
+  /**
    * Gets the name of a primary CodeQL class to which this node belongs.
    *
    * For most nodes, this is simply the most precise syntactic category to which they belong;


### PR DESCRIPTION
This is a non-overridable predicate that concatenates all the `getAPrimaryQlClass()` results into a comma-separated string.