### PR TITLE
Remove `CODEQL_REDUCE_FILES_FOLDERS_RELATIONS`

### DIFF
--- a/codeql-extractor.yml
+++ b/codeql-extractor.yml
@@ -6,8 +6,6 @@ pull_request_triggers:
   - "**/glide.yaml"
   - "**/Gopkg.toml"
 column_kind: "utf8"
-extra_env_vars:
-  CODEQL_REDUCE_FILES_FOLDERS_RELATIONS: "true"
 file_types:
   - name: go
     display_name: Go

--- a/codeql-tools/pre-finalize.cmd
+++ b/codeql-tools/pre-finalize.cmd
@@ -1,8 +1,6 @@
 @echo off
 SETLOCAL EnableDelayedExpansion
 
-SET CODEQL_REDUCE_FILES_FOLDERS_RELATIONS=true
-
 if NOT "%CODEQL_EXTRACTOR_GO_EXTRACT_HTML%"=="no" (
   type NUL && "%CODEQL_DIST%/codeql.exe" database index-files ^
                         --working-dir=. ^

--- a/codeql-tools/pre-finalize.sh
+++ b/codeql-tools/pre-finalize.sh
@@ -3,7 +3,7 @@
 set -eu
 
 if [ "${CODEQL_EXTRACTOR_GO_EXTRACT_HTML:-yes}" != "no" ]; then
-  CODEQL_REDUCE_FILES_FOLDERS_RELATIONS=true "$CODEQL_DIST/codeql" database index-files \
+  "$CODEQL_DIST/codeql" database index-files \
                         --working-dir=. \
                         --include-extension=.htm \
                         --include-extension=.html \


### PR DESCRIPTION
With [CodeQL 2.6.2](https://github.com/github/codeql-cli-binaries/releases/tag/v2.6.2) this is now the default behavior, and the environment variable is therefore no longer needed.