### PR TITLE
Fix recursive reference in query suite

### DIFF
--- a/ql/src/codeql-suites/go-code-scanning.qls
+++ b/ql/src/codeql-suites/go-code-scanning.qls
@@ -1,4 +1,4 @@
 - description: Standard Code Scanning queries for Go
-- qlpack: codeql-go
+- queries: .
 - apply: code-scanning-selectors.yml
-  from: codeql-suite-helpers
+  from: codeql/suite-helpers


### PR DESCRIPTION
The line `- qlpack: codeql-go` references the pack's
default suite, which is this suite. Therefore this
reference is recursive and not allowed.

The change here aligns the query pack with other
languages.