### PR TITLE
localTaint: use fastTC

### DIFF
--- a/ql/lib/semmle/go/dataflow/internal/TaintTrackingUtil.qll
+++ b/ql/lib/semmle/go/dataflow/internal/TaintTrackingUtil.qll
@@ -4,11 +4,17 @@
 
 private import go
 
+private predicate localTaintStepPlus(DataFlow::Node src, DataFlow::Node sink) =
+  fastTC(localTaintStep/2)(src, sink)
+
 /**
  * Holds if taint can flow from `src` to `sink` in zero or more
  * local (intra-procedural) steps.
  */
-predicate localTaint(DataFlow::Node src, DataFlow::Node sink) { localTaintStep*(src, sink) }
+predicate localTaint(DataFlow::Node src, DataFlow::Node sink) {
+  src = sink or
+  localTaintStepPlus(src, sink)
+}
 
 /**
  * Holds if taint can flow from `src` to `sink` in zero or more


### PR DESCRIPTION
For some reason the compiler was declining to do this on v2.7.1, and at least with some taint-flow graphs it can be much faster, in one case cutting the compute time for this predicate from 9 minutes to 3 seconds.