### PR TITLE
Update tracing-config.lua to newest API.

### DIFF
--- a/codeql-tools/tracing-config.lua
+++ b/codeql-tools/tracing-config.lua
@@ -1,18 +1,14 @@
 function RegisterExtractorPack()
     local goExtractor = GetPlatformToolsDirectory() .. 'go-extractor'
     if OperatingSystem == 'windows' then
-        local goExtractor = GetPlatformToolsDirectory() .. 'go-extractor.exe'
+        goExtractor = GetPlatformToolsDirectory() .. 'go-extractor.exe'
     end
-    local matchers = {
-        CreatePatternMatcher('go',
-                             {'^go-autobuilder$', '^go-autobuilder%.exe$'},
+    return {
+        CreatePatternMatcher({'^go-autobuilder$', '^go-autobuilder%.exe$'},
                              MatchCompilerName, nil, {trace = false}),
-
-        CreatePatternMatcher('go', {'^go$', '^go%.exe$'}, MatchCompilerName,
+        CreatePatternMatcher({'^go$', '^go%.exe$'}, MatchCompilerName,
                              goExtractor, {prepend = {'--mimic', '${compiler}'}})
     }
-
-    RegisterLanguage('go', matchers)
 end
 
 -- Return a list of minimum supported versions of the configuration file format


### PR DESCRIPTION
There have been some updates to the Lua tracing API, this converts the `tracing-config.lua` to follow these API changes.