### PR TITLE
Path transformer: use fully resolved path

### DIFF
--- a/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -374,7 +374,7 @@ func main() {
 			log.Fatalf("Unable to create path transformer file: %s.", err.Error())
 		}
 		defer os.Remove(pt.Name())
-		_, err = pt.WriteString("#" + srcdir + "\n" + newdir + "//\n")
+		_, err = pt.WriteString("#" + realSrc + "\n" + newdir + "//\n")
 		if err != nil {
 			log.Fatalf("Unable to write path transformer file: %s.", err.Error())
 		}


### PR DESCRIPTION
This makes source locations consistent between databases that do and don't use the `SEMMLE_PATH_TRANSFORMER` option in the case where the original source location isn't its own realpath (i.e, some parent directory is a symbolic link).

This can't be tested with a qltest since they can't use path rewriting. I will test this with a dist-compare run instead. It can also be informally tested by observing that if we have source dir `/a` which is a symlink to `/b`, an extraction without `LGTM_INDEX_IMPORT_PATH` or `GITHUB_REPOSITORY` set will result in source locations described relative to `/b`, whereas an extraction with one of those variables set will describe source locations relative to `/a` before this patch or to `/b` afterwards.

This caused results to go missing because their source locations appeared to fall outside the `realpath`'d source root (in this example `/b`).