### PR TITLE
Update `isVariadic`

### DIFF
--- a/ql/lib/semmle/go/Decls.qll
+++ b/ql/lib/semmle/go/Decls.qll
@@ -137,6 +137,7 @@ class FuncDef extends @funcdef, StmtParent, ExprParent {
    */
   DataFlow::CallNode getACall() { result.getACallee() = this }
 
+  /** Holds if this function is variadic. */
   predicate isVariadic() { this.getType().isVariadic() }
 
   override string getAPrimaryQlClass() { result = "FuncDef" }

--- a/ql/lib/semmle/go/Scopes.qll
+++ b/ql/lib/semmle/go/Scopes.qll
@@ -380,7 +380,7 @@ class Function extends ValueEntity, @functionobject {
   predicate isVariadic() {
     this.(BuiltinFunction).getName() = ["append", "make", "print", "println"]
     or
-    this.(DeclaredFunction).getFuncDecl().isVariadic()
+    this.(DeclaredFunction).getType().(SignatureType).isVariadic()
   }
 
   /** Holds if this function has no observable side effects. */

--- a/ql/lib/semmle/go/Scopes.qll
+++ b/ql/lib/semmle/go/Scopes.qll
@@ -377,6 +377,7 @@ class Function extends ValueEntity, @functionobject {
   /** Gets the declaration of this function, if any. */
   FuncDecl getFuncDecl() { none() }
 
+  /** Holds if this function is variadic. */
   predicate isVariadic() {
     this.(BuiltinFunction).getName() = ["append", "make", "print", "println"]
     or

--- a/ql/test/library-tests/semmle/go/Function/getParameter.expected
+++ b/ql/test/library-tests/semmle/go/Function/getParameter.expected
@@ -9,4 +9,4 @@
 | main.go:13:6:13:7 | f4 | 1 | main.go:13:16:13:16 | y |
 | main.go:15:6:15:7 | f5 | 0 | main.go:15:9:15:9 | x |
 | main.go:17:6:17:7 | f6 | 0 | main.go:17:9:17:9 | x |
-| variadicFunctions.go:7:6:7:29 | variadicDeclaredFunction | 0 | variadicFunctions.go:7:31:7:31 | x |
+| variadicFunctions.go:9:6:9:29 | variadicDeclaredFunction | 0 | variadicFunctions.go:9:31:9:31 | x |

--- a/ql/test/library-tests/semmle/go/Function/variadicFunctions.go
+++ b/ql/test/library-tests/semmle/go/Function/variadicFunctions.go
@@ -11,7 +11,7 @@ func variadicDeclaredFunction(x ...int) int {
 	y := append(x, a...)      // $ isVariadic
 	print(x[0], x[1])         // $ isVariadic
 	println(x[0], x[1])       // $ isVariadic
-	fmt.Fprint(nil, nil, nil) // $ MISSING: isVariadic
+	fmt.Fprint(nil, nil, nil) // $ isVariadic
 	variadicFunctionLiteral := func(z ...int) int { return z[1] }
 	return variadicFunctionLiteral(y...)
 }

--- a/ql/test/library-tests/semmle/go/Function/variadicFunctions.go
+++ b/ql/test/library-tests/semmle/go/Function/variadicFunctions.go
@@ -1,14 +1,17 @@
 package main
 
+import "fmt"
+
 func testing() {
 	variadicDeclaredFunction() // $ isVariadic
 }
 
 func variadicDeclaredFunction(x ...int) int {
-	a := make([]int, 0, 10) // $ isVariadic
-	y := append(x, a...)    // $ isVariadic
-	print(x[0], x[1])       // $ isVariadic
-	println(x[0], x[1])     // $ isVariadic
+	a := make([]int, 0, 10)   // $ isVariadic
+	y := append(x, a...)      // $ isVariadic
+	print(x[0], x[1])         // $ isVariadic
+	println(x[0], x[1])       // $ isVariadic
+	fmt.Fprint(nil, nil, nil) // $ MISSING: isVariadic
 	variadicFunctionLiteral := func(z ...int) int { return z[1] }
 	return variadicFunctionLiteral(y...)
 }

--- a/ql/test/library-tests/semmle/go/Types/SignatureType_getNumParameter.expected
+++ b/ql/test/library-tests/semmle/go/Types/SignatureType_getNumParameter.expected
@@ -10,6 +10,6 @@
 | pkg1/tst.go:37:1:37:26 | function declaration | 1 |
 | pkg1/tst.go:39:1:57:1 | function declaration | 2 |
 | unknownFunction.go:8:1:12:1 | function declaration | 0 |
-| variadicFunctions.go:3:1:5:1 | function declaration | 0 |
-| variadicFunctions.go:7:1:14:1 | function declaration | 1 |
-| variadicFunctions.go:12:29:12:62 | function literal | 1 |
+| variadicFunctions.go:5:1:7:1 | function declaration | 0 |
+| variadicFunctions.go:9:1:17:1 | function declaration | 1 |
+| variadicFunctions.go:15:29:15:62 | function literal | 1 |

--- a/ql/test/library-tests/semmle/go/Types/SignatureType_getNumResult.expected
+++ b/ql/test/library-tests/semmle/go/Types/SignatureType_getNumResult.expected
@@ -10,6 +10,6 @@
 | pkg1/tst.go:37:1:37:26 | function declaration | 0 |
 | pkg1/tst.go:39:1:57:1 | function declaration | 0 |
 | unknownFunction.go:8:1:12:1 | function declaration | 0 |
-| variadicFunctions.go:3:1:5:1 | function declaration | 0 |
-| variadicFunctions.go:7:1:14:1 | function declaration | 1 |
-| variadicFunctions.go:12:29:12:62 | function literal | 1 |
+| variadicFunctions.go:5:1:7:1 | function declaration | 0 |
+| variadicFunctions.go:9:1:17:1 | function declaration | 1 |
+| variadicFunctions.go:15:29:15:62 | function literal | 1 |

--- a/ql/test/library-tests/semmle/go/Types/variadicFunctions.go
+++ b/ql/test/library-tests/semmle/go/Types/variadicFunctions.go
@@ -1,5 +1,7 @@
 package main
 
+import "fmt"
+
 func testing() {
 	variadicDeclaredFunction()
 }
@@ -9,6 +11,7 @@ func variadicDeclaredFunction(x ...int) int { // $ isVariadic
 	y := append(x, a...)
 	print(x[0], x[1])
 	println(x[0], x[1])
+	fmt.Fprint(nil, nil, nil)
 	variadicFunctionLiteral := func(z ...int) int { return z[1] } // $ isVariadic
 	return variadicFunctionLiteral(y...)
 }


### PR DESCRIPTION
Follow on from https://github.com/github/codeql-go/pull/597. This fixes `isVariadic` for functions from external packages, adds a test for it (with a check that it failed before), and adds qldocs that were missed in #597 .