### PR TITLE
Update extractor to distinguish variadic and non-variadic signature types

### DIFF
--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -1555,6 +1555,9 @@ func getTypeLabel(tw *trap.Writer, tp types.Type) (trap.Label, bool) {
 					fmt.Fprintf(&b, "{%s}", resultLbl)
 				}
 			}
+			if tp.Variadic() {
+				b.WriteString(";variadic")
+			}
 			lbl = tw.Labeler.GlobalID(fmt.Sprintf("%s;signaturetype", b.String()))
 		case *types.Map:
 			key := extractType(tw, tp.Key())

--- a/ql/test/library-tests/semmle/go/Function/getParameter.expected
+++ b/ql/test/library-tests/semmle/go/Function/getParameter.expected
@@ -9,4 +9,5 @@
 | main.go:13:6:13:7 | f4 | 1 | main.go:13:16:13:16 | y |
 | main.go:15:6:15:7 | f5 | 0 | main.go:15:9:15:9 | x |
 | main.go:17:6:17:7 | f6 | 0 | main.go:17:9:17:9 | x |
-| variadicFunctions.go:9:6:9:29 | variadicDeclaredFunction | 0 | variadicFunctions.go:9:31:9:31 | x |
+| variadicFunctions.go:10:6:10:29 | variadicDeclaredFunction | 0 | variadicFunctions.go:10:31:10:31 | x |
+| variadicFunctions.go:20:6:20:32 | nonvariadicDeclaredFunction | 0 | variadicFunctions.go:20:34:20:34 | x |

--- a/ql/test/library-tests/semmle/go/Function/variadicFunctions.go
+++ b/ql/test/library-tests/semmle/go/Function/variadicFunctions.go
@@ -3,7 +3,8 @@ package main
 import "fmt"
 
 func testing() {
-	variadicDeclaredFunction() // $ isVariadic
+	variadicDeclaredFunction()           // $ isVariadic
+	nonvariadicDeclaredFunction([]int{}) // $ SPURIOUS: isVariadic
 }
 
 func variadicDeclaredFunction(x ...int) int {
@@ -14,4 +15,8 @@ func variadicDeclaredFunction(x ...int) int {
 	fmt.Fprint(nil, nil, nil) // $ isVariadic
 	variadicFunctionLiteral := func(z ...int) int { return z[1] }
 	return variadicFunctionLiteral(y...)
+}
+
+func nonvariadicDeclaredFunction(x []int) int {
+	return 0
 }

--- a/ql/test/library-tests/semmle/go/Function/variadicFunctions.go
+++ b/ql/test/library-tests/semmle/go/Function/variadicFunctions.go
@@ -3,8 +3,8 @@ package main
 import "fmt"
 
 func testing() {
-	variadicDeclaredFunction()           // $ isVariadic
-	nonvariadicDeclaredFunction([]int{}) // $ SPURIOUS: isVariadic
+	variadicDeclaredFunction() // $ isVariadic
+	nonvariadicDeclaredFunction([]int{})
 }
 
 func variadicDeclaredFunction(x ...int) int {

--- a/ql/test/library-tests/semmle/go/Types/SignatureType_getNumParameter.expected
+++ b/ql/test/library-tests/semmle/go/Types/SignatureType_getNumParameter.expected
@@ -10,6 +10,7 @@
 | pkg1/tst.go:37:1:37:26 | function declaration | 1 |
 | pkg1/tst.go:39:1:57:1 | function declaration | 2 |
 | unknownFunction.go:8:1:12:1 | function declaration | 0 |
-| variadicFunctions.go:5:1:7:1 | function declaration | 0 |
-| variadicFunctions.go:9:1:17:1 | function declaration | 1 |
-| variadicFunctions.go:15:29:15:62 | function literal | 1 |
+| variadicFunctions.go:5:1:8:1 | function declaration | 0 |
+| variadicFunctions.go:10:1:18:1 | function declaration | 1 |
+| variadicFunctions.go:16:29:16:62 | function literal | 1 |
+| variadicFunctions.go:20:1:22:1 | function declaration | 1 |

--- a/ql/test/library-tests/semmle/go/Types/SignatureType_getNumResult.expected
+++ b/ql/test/library-tests/semmle/go/Types/SignatureType_getNumResult.expected
@@ -10,6 +10,7 @@
 | pkg1/tst.go:37:1:37:26 | function declaration | 0 |
 | pkg1/tst.go:39:1:57:1 | function declaration | 0 |
 | unknownFunction.go:8:1:12:1 | function declaration | 0 |
-| variadicFunctions.go:5:1:7:1 | function declaration | 0 |
-| variadicFunctions.go:9:1:17:1 | function declaration | 1 |
-| variadicFunctions.go:15:29:15:62 | function literal | 1 |
+| variadicFunctions.go:5:1:8:1 | function declaration | 0 |
+| variadicFunctions.go:10:1:18:1 | function declaration | 1 |
+| variadicFunctions.go:16:29:16:62 | function literal | 1 |
+| variadicFunctions.go:20:1:22:1 | function declaration | 1 |

--- a/ql/test/library-tests/semmle/go/Types/variadicFunctions.go
+++ b/ql/test/library-tests/semmle/go/Types/variadicFunctions.go
@@ -4,6 +4,7 @@ import "fmt"
 
 func testing() {
 	variadicDeclaredFunction()
+	nonvariadicDeclaredFunction([]int{})
 }
 
 func variadicDeclaredFunction(x ...int) int { // $ isVariadic
@@ -14,4 +15,8 @@ func variadicDeclaredFunction(x ...int) int { // $ isVariadic
 	fmt.Fprint(nil, nil, nil)
 	variadicFunctionLiteral := func(z ...int) int { return z[1] } // $ isVariadic
 	return variadicFunctionLiteral(y...)
+}
+
+func nonvariadicDeclaredFunction(x []int) int { // $ SPURIOUS: isVariadic
+	return 0
 }

--- a/ql/test/library-tests/semmle/go/Types/variadicFunctions.go
+++ b/ql/test/library-tests/semmle/go/Types/variadicFunctions.go
@@ -17,6 +17,6 @@ func variadicDeclaredFunction(x ...int) int { // $ isVariadic
 	return variadicFunctionLiteral(y...)
 }
 
-func nonvariadicDeclaredFunction(x []int) int { // $ SPURIOUS: isVariadic
+func nonvariadicDeclaredFunction(x []int) int {
 	return 0
 }


### PR DESCRIPTION
This will fix a bug where non-variadic functions which have the same signature as a variadic function are erroneously considered as variadic.

Note that this PR clashes with https://github.com/github/codeql-go/pull/619. When one is merged the tests will have to be updated in the other.