### PR TITLE
Update query description

### DIFF
--- a/ql/src/experimental/CWE-942/CorsMisconfiguration.ql
+++ b/ql/src/experimental/CWE-942/CorsMisconfiguration.ql
@@ -1,7 +1,7 @@
 /**
  * @name CORS misconfiguration
  * @description If a CORS policy is configured to accept an origin value obtained from the request data,
- * 				or is set to `*` or `null`, and it allows credential sharing, then the users of the
+ * 				or is set to `null`, and it allows credential sharing, then the users of the
  * 				application are vulnerable to the same range of attacks as in XSS (credential stealing, etc.).
  * @kind problem
  * @problem.severity warning


### PR DESCRIPTION
A wildcard origin does not allow Access-Control-Allow-Credentials: true.
This change had been made in https://github.com/github/codeql-go/commit/824b5a4b52b92859b4963f702b3c117e729b815e
but I has been forgotten to update the query description.

CC:@gagliardetto