### PR TITLE
Allow data flow through receiver for modelled methods

### DIFF
--- a/ql/lib/semmle/go/dataflow/ExternalFlow.qll
+++ b/ql/lib/semmle/go/dataflow/ExternalFlow.qll
@@ -396,6 +396,13 @@ SourceOrSinkElement interpretElement(
   )
 }
 
+/** Holds if there is an external specification for `f`. */
+predicate hasExternalSpecification(Function f) {
+  f = any(SummarizedCallable sc).asFunction()
+  or
+  exists(SourceOrSinkElement e | f = e.asEntity() | sourceElement(e, _, _) or sinkElement(e, _, _))
+}
+
 private predicate parseField(string c, DataFlow::FieldContent f) {
   specSplit(_, c, _) and
   exists(string fieldRegex, string package, string className, string fieldName |

--- a/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -713,11 +713,7 @@ module Public {
         or
         exists(c.(MethodCallNode).getTarget().getBody())
         or
-        exists(string package, string type, string name |
-          c.(MethodCallNode).getTarget().hasQualifiedName(package, type, name)
-        |
-          exists(interpretElement(package, type, _, name, "", _))
-        )
+        hasExternalSpecification(c.(DataFlow::MethodCallNode).getTarget())
       )
     }
 

--- a/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -3,6 +3,7 @@ private import semmle.go.dataflow.FunctionInputsAndOutputs
 private import semmle.go.dataflow.FlowSummary
 private import DataFlowPrivate
 private import FlowSummaryImpl as FlowSummaryImpl
+private import semmle.go.dataflow.ExternalFlow
 
 cached
 private newtype TNode =
@@ -711,6 +712,12 @@ module Public {
         i != -1
         or
         exists(c.(MethodCallNode).getTarget().getBody())
+        or
+        exists(string package, string type, string name |
+          c.(MethodCallNode).getTarget().hasQualifiedName(package, type, name)
+        |
+          exists(interpretElement(package, type, _, name, "", _))
+        )
       )
     }
 

--- a/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/sinks.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/sinks.expected
@@ -1,6 +1,7 @@
 invalidModelRow
 #select
 | test.go:47:10:47:12 | arg | qltest |
+| test.go:48:2:48:13 | type assertion | qltest |
 | test.go:61:10:61:15 | taint1 | qltest |
 | test.go:64:10:64:15 | taint2 | qltest |
 | test.go:68:10:68:15 | taint3 | qltest |

--- a/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/steps.expected
+++ b/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/steps.expected
@@ -3,8 +3,14 @@ invalidModelRow
 | test.go:17:23:17:25 | arg | test.go:17:10:17:26 | call to StepArgRes |
 | test.go:18:27:18:29 | arg | test.go:18:2:18:30 | ... = ...[1] |
 | test.go:19:15:19:17 | arg | test.go:11:6:11:9 | definition of arg1 |
+| test.go:20:16:20:18 | arg | test.go:13:6:13:6 | definition of t |
+| test.go:21:10:21:10 | t | test.go:21:10:21:24 | call to StepQualRes |
+| test.go:22:2:22:2 | t | test.go:10:6:10:8 | definition of arg |
 | test.go:23:32:23:34 | arg | test.go:23:10:23:35 | call to StepArgResNoQual |
 | test.go:60:25:60:27 | src | test.go:60:12:60:28 | call to StepArgRes |
 | test.go:63:29:63:31 | src | test.go:63:2:63:32 | ... := ...[1] |
 | test.go:67:15:67:17 | src | test.go:66:6:66:11 | definition of taint3 |
+| test.go:71:21:71:23 | src | test.go:70:6:70:11 | definition of taint4 |
+| test.go:74:13:74:25 | type assertion | test.go:74:12:74:40 | call to StepQualRes |
+| test.go:78:3:78:15 | type assertion | test.go:77:6:77:11 | definition of taint6 |
 | test.go:81:34:81:36 | src | test.go:81:12:81:37 | call to StepArgResNoQual |

--- a/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/test.go
+++ b/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/test.go
@@ -69,14 +69,14 @@ func simpleflow() {
 
 	var taint4 test.T
 	taint4.StepArgQual(src)
-	b.Sink1(taint4) // $ MISSING: hasTaintFlow="taint4" // because we don't allow flow through receiver arguments into calls to functions without bodies
+	b.Sink1(taint4) // $ hasTaintFlow="taint4"
 
 	taint5 := (src.(*test.T)).StepQualRes()
-	b.Sink1(taint5) // $ MISSING: hasTaintFlow="taint5" // because we don't allow flow through receiver arguments into calls to functions without bodies
+	b.Sink1(taint5) // $ hasTaintFlow="taint5"
 
 	var taint6 interface{}
 	(src.(*test.T)).StepQualArg(taint6)
-	b.Sink1(taint6) // $ MISSING: hasTaintFlow="taint6" // because we don't allow flow through receiver arguments into calls to functions without bodies
+	b.Sink1(taint6) // $ hasTaintFlow="taint6"
 
 	taint7 := test.StepArgResNoQual(src)
 	b.Sink1(taint7) // $ hasTaintFlow="taint7"
@@ -127,17 +127,17 @@ func simpleflow() {
 
 	c1 := test.C{""}
 	c1.Set(a.Src1().(string))
-	b.Sink1(c1.F) // $ MISSING: hasTaintFlow="selection of F" // currently fails because we don't allow flow through receiver arguments into calls to functions without bodies
+	b.Sink1(c1.F) // $ hasTaintFlow="selection of F"
 
 	c2 := test.C{a.Src1().(string)}
-	b.Sink1(c2.Get()) // $ MISSING: hasTaintFlow="call to Get" // currently fails because we don't allow flow through receiver arguments into calls to functions without bodies
+	b.Sink1(c2.Get()) // $ hasTaintFlow="call to Get"
 
 	c3 := test.C{""}
 	c3.Set(a.Src1().(string))
-	b.Sink1(c3.Get()) // $ MISSING: hasTaintFlow="call to Get" // currently fails because we don't allow flow through receiver arguments into calls to functions without bodies
+	b.Sink1(c3.Get()) // $ hasTaintFlow="call to Get"
 
 	c4 := test.C{""}
 	c4.Set(a.Src1().(string))
 	c4.Set("")
-	b.Sink1(c4.Get())
+	b.Sink1(c4.Get()) // $ SPURIOUS: hasTaintFlow="call to Get" // because we currently don't clear content
 }


### PR DESCRIPTION
This is needed so that the new models-as-data framework can be used to model flow through receivers.