### PR TITLE
Fixed broken/moved/redirected links.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,9 +68,9 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+https://www.contributor-covenant.org/faq/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 
-Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
+Contributions to this project are [released](https://docs.github.com/en/github/site-policy/github-terms-of-service#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
@@ -29,11 +29,11 @@ Follow the steps below to help other users understand what your query does, and 
 
 1. **Consult the documentation for query writers**
 
-   There is lots of useful documentation to help you write CodeQL queries, ranging from information about query file structure to language-specific tutorials. For more information on the documentation available, see [Writing QL queries](https://help.semmle.com/QL/learn-ql/writing-queries/writing-queries.html) on [help.semmle.com](https://help.semmle.com).
+   There is lots of useful documentation to help you write CodeQL queries, ranging from information about query file structure to language-specific tutorials. For more information on the documentation available, see [Writing QL queries](https://codeql.github.com/docs/writing-codeql-queries/) on [codeql.github.com/docs](https://codeql.github.com/docs/).
 
 2. **Format your code correctly**
 
-   All of the standard CodeQL queries and libraries are uniformly formatted for clarity and consistency, so we strongly recommend that all contributions follow the same formatting guidelines. If you use the CodeQL extension for Visual Studio Code, you can auto-format your query using the [Format Document command](https://help.semmle.com/codeql/codeql-for-vscode/procedures/about-codeql-for-vscode.html). For more information, see the [QL style guide](https://github.com/github/codeql/blob/main/docs/ql-style-guide.md).
+   All of the standard CodeQL queries and libraries are uniformly formatted for clarity and consistency, so we strongly recommend that all contributions follow the same formatting guidelines. If you use the CodeQL extension for Visual Studio Code, you can auto-format your query using the [Format Document command](https://codeql.github.com/docs/codeql-for-visual-studio-code/about-codeql-for-visual-studio-code/). For more information, see the [QL style guide](https://github.com/github/codeql/blob/main/docs/ql-style-guide.md).
 
 3. **Make sure your query has the correct metadata**
 
@@ -45,7 +45,7 @@ Follow the steps below to help other users understand what your query does, and 
 4. **Make sure the `select` statement is compatible with the query type**
 
    The `select` statement of your query must be compatible with the query type (determined by the `@kind` metadata property) for alert or path results to be displayed correctly in LGTM and Visual Studio Code.
-   For more information on `select` statement format, see [Introduction to query files](https://help.semmle.com/QL/learn-ql/writing-queries/introduction-to-queries.html#select-clause) on help.semmle.com.
+   For more information on `select` statement format, see [Introduction to query files](https://codeql.github.com/docs/writing-codeql-queries/introduction-to-ql/) on help.semmle.com.
 
 5. **Write a query help file**
 
@@ -61,6 +61,6 @@ In addition to contributions to our standard queries and libraries, we also welc
 ## Resources
 
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
-- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
-- [GitHub Help](https://help.github.com)
-- [A Note About Git Commit Messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+- [Using Pull Requests](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
+- [GitHub Help](https://docs.github.com/en)
+- [A Note About Git Commit Messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Follow the steps below to help other users understand what your query does, and 
 4. **Make sure the `select` statement is compatible with the query type**
 
    The `select` statement of your query must be compatible with the query type (determined by the `@kind` metadata property) for alert or path results to be displayed correctly in LGTM and Visual Studio Code.
-   For more information on `select` statement format, see [Introduction to query files](https://codeql.github.com/docs/writing-codeql-queries/introduction-to-ql/) on help.semmle.com.
+   For more information on `select` statement format, see [About CodeQL queries](https://codeql.github.com/docs/writing-codeql-queries/about-codeql-queries/#select-clause) on codeql.github.com.
 
 5. **Write a query help file**
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ makes available to its customers worldwide.
 It contains two major components:
   - an extractor, itself written in Go, that parses Go source code and converts it into a database
     that can be queried using CodeQL.
-  - static analysis libraries and queries written in [QL](https://help.semmle.com/QL) that can be
+  - static analysis libraries and queries written in [QL](https://codeql.github.com/docs/) that can be
     used to analyze such a database to find coding mistakes or security vulnerabilities.
 
 The goal of this project is to provide comprehensive static analysis support for Go in CodeQL.
@@ -29,7 +29,7 @@ Code workspace.
 ## Usage
 
 To analyze a Go codebase, either use the [CodeQL command-line
-interface](https://help.semmle.com/codeql/codeql-cli.html) to create a database yourself, or
+interface](https://codeql.github.com/docs/codeql-cli/) to create a database yourself, or
 download a pre-built database from [LGTM.com](https://lgtm.com/). You can then run any of the
 queries contained in this repository either on the command line or using the VS Code extension.
 
@@ -50,5 +50,5 @@ The code in this repository is licensed under the [MIT license](LICENSE).
 
 ## Resources
 
-- [Writing CodeQL queries](https://help.semmle.com/QL/learn-ql/ql/writing-queries/writing-queries.html)
-- [Learning CodeQL](https://help.semmle.com/QL/learn-ql/index.html)
+- [Writing CodeQL queries](https://codeql.github.com/docs/writing-codeql-queries/codeql-queries/)
+- [Learning CodeQL](https://codeql.github.com/docs/writing-codeql-queries/ql-tutorials/)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ makes available to its customers worldwide.
 It contains two major components:
   - an extractor, itself written in Go, that parses Go source code and converts it into a database
     that can be queried using CodeQL.
-  - static analysis libraries and queries written in [QL](https://codeql.github.com/docs/) that can be
+  - static analysis libraries and queries written in [CodeQL](https://codeql.github.com/docs/) that can be
     used to analyze such a database to find coding mistakes or security vulnerabilities.
 
 The goal of this project is to provide comprehensive static analysis support for Go in CodeQL.

--- a/change-notes/1.24/analysis-go.md
+++ b/change-notes/1.24/analysis-go.md
@@ -10,7 +10,7 @@
 
 ## New queries
 
-The CodeQL library for Go now contains a folder of simple "cookbook" queries that show how to access basic Go elements using the predicates defined by the standard library. They're intended to give you a starting point for your own experiments and to help you work out the best way to frame your questions using CodeQL. You can find them in the `examples/snippets` folder in the [CodeQL for Go repository](https://github.com/github/codeql-go/tree/master/ql/examples/snippets).
+The CodeQL library for Go now contains a folder of simple "cookbook" queries that show how to access basic Go elements using the predicates defined by the standard library. They're intended to give you a starting point for your own experiments and to help you work out the best way to frame your questions using CodeQL. You can find them in the `examples/snippets` folder in the [CodeQL for Go repository](https://github.com/github/codeql-go/tree/main/ql/examples/snippets).
 
 | **Query**                                                                    | **Tags**                                                                                | **Purpose**                                                                                                                                                                         |
 |------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/change-notes/2020-12-08-k8s-io-apimachinery-pkg-runtime.md
+++ b/change-notes/2020-12-08-k8s-io-apimachinery-pkg-runtime.md
@@ -1,2 +1,2 @@
 lgtm,codescanning
-* Support for the [k8s.io/apimachinery/pkg/runtime](https://godoc.org/k8s.io/apimachinery/pkg/runtime) library has been added, which may lead to more results from the security queries.
+* Support for the [k8s.io/apimachinery/pkg/runtime](https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime) library has been added, which may lead to more results from the security queries.

--- a/ql/docs/experimental.md
+++ b/ql/docs/experimental.md
@@ -21,7 +21,7 @@ Experimental queries and libraries may not be actively maintained as the standar
 
 3. **Formatting**
 
-    - The queries and libraries must be [autoformatted](https://help.semmle.com/codeql/codeql-for-vscode/reference/editor.html#autoformatting).
+    - The queries and libraries must be [autoformatted](https://codeql.github.com/docs/codeql-for-visual-studio-code/about-codeql-for-visual-studio-code/).
 
 4. **Compilation**
 

--- a/ql/test/library-tests/semmle/go/frameworks/Revel/examples/README.md
+++ b/ql/test/library-tests/semmle/go/frameworks/Revel/examples/README.md
@@ -1,3 +1,3 @@
-Revel example adapted from [revel-examples](https://github.com/revel/revel-examples).
+Revel example adapted from [revel-examples](https://github.com/revel/examples).
 
 See `LICENSE` for license information.


### PR DESCRIPTION
Was working on [CTF Go and don't return](https://securitylab.github.com/ctf/go-and-dont-return/) and hit a few broken links along the way, namely [QL](https://help.semmle.com/QL/) and [CodeQL CLI](https://help.semmle.com/codeql/codeql-cli.html) from the README of the repo, looks like quite a few of the semmle pages have disappeared. 

Wrote a script to find all links in `.md` files with non-200 response status codes, and fixed those to all be 200.

Original script results before these changes was:

```
[301]  codeql-go/CODE_OF_CONDUCT.md -> https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
[301]  codeql-go/CODE_OF_CONDUCT.md -> https://www.contributor-covenant.org/faq
[301]  codeql-go/README.md -> https://help.semmle.com/QL
[404]  codeql-go/README.md -> https://help.semmle.com/codeql/codeql-cli.html
[404]  codeql-go/README.md -> https://help.semmle.com/QL/learn-ql/ql/writing-queries/writing-queries.html
[404]  codeql-go/README.md -> https://help.semmle.com/QL/learn-ql/index.html
[301]  codeql-go/CONTRIBUTING.md -> https://help.github.com/articles/github-terms-of-service/
[404]  codeql-go/CONTRIBUTING.md -> https://help.semmle.com/QL/learn-ql/writing-queries/writing-queries.html
[404]  codeql-go/CONTRIBUTING.md -> https://help.semmle.com/codeql/codeql-for-vscode/procedures/about-codeql-for-vscode.html
[404]  codeql-go/CONTRIBUTING.md -> https://help.semmle.com/QL/learn-ql/writing-queries/introduction-to-queries.html
[301]  codeql-go/CONTRIBUTING.md -> https://help.github.com/articles/about-pull-requests/
[301]  codeql-go/CONTRIBUTING.md -> https://help.github.com
[404]  codeql-go/ql/docs/experimental.md -> https://help.semmle.com/codeql/codeql-for-vscode/reference/editor.html
[404]  codeql-go/ql/test/library-tests/semmle/go/frameworks/Revel/examples/README.md -> https://github.com/revel/revel-examples
[302]  codeql-go/change-notes/1.24/analysis-go.md -> https://github.com/github/codeql-go/tree/master/ql/examples/snippets
[301]  codeql-go/change-notes/2020-12-08-k8s-io-apimachinery-pkg-runtime.md -> https://godoc.org/k8s.io/apimachinery/pkg
``` 

Not sure if any test points rely on link changes, but given the scope of the changes here I did not build/test the project. Happy to do so if needed.