### PR TITLE
Fix incorrect type name in database/sql model

### DIFF
--- a/ql/lib/semmle/go/frameworks/stdlib/DatabaseSql.qll
+++ b/ql/lib/semmle/go/frameworks/stdlib/DatabaseSql.qll
@@ -141,11 +141,11 @@ module DatabaseSql {
       (inp.isParameter(0) and outp.isReceiver())
       or
       // Prepare methods
-      this.hasQualifiedName("database/sql", ["Tx", "Db"], "Prepare") and
+      this.hasQualifiedName("database/sql", ["Tx", "DB"], "Prepare") and
       (inp.isParameter(0) and outp.isResult(0))
       or
       // PrepareContext methods
-      this.hasQualifiedName("database/sql", ["Tx", "Db", "Conn"], "PrepareContext") and
+      this.hasQualifiedName("database/sql", ["Tx", "DB", "Conn"], "PrepareContext") and
       (inp.isParameter(1) and outp.isResult(0))
     }
 


### PR DESCRIPTION
This error seems to have been introduced in
36bbf1eeb9d8674e0e27b4ce9dc21da7590d6df1

Docs: https://pkg.go.dev/database/sql#DB