### PR TITLE
Move change notes to proper location

### DIFF
--- a/ql/src/change-notes/2021-12-14-strings-replace-sanitizers.md
+++ b/ql/src/change-notes/2021-12-14-strings-replace-sanitizers.md
@@ -1,2 +1,4 @@
-lgtm,codescanning
+---
+category: minorAnalysis
+---
 * Fixed sanitization by calls to `strings.Replace` and `strings.ReplaceAll` in queries `go/log-injection` and `go/unsafe-quoting`.


### PR DESCRIPTION
There was a single change note that was added to the old change note directory right around the time we moved to using the new per-pack location.
