### PR TITLE
Improve performance: join-order AllocationSizeOverflow's source and use `matches` not `regexpFind`

### DIFF
--- a/ql/lib/semmle/go/security/AllocationSizeOverflowCustomizations.qll
+++ b/ql/lib/semmle/go/security/AllocationSizeOverflowCustomizations.qll
@@ -49,7 +49,8 @@ module AllocationSizeOverflow {
   class MarshalingSource extends Source {
     MarshalingSource() {
       exists(MarshalingFunction marshal, DataFlow::CallNode call |
-        call = marshal.getACall() and
+        // Binding order tweak: start with marshalling function calls then work outwards:
+        pragma[only_bind_into](call) = marshal.getACall() and
         // rule out cases where we can tell that the result will always be small
         exists(FunctionInput inp | inp = marshal.getAnInput() | isBig(inp.getNode(call).asExpr())) and
         this = marshal.getOutput().getNode(call)

--- a/ql/src/Security/CWE-209/StackTraceExposure.ql
+++ b/ql/src/Security/CWE-209/StackTraceExposure.ql
@@ -26,7 +26,10 @@ class DebugModeFlag extends FlagKind {
 
   bindingset[result]
   override string getAFlagName() {
-    result.regexpMatch("(?i).*(trace|debug|devel|(enable|disable|print)stack).*")
+    result
+        .toLowerCase()
+        .matches("%" + ["trace", "debug", "devel", "enablestack", "disablestack", "printstack"] +
+            "%")
   }
 }
 

--- a/ql/src/Security/CWE-295/DisabledCertificateCheck.ql
+++ b/ql/src/Security/CWE-295/DisabledCertificateCheck.ql
@@ -45,7 +45,7 @@ class InsecureCertificateFlag extends FlagKind {
 
   bindingset[result]
   override string getAFlagName() {
-    result.regexpMatch("(?i).*(selfCert|selfSign|validat|verif|trust).*")
+    result.toLowerCase().matches("%" + ["selfcert", "selfsign", "validat", "verif", "trust"] + "%")
   }
 }
 

--- a/ql/src/Security/CWE-327/InsecureTLS.ql
+++ b/ql/src/Security/CWE-327/InsecureTLS.ql
@@ -243,7 +243,9 @@ class LegacyTlsVersionFlag extends FlagKind {
   LegacyTlsVersionFlag() { this = "legacyTlsVersion" }
 
   bindingset[result]
-  override string getAFlagName() { result.regexpMatch("(?i).*(old|intermediate|legacy).*") }
+  override string getAFlagName() {
+    result.toLowerCase().matches("%" + ["old", "intermediate", "legacy"] + "%")
+  }
 }
 
 /**

--- a/ql/src/experimental/CWE-942/CorsMisconfiguration.ql
+++ b/ql/src/experimental/CWE-942/CorsMisconfiguration.ql
@@ -22,7 +22,9 @@ class AllowedFlag extends FlagKind {
 
   bindingset[result]
   override string getAFlagName() {
-    result.regexpMatch("(?i).*(allow|match|check|debug|devel|insecure).*")
+    result
+        .toLowerCase()
+        .matches("%" + ["allow", "match", "check", "debug", "devel", "insecure"] + "%")
   }
 }
 


### PR DESCRIPTION
The join order fix takes 10 seconds off that predicate; the get-a-flag changes take about 25% off compared to using regexes.