### PR TITLE
Remove macos compatibility stanzas from tracing config.

### DIFF
--- a/codeql-tools/osx64/compiler-tracing.spec
+++ b/codeql-tools/osx64/compiler-tracing.spec
@@ -5,18 +5,3 @@
   invoke ${config_dir}/go-extractor
   prepend --mimic
   prepend "${compiler}"
-/usr/bin/codesign:
-  replace yes
-  invoke /usr/bin/env
-  prepend /usr/bin/codesign
-  trace no
-/usr/bin/pkill:
-  replace yes
-  invoke /usr/bin/env
-  prepend /usr/bin/pkill
-  trace no
-/usr/bin/pgrep:
-  replace yes
-  invoke /usr/bin/env
-  prepend /usr/bin/pgrep
-  trace no


### PR DESCRIPTION
As outlined in https://github.com/github/semmle-code/pull/40797, we do not need these stanzas anymore.