### PR TITLE
Packaging: Normalize src/qlpack.yml

### DIFF
--- a/ql/src/qlpack.yml
+++ b/ql/src/qlpack.yml
@@ -3,5 +3,5 @@ version: 0.0.2
 suites: codeql-suites
 extractor: go
 dependencies:
-  codeql/go-all: ^0.0.2
-  codeql/suite-helpers: ^0.0.2
+  codeql/go-all: "*"
+  codeql/suite-helpers: "*"


### PR DESCRIPTION
Port of 4) from https://github.com/github/codeql/pull/6605

> Dependencies from query packs to other packs are always "*" since
these dependencies are always from source and we should get the
latest.

Compare with [C++ change](https://github.com/github/codeql/pull/6605/files#diff-0236560ca1b9c19eb7c74d8bfecd1c78005e762122f8bcdaee9eb9b20460bf9c).

/cc @aeisenberg 