### PR TITLE
Add `Where` method of squirrel sql builders to query range

### DIFF
--- a/ql/lib/semmle/go/frameworks/SQL.qll
+++ b/ql/lib/semmle/go/frameworks/SQL.qll
@@ -88,10 +88,11 @@ module SQL {
             // first argument to `squirrel.Expr`
             fn.hasQualifiedName(sq, "Expr")
             or
-            // first argument to the `Prefix` or `Suffix` method of one of the `*Builder` classes
+            // first argument to the `Prefix`, `Suffix` or `Where` method of one of the `*Builder` classes
             exists(string builder | builder.matches("%Builder") |
               fn.(Method).hasQualifiedName(sq, builder, "Prefix") or
-              fn.(Method).hasQualifiedName(sq, builder, "Suffix")
+              fn.(Method).hasQualifiedName(sq, builder, "Suffix") or
+              fn.(Method).hasQualifiedName(sq, builder, "Where")
             )
           ) and
           this = fn.getACall().getArgument(0) and

--- a/ql/test/library-tests/semmle/go/frameworks/SQL/main.go
+++ b/ql/test/library-tests/semmle/go/frameworks/SQL/main.go
@@ -44,6 +44,7 @@ func test(db *sql.DB, ctx context.Context) {
 
 func squirrelTest(querypart string) {
 	squirrel.Select("*").From("users").Where(squirrel.Expr(querypart)) // $ querystring=querypart
+	squirrel.Select("*").From("users").Where(querypart)                // $ querystring=querypart
 	squirrel.Select("*").From("users").Suffix(querypart)               // $ querystring=querypart
 }
 


### PR DESCRIPTION
## Changes

Add `Where` method of builders for sql query sinks. `Where` is a vulnerable sink if tainted input of `string` type ends up in the first parameter. First parameter to `Where` is [typed as](https://github.com/Masterminds/squirrel/blob/84ae2bc4a87a432b1400474f3d48dd08961ecf40/where.go#L9) `interface{}` but the current ql only considers when the parameter is of `StringType`.

## Links

- [SelectBuilder.Where](https://pkg.go.dev/github.com/Masterminds/squirrel#SelectBuilder.Where)
- [UpdateBuilder.Where](https://pkg.go.dev/github.com/Masterminds/squirrel#UpdateBuilder.Where)
- [DeleteBuilder.Where](https://pkg.go.dev/github.com/Masterminds/squirrel#DeleteBuilder.Where)