### PR TITLE
Suites: Switch to the `queries` directive

### DIFF
--- a/ql/src/codeql-suites/go-developer-happiness.qls
+++ b/ql/src/codeql-suites/go-developer-happiness.qls
@@ -1,5 +1,5 @@
 - description: Experimental queries showing how we use CodeQL internally for developer happiness
-- qlpack: codeql-go
+- queries: .
 - include:
     id: go/examples/database-call-in-loop
 - include:

--- a/ql/src/codeql-suites/go-lgtm-full.qls
+++ b/ql/src/codeql-suites/go-lgtm-full.qls
@@ -1,5 +1,5 @@
 - description: Standard LGTM queries for Go, including ones not displayed by default
-- qlpack: codeql-go
+- queries: .
 - apply: lgtm-selectors.yml
   from: codeql-suite-helpers
 # These are only for IDE use.

--- a/ql/src/codeql-suites/go-security-and-quality.qls
+++ b/ql/src/codeql-suites/go-security-and-quality.qls
@@ -1,4 +1,4 @@
 - description: Security-and-quality queries for Go
-- qlpack: codeql-go
+- queries: .
 - apply: security-and-quality-selectors.yml
   from: codeql-suite-helpers

--- a/ql/src/codeql-suites/go-security-extended.qls
+++ b/ql/src/codeql-suites/go-security-extended.qls
@@ -1,4 +1,4 @@
 - description: Security-extended queries for Go
-- qlpack: codeql-go
+- queries: .
 - apply: security-extended-selectors.yml
   from: codeql-suite-helpers


### PR DESCRIPTION
The addition of the `defaultSuite` directive means that using
the `qlpack` directive in a query suite will only return the
queries in the default suite, not _all_ the queries in the
pack as was the prior behaviour. This change ensures that
all query suites resolve to the same queries as before.