### PR TITLE
Revert `Function.getACall` behaviour

### DIFF
--- a/ql/examples/snippets/calltobuiltin.ql
+++ b/ql/examples/snippets/calltobuiltin.ql
@@ -11,5 +11,5 @@
 import go
 
 from DataFlow::CallNode call
-where call = Builtin::len().getACall()
+where call = Builtin::len().getACallIncludingExternals()
 select call

--- a/ql/examples/snippets/calltofunction.ql
+++ b/ql/examples/snippets/calltofunction.ql
@@ -12,5 +12,5 @@ import go
 from Function println, DataFlow::CallNode call
 where
   println.hasQualifiedName("fmt", "Println") and
-  call = println.getACall()
+  call = println.getACallIncludingExternals()
 select call

--- a/ql/examples/snippets/calltomethod.ql
+++ b/ql/examples/snippets/calltomethod.ql
@@ -14,5 +14,5 @@ import go
 from Method get, DataFlow::CallNode call
 where
   get.hasQualifiedName("net/http", "Header", "Get") and
-  call = get.getACall()
+  call = get.getACallIncludingExternals()
 select call

--- a/ql/lib/change-notes/2021-01-13-deprecated-function-get-a-call.md
+++ b/ql/lib/change-notes/2021-01-13-deprecated-function-get-a-call.md
@@ -1,0 +1,4 @@
+---
+category: deprecated
+---
+* The member predicate `getACall` on the class `Function` has been deprecated. The recommended replacement is `getACallIncludingExternals`, which gives more results in some cases. See its QLDoc for more details. If these extra results are not desired then instead use `getACallExcludingExternals`, which gives exactly the same results as `getACall`.

--- a/ql/lib/semmle/go/Scopes.qll
+++ b/ql/lib/semmle/go/Scopes.qll
@@ -366,12 +366,20 @@ class PromotedField extends Field {
 
 /** A built-in or declared function. */
 class Function extends ValueEntity, @functionobject {
-  /** Gets a call to this function. */
+  /**
+   * Gets a call to this function, excluding some calls to external functions.
+   *
+   * This excludes calls that target this function indirectly (by calling an
+   * interface method that this function implements) if this is an external
+   * function (for example, a standard library function).
+   *
+   * To avoid this limitation, use `getACallIncludingExternals` instead.
+   */
   pragma[nomagic]
   DataFlow::CallNode getACall() {
     this = result.getTarget()
     or
-    this = result.getACalleeIncludingExternals().asFunction()
+    this.getFuncDecl() = result.getACallee()
   }
 
   /** Gets the declaration of this function, if any. */

--- a/ql/lib/semmle/go/Scopes.qll
+++ b/ql/lib/semmle/go/Scopes.qll
@@ -382,6 +382,19 @@ class Function extends ValueEntity, @functionobject {
     this.getFuncDecl() = result.getACallee()
   }
 
+  /**
+   * Gets a call to this function.
+   *
+   * See documentation for `getACall` for the difference between that function
+   * and this one.
+   */
+  pragma[nomagic]
+  DataFlow::CallNode getACallIncludingExternals() {
+    this = result.getTarget()
+    or
+    this = result.getACalleeIncludingExternals().asFunction()
+  }
+
   /** Gets the declaration of this function, if any. */
   FuncDecl getFuncDecl() { none() }
 

--- a/ql/lib/semmle/go/Scopes.qll
+++ b/ql/lib/semmle/go/Scopes.qll
@@ -367,6 +367,26 @@ class PromotedField extends Field {
 /** A built-in or declared function. */
 class Function extends ValueEntity, @functionobject {
   /**
+   * DEPRECATED: Renamed to `getACallExcludingExternals`. Consider using
+   * `getACallIncludingExternals` instead.
+   */
+  pragma[nomagic]
+  deprecated DataFlow::CallNode getACall() { result = getACallExcludingExternals() }
+
+  /**
+   * Gets a call to this function.
+   *
+   * See documentation for `getACallExcludingExternals` for the difference
+   * between that function and this one.
+   */
+  pragma[nomagic]
+  DataFlow::CallNode getACallIncludingExternals() {
+    this = result.getTarget()
+    or
+    this = result.getACalleeIncludingExternals().asFunction()
+  }
+
+  /**
    * Gets a call to this function, excluding some calls to external functions.
    *
    * This excludes calls that target this function indirectly (by calling an
@@ -376,23 +396,10 @@ class Function extends ValueEntity, @functionobject {
    * To avoid this limitation, use `getACallIncludingExternals` instead.
    */
   pragma[nomagic]
-  DataFlow::CallNode getACall() {
+  DataFlow::CallNode getACallExcludingExternals() {
     this = result.getTarget()
     or
     this.getFuncDecl() = result.getACallee()
-  }
-
-  /**
-   * Gets a call to this function.
-   *
-   * See documentation for `getACall` for the difference between that function
-   * and this one.
-   */
-  pragma[nomagic]
-  DataFlow::CallNode getACallIncludingExternals() {
-    this = result.getTarget()
-    or
-    this = result.getACalleeIncludingExternals().asFunction()
   }
 
   /** Gets the declaration of this function, if any. */

--- a/ql/lib/semmle/go/StringOps.qll
+++ b/ql/lib/semmle/go/StringOps.qll
@@ -149,7 +149,7 @@ module StringOps {
         slice.getLow().getIntValue() = 0 and
         (
           exists(DataFlow::CallNode len |
-            len = Builtin::len().getACall() and
+            len = Builtin::len().getACallIncludingExternals() and
             len.getArgument(0) = globalValueNumber(substring).getANode() and
             slice.getHigh() = globalValueNumber(len).getANode()
           )
@@ -319,7 +319,9 @@ module StringOps {
      * transformations that we cannot easily represent.
      */
     private class SprintfConcat extends Range instanceof Formatting::StringFormatCall {
-      SprintfConcat() { this = any(Function f | f.hasQualifiedName("fmt", "Sprintf")).getACall() }
+      SprintfConcat() {
+        this = any(Function f | f.hasQualifiedName("fmt", "Sprintf")).getACallIncludingExternals()
+      }
 
       override DataFlow::Node getOperand(int n) {
         result = Formatting::StringFormatCall.super.getOperand(n, ["%s", "%v"])

--- a/ql/lib/semmle/go/StringOps.qll
+++ b/ql/lib/semmle/go/StringOps.qll
@@ -213,7 +213,7 @@ module StringOps {
       Range f;
 
       StringFormatCall() {
-        this = f.getACall() and
+        this = f.getACallIncludingExternals() and
         fmt = this.getArgument(f.getFormatStringIndex()).getStringValue() and
         fmt.regexpMatch(getFormatComponentRegex() + "*")
       }

--- a/ql/lib/semmle/go/dataflow/barrierguardutil/RegexpCheck.qll
+++ b/ql/lib/semmle/go/dataflow/barrierguardutil/RegexpCheck.qll
@@ -14,7 +14,7 @@ import go
  */
 predicate regexpFunctionChecksExpr(DataFlow::Node resultNode, Expr checked, boolean branch) {
   exists(RegexpMatchFunction matchfn, DataFlow::CallNode call |
-    matchfn.getACall() = call and
+    matchfn.getACallIncludingExternals() = call and
     resultNode = matchfn.getResult().getNode(call).getASuccessor*() and
     checked = matchfn.getValue().getNode(call).asExpr() and
     (branch = false or branch = true)

--- a/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -37,7 +37,7 @@ abstract class FunctionModel extends Function {
 
   /** Holds if this function model causes data to flow from `pred` to `succ` for the call `c`. */
   predicate flowStepForCall(DataFlow::Node pred, DataFlow::Node succ, DataFlow::CallNode c) {
-    c = this.getACall() and
+    c = this.getACallIncludingExternals() and
     exists(FunctionInput inp, FunctionOutput outp | this.hasDataFlow(inp, outp) |
       pred = inp.getNode(c) and
       succ = outp.getNode(c)
@@ -293,7 +293,7 @@ abstract class BarrierGuard extends Node {
     Node resNode
   ) {
     this.guardingFunction(f, inp, outp, p) and
-    c = f.getACall() and
+    c = f.getACallIncludingExternals() and
     nd = inp.getNode(c) and
     localFlow(pragma[only_bind_out](outp.getNode(c)), resNode)
   }
@@ -352,7 +352,7 @@ abstract class BarrierGuard extends Node {
         |
           ret = getUniqueOutputNode(fd, outp) and
           this.guardingFunction(f2, inp2, outp2, outpProp) and
-          c = f2.getACall() and
+          c = f2.getACallIncludingExternals() and
           arg = inp2.getNode(c) and
           (
             // See comment above ("This method's contract...") for rationale re: the inversion of

--- a/ql/lib/semmle/go/dataflow/internal/TaintTrackingUtil.qll
+++ b/ql/lib/semmle/go/dataflow/internal/TaintTrackingUtil.qll
@@ -195,7 +195,7 @@ abstract class FunctionModel extends Function {
 
   /** Holds if this function model causes taint to flow from `pred` to `succ` for the call `c`. */
   predicate taintStepForCall(DataFlow::Node pred, DataFlow::Node succ, DataFlow::CallNode c) {
-    c = this.getACall() and
+    c = this.getACallIncludingExternals() and
     exists(FunctionInput inp, FunctionOutput outp | this.hasTaintFlow(inp, outp) |
       pred = inp.getNode(c) and
       succ = outp.getNode(c)
@@ -392,7 +392,7 @@ predicate inputIsConstantIfOutputHasProperty(
 ) {
   exists(Function f, FunctionInput inp, FunctionOutput outp, DataFlow::CallNode call |
     functionEnsuresInputIsConstant(f, inp, outp, p) and
-    call = f.getACall() and
+    call = f.getACallIncludingExternals() and
     inputNode = inp.getNode(call) and
     DataFlow::localFlow(outp.getNode(call), outputNode)
   )

--- a/ql/lib/semmle/go/frameworks/Beego.qll
+++ b/ql/lib/semmle/go/frameworks/Beego.qll
@@ -90,7 +90,7 @@ module Beego {
   private class BeegoContextSource extends UntrustedFlowSource::Range {
     BeegoContextSource() {
       exists(Method m | m.hasQualifiedName(contextPackagePath(), "Context", "GetCookie") |
-        this = m.getACall().getResult()
+        this = m.getACallIncludingExternals().getResult()
       )
     }
   }
@@ -145,7 +145,7 @@ module Beego {
 
     BeegoResponseBody() {
       exists(Method m | m.hasQualifiedName(contextPackagePath(), "BeegoOutput", methodName) |
-        call = m.getACall() and
+        call = m.getACallIncludingExternals() and
         this = call.getArgument(0)
       ) and
       methodName in ["Body", "JSON", "JSONP", "ServeFormatted", "XML", "YAML"]
@@ -178,9 +178,9 @@ module Beego {
 
     ControllerResponseBody() {
       exists(Method m | m.hasQualifiedName(packagePath(), "Controller", name) |
-        name = "CustomAbort" and this = m.getACall().getArgument(1)
+        name = "CustomAbort" and this = m.getACallIncludingExternals().getArgument(1)
         or
-        name = "SetData" and this = m.getACall().getArgument(0)
+        name = "SetData" and this = m.getACallIncludingExternals().getArgument(0)
       )
     }
 
@@ -199,9 +199,9 @@ module Beego {
 
     ContextResponseBody() {
       exists(Method m | m.hasQualifiedName(contextPackagePath(), "Context", name) |
-        name = "Abort" and this = m.getACall().getArgument(1)
+        name = "Abort" and this = m.getACallIncludingExternals().getArgument(1)
         or
-        name = "WriteString" and this = m.getACall().getArgument(0)
+        name = "WriteString" and this = m.getACallIncludingExternals().getArgument(0)
       )
     }
 
@@ -282,7 +282,7 @@ module Beego {
     FsOperations() {
       this.getTarget().hasQualifiedName(packagePath(), "Walk")
       or
-      exists(Method m | this = m.getACall() |
+      exists(Method m | this = m.getACallIncludingExternals() |
         m.hasQualifiedName(packagePath(), "FileSystem", "Open") or
         m.hasQualifiedName(packagePath(), "Controller", "SaveToFile")
       )
@@ -305,7 +305,9 @@ module Beego {
         or
         package = contextPackagePath() and className = "Context"
       ) and
-      this = any(Method m | m.hasQualifiedName(package, className, "Redirect")).getACall()
+      this =
+        any(Method m | m.hasQualifiedName(package, className, "Redirect"))
+            .getACallIncludingExternals()
     }
 
     override DataFlow::Node getUrl() {

--- a/ql/lib/semmle/go/frameworks/BeegoOrm.qll
+++ b/ql/lib/semmle/go/frameworks/BeegoOrm.qll
@@ -24,7 +24,7 @@ module BeegoOrm {
           ] and
         if methodName.matches("%Context") then argNum = 1 else argNum = 0
       |
-        this = m.getACall().getArgument(argNum)
+        this = m.getACallIncludingExternals().getArgument(argNum)
       )
     }
   }
@@ -33,7 +33,7 @@ module BeegoOrm {
     // Note this class doesn't do any escaping, unlike the true ORM part of the package
     QueryBuilderSink() {
       exists(Method impl | impl.implements(packagePath(), "QueryBuilder", _) |
-        this = impl.getACall().getAnArgument()
+        this = impl.getACallIncludingExternals().getAnArgument()
       ) and
       this.getType().getUnderlyingType() instanceof StringType
     }
@@ -42,7 +42,7 @@ module BeegoOrm {
   private class OrmerRawSink extends SQL::QueryString::Range {
     OrmerRawSink() {
       exists(Method impl | impl.implements(packagePath(), "Ormer", "Raw") |
-        this = impl.getACall().getArgument(0)
+        this = impl.getACallIncludingExternals().getArgument(0)
       )
     }
   }
@@ -50,7 +50,7 @@ module BeegoOrm {
   private class QuerySeterFilterRawSink extends SQL::QueryString::Range {
     QuerySeterFilterRawSink() {
       exists(Method impl | impl.implements(packagePath(), "QuerySeter", "FilterRaw") |
-        this = impl.getACall().getArgument(1)
+        this = impl.getACallIncludingExternals().getArgument(1)
       )
     }
   }
@@ -58,7 +58,7 @@ module BeegoOrm {
   private class ConditionRawSink extends SQL::QueryString::Range {
     ConditionRawSink() {
       exists(Method impl | impl.implements(packagePath(), "Condition", "Raw") |
-        this = impl.getACall().getArgument(1)
+        this = impl.getACallIncludingExternals().getArgument(1)
       )
     }
   }
@@ -68,7 +68,7 @@ module BeegoOrm {
       exists(Method impl |
         impl.implements(packagePath(), "Ormer", ["Read", "ReadForUpdate", "ReadOrCreate"])
       |
-        this = FunctionOutput::parameter(0).getExitNode(impl.getACall())
+        this = FunctionOutput::parameter(0).getExitNode(impl.getACallIncludingExternals())
       )
     }
   }
@@ -79,7 +79,7 @@ module BeegoOrm {
         m.hasQualifiedName(packagePath(), ["JSONField", "JsonbField", "TextField"],
           ["RawValue", "String", "Value"])
       |
-        this = m.getACall().getResult()
+        this = m.getACallIncludingExternals().getResult()
       )
     }
   }
@@ -94,7 +94,7 @@ module BeegoOrm {
             "QueryRow", "QueryRows"
           ])
       |
-        this = FunctionOutput::parameter(0).getExitNode(impl.getACall())
+        this = FunctionOutput::parameter(0).getExitNode(impl.getACallIncludingExternals())
       )
     }
   }

--- a/ql/lib/semmle/go/frameworks/Couchbase.qll
+++ b/ql/lib/semmle/go/frameworks/Couchbase.qll
@@ -72,7 +72,7 @@ module Couchbase {
         structName in ["Bucket", "Cluster"] and
         methodName in ["ExecuteN1qlQuery", "ExecuteAnalyticsQuery"] and
         meth.hasQualifiedName(packagePath(), structName, methodName) and
-        this = meth.getACall().getArgument(0)
+        this = meth.getACallIncludingExternals().getArgument(0)
       )
     }
   }
@@ -91,7 +91,7 @@ module Couchbase {
         structName in ["Cluster", "Scope"] and
         methodName in ["AnalyticsQuery", "Query"] and
         meth.hasQualifiedName(packagePath(), structName, methodName) and
-        this = meth.getACall().getArgument(0)
+        this = meth.getACallIncludingExternals().getArgument(0)
       )
     }
   }

--- a/ql/lib/semmle/go/frameworks/Echo.qll
+++ b/ql/lib/semmle/go/frameworks/Echo.qll
@@ -80,7 +80,7 @@ private module Echo {
   private class EchoHtmlOutputs extends HTTP::ResponseBody::Range {
     EchoHtmlOutputs() {
       exists(Method m | m.hasQualifiedName(packagePath(), "Context", ["HTML", "HTMLBlob"]) |
-        this = m.getACall().getArgument(1)
+        this = m.getACallIncludingExternals().getArgument(1)
       )
     }
 
@@ -97,7 +97,7 @@ private module Echo {
 
     EchoParameterizedOutputs() {
       exists(Method m | m.hasQualifiedName(packagePath(), "Context", ["Blob", "Stream"]) |
-        callNode = m.getACall() and this = callNode.getArgument(2)
+        callNode = m.getACallIncludingExternals() and this = callNode.getArgument(2)
       )
     }
 
@@ -112,7 +112,7 @@ private module Echo {
   private class EchoRedirectMethod extends HTTP::Redirect::Range, DataFlow::CallNode {
     EchoRedirectMethod() {
       exists(Method m | m.hasQualifiedName(packagePath(), "Context", "Redirect") |
-        this = m.getACall()
+        this = m.getACallIncludingExternals()
       )
     }
 

--- a/ql/lib/semmle/go/frameworks/Email.qll
+++ b/ql/lib/semmle/go/frameworks/Email.qll
@@ -32,13 +32,13 @@ module EmailData {
       // func (c *Client) Data() (io.WriteCloser, error)
       exists(Method data |
         data.hasQualifiedName("net/smtp", "Client", "Data") and
-        this.(DataFlow::SsaNode).getInit() = data.getACall().getResult(0)
+        this.(DataFlow::SsaNode).getInit() = data.getACallIncludingExternals().getResult(0)
       )
       or
       // func SendMail(addr string, a Auth, from string, to []string, msg []byte) error
       exists(Function sendMail |
         sendMail.hasQualifiedName("net/smtp", "SendMail") and
-        this = sendMail.getACall().getArgument(4)
+        this = sendMail.getACallIncludingExternals().getArgument(4)
       )
     }
   }
@@ -65,19 +65,19 @@ module EmailData {
       // func NewSingleEmail(from *Email, subject string, to *Email, plainTextContent string, htmlContent string) *SGMailV3
       exists(Function newSingleEmail |
         newSingleEmail.hasQualifiedName(sendgridMail(), "NewSingleEmail") and
-        this = newSingleEmail.getACall().getArgument([1, 3, 4])
+        this = newSingleEmail.getACallIncludingExternals().getArgument([1, 3, 4])
       )
       or
       // func NewV3MailInit(from *Email, subject string, to *Email, content ...*Content) *SGMailV3
       exists(Function newv3MailInit |
         newv3MailInit.hasQualifiedName(sendgridMail(), "NewV3MailInit") and
-        this = newv3MailInit.getACall().getArgument(any(int i | i = 1 or i >= 3))
+        this = newv3MailInit.getACallIncludingExternals().getArgument(any(int i | i = 1 or i >= 3))
       )
       or
       // func (s *SGMailV3) AddContent(c ...*Content) *SGMailV3
       exists(Method addContent |
         addContent.hasQualifiedName(sendgridMail(), "SGMailV3", "AddContent") and
-        this = addContent.getACall().getAnArgument()
+        this = addContent.getACallIncludingExternals().getAnArgument()
       )
     }
   }

--- a/ql/lib/semmle/go/frameworks/Glog.qll
+++ b/ql/lib/semmle/go/frameworks/Glog.qll
@@ -47,7 +47,7 @@ module Glog {
   private class GlogCall extends LoggerCall::Range, DataFlow::CallNode {
     GlogFunction callee;
 
-    GlogCall() { this = callee.getACall() }
+    GlogCall() { this = callee.getACallIncludingExternals() }
 
     override DataFlow::Node getAMessageComponent() {
       result = this.getArgument(any(int i | i >= callee.getFirstPrintedArg()))

--- a/ql/lib/semmle/go/frameworks/GoRestfulHttp.qll
+++ b/ql/lib/semmle/go/frameworks/GoRestfulHttp.qll
@@ -28,7 +28,7 @@ private module GoRestfulHttp {
    * A model of go-restful's `Request` object as a source of user-controlled data.
    */
   private class GoRestfulSource extends UntrustedFlowSource::Range {
-    GoRestfulSource() { this = any(GoRestfulSourceMethod g).getACall() }
+    GoRestfulSource() { this = any(GoRestfulSourceMethod g).getACallIncludingExternals() }
   }
 
   /**

--- a/ql/lib/semmle/go/frameworks/K8sIoClientGo.qll
+++ b/ql/lib/semmle/go/frameworks/K8sIoClientGo.qll
@@ -23,6 +23,8 @@ module K8sIoClientGo {
    * A model of `SecretInterface` as a source of secret data.
    */
   class SecretInterfaceSource extends DataFlow::Node {
-    SecretInterfaceSource() { this = any(SecretInterfaceSourceMethod g).getACall().getResult(0) }
+    SecretInterfaceSource() {
+      this = any(SecretInterfaceSourceMethod g).getACallIncludingExternals().getResult(0)
+    }
   }
 }

--- a/ql/lib/semmle/go/frameworks/Logrus.qll
+++ b/ql/lib/semmle/go/frameworks/Logrus.qll
@@ -33,7 +33,7 @@ module Logrus {
   }
 
   private class LogCall extends LoggerCall::Range, DataFlow::CallNode {
-    LogCall() { this = any(LogFunction f).getACall() }
+    LogCall() { this = any(LogFunction f).getACallIncludingExternals() }
 
     override DataFlow::Node getAMessageComponent() { result = this.getAnArgument() }
   }

--- a/ql/lib/semmle/go/frameworks/NoSQL.qll
+++ b/ql/lib/semmle/go/frameworks/NoSQL.qll
@@ -101,7 +101,7 @@ module NoSQL {
           mongoDbCollectionMethod(methodName, n) and
           meth.hasQualifiedName(package("go.mongodb.org/mongo-driver", "mongo"), "Collection",
             methodName) and
-          this = meth.getACall().getArgument(n)
+          this = meth.getACallIncludingExternals().getArgument(n)
         )
       }
     }

--- a/ql/lib/semmle/go/frameworks/Protobuf.qll
+++ b/ql/lib/semmle/go/frameworks/Protobuf.qll
@@ -69,7 +69,7 @@ module Protobuf {
   private class MarshalStateStep extends TaintTracking::AdditionalTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::PostUpdateNode marshalInput, DataFlow::CallNode marshalStateCall |
-        marshalStateCall = marshalStateMethod().getACall() and
+        marshalStateCall = marshalStateMethod().getACallIncludingExternals() and
         // pred -> marshalInput.Message
         any(DataFlow::Write w)
             .writesField(marshalInput.getPreUpdateNode(), inputMessageField(), pred) and

--- a/ql/lib/semmle/go/frameworks/Revel.qll
+++ b/ql/lib/semmle/go/frameworks/Revel.qll
@@ -120,7 +120,7 @@ module Revel {
     ControllerRenderMethods() {
       exists(Method m, string methodName, DataFlow::CallNode methodCall |
         m.hasQualifiedName(packagePath(), "Controller", methodName) and
-        methodCall = m.getACall()
+        methodCall = m.getACallIncludingExternals()
       |
         exists(int exposedArgument |
           this = methodCall.getArgument(exposedArgument) and
@@ -162,7 +162,8 @@ module Revel {
   private class RenderFileNameCall extends FileSystemAccess::Range, DataFlow::CallNode {
     RenderFileNameCall() {
       this =
-        any(Method m | m.hasQualifiedName(packagePath(), "Controller", "RenderFileName")).getACall()
+        any(Method m | m.hasQualifiedName(packagePath(), "Controller", "RenderFileName"))
+            .getACallIncludingExternals()
     }
 
     override DataFlow::Node getAPathArgument() { result = this.getArgument(0) }
@@ -177,7 +178,7 @@ module Revel {
   private class ControllerRedirectMethod extends HTTP::Redirect::Range, DataFlow::CallNode {
     ControllerRedirectMethod() {
       exists(Method m | m.hasQualifiedName(packagePath(), "Controller", "Redirect") |
-        this = m.getACall()
+        this = m.getACallIncludingExternals()
       )
     }
 

--- a/ql/lib/semmle/go/frameworks/SQL.qll
+++ b/ql/lib/semmle/go/frameworks/SQL.qll
@@ -95,7 +95,7 @@ module SQL {
               fn.(Method).hasQualifiedName(sq, builder, "Where")
             )
           ) and
-          this = fn.getACall().getArgument(0) and
+          this = fn.getACallIncludingExternals().getArgument(0) and
           this.getType().getUnderlyingType() instanceof StringType
         )
       }
@@ -126,7 +126,7 @@ module SQL {
             )
           )
         |
-          this = f.getACall().getArgument(arg)
+          this = f.getACallIncludingExternals().getArgument(arg)
         )
       }
     }
@@ -151,7 +151,7 @@ module SQL {
             arg = 1
           )
         |
-          this = f.getACall().getArgument(arg)
+          this = f.getACallIncludingExternals().getArgument(arg)
         )
       }
     }
@@ -183,7 +183,7 @@ module SQL {
     GormSink() {
       exists(Method meth, string package, string name |
         meth.hasQualifiedName(package, "DB", name) and
-        this = meth.getACall().getArgument(0) and
+        this = meth.getACallIncludingExternals().getArgument(0) and
         package = Gorm::packagePath() and
         name in [
             "Where", "Raw", "Order", "Not", "Or", "Select", "Table", "Group", "Having", "Joins",
@@ -198,7 +198,7 @@ module SQL {
     SqlxSink() {
       exists(Method meth, string name, int n |
         meth.hasQualifiedName(package("github.com/jmoiron/sqlx", ""), ["DB", "Tx"], name) and
-        this = meth.getACall().getArgument(n)
+        this = meth.getACallIncludingExternals().getArgument(n)
       |
         name = ["Select", "Get"] and n = 1
         or
@@ -230,7 +230,7 @@ module Xorm {
     XormSink() {
       exists(Method meth, string type, string name, int n |
         meth.hasQualifiedName(Xorm::packagePath(), type, name) and
-        this = meth.getACall().getArgument(n) and
+        this = meth.getACallIncludingExternals().getArgument(n) and
         type = ["Engine", "Session"]
       |
         name =

--- a/ql/lib/semmle/go/frameworks/Spew.qll
+++ b/ql/lib/semmle/go/frameworks/Spew.qll
@@ -39,7 +39,7 @@ module Spew {
   private class SpewCall extends LoggerCall::Range, DataFlow::CallNode {
     SpewFunction target;
 
-    SpewCall() { this = target.getACall() }
+    SpewCall() { this = target.getACallIncludingExternals() }
 
     override DataFlow::Node getAMessageComponent() {
       result = this.getArgument(any(int i | i >= target.getFirstPrintedArg()))

--- a/ql/lib/semmle/go/frameworks/SystemCommandExecutors.qll
+++ b/ql/lib/semmle/go/frameworks/SystemCommandExecutors.qll
@@ -66,7 +66,7 @@ private class GoShCommandExecution extends SystemCommandExecution::Range, DataFl
         or
         method.hasQualifiedName(packagePath, "Session", "Exec")
       |
-        this = method.getACall()
+        this = method.getACallIncludingExternals()
       )
       or
       // Catch calls to the `Command` function:
@@ -102,7 +102,7 @@ module CryptoSsh {
         methodName = "Start"
       |
         method.hasQualifiedName(packagePath(), "Session", methodName) and
-        this = method.getACall()
+        this = method.getACallIncludingExternals()
       )
     }
 

--- a/ql/lib/semmle/go/frameworks/WebSocket.qll
+++ b/ql/lib/semmle/go/frameworks/WebSocket.qll
@@ -133,7 +133,7 @@ module WebSocketRequestCall {
  */
 class WebSocketReaderAsSource extends UntrustedFlowSource::Range {
   WebSocketReaderAsSource() {
-    exists(WebSocketReader r | this = r.getAnOutput().getNode(r.getACall()))
+    exists(WebSocketReader r | this = r.getAnOutput().getNode(r.getACallIncludingExternals()))
   }
 }
 

--- a/ql/lib/semmle/go/frameworks/XPath.qll
+++ b/ql/lib/semmle/go/frameworks/XPath.qll
@@ -36,17 +36,17 @@ module XPath {
       AntchfxXpathXPathExpressionString() {
         exists(Function f, string name | name.matches("Compile%") |
           f.hasQualifiedName(package("github.com/antchfx/xpath", ""), name) and
-          this = f.getACall().getArgument(0)
+          this = f.getACallIncludingExternals().getArgument(0)
         )
         or
         exists(Function f, string name | name.matches("MustCompile%") |
           f.hasQualifiedName(package("github.com/antchfx/xpath", ""), name) and
-          this = f.getACall().getArgument(0)
+          this = f.getACallIncludingExternals().getArgument(0)
         )
         or
         exists(Function f, string name | name.matches("Select%") |
           f.hasQualifiedName(package("github.com/antchfx/xpath", ""), name) and
-          this = f.getACall().getArgument(1)
+          this = f.getACallIncludingExternals().getArgument(1)
         )
       }
     }
@@ -59,12 +59,12 @@ module XPath {
       AntchfxHtmlqueryXPathExpressionString() {
         exists(Function f, string name | name.matches("Find%") |
           f.hasQualifiedName(package("github.com/antchfx/htmlquery", ""), name) and
-          this = f.getACall().getArgument(1)
+          this = f.getACallIncludingExternals().getArgument(1)
         )
         or
         exists(Function f, string name | name.matches("Query%") |
           f.hasQualifiedName(package("github.com/antchfx/htmlquery", ""), name) and
-          this = f.getACall().getArgument(1)
+          this = f.getACallIncludingExternals().getArgument(1)
         )
       }
     }
@@ -77,17 +77,17 @@ module XPath {
       AntchfxXmlqueryXPathExpressionString() {
         exists(Function f, string name | name.matches("Find%") |
           f.hasQualifiedName(package("github.com/antchfx/xmlquery", ""), name) and
-          this = f.getACall().getArgument(1)
+          this = f.getACallIncludingExternals().getArgument(1)
         )
         or
         exists(Function f, string name | name.matches("Query%") |
           f.hasQualifiedName(package("github.com/antchfx/xmlquery", ""), name) and
-          this = f.getACall().getArgument(1)
+          this = f.getACallIncludingExternals().getArgument(1)
         )
         or
         exists(Method m, string name | name.matches("Select%") |
           m.hasQualifiedName(package("github.com/antchfx/xmlquery", ""), "Node", name) and
-          this = m.getACall().getArgument(0)
+          this = m.getACallIncludingExternals().getArgument(0)
         )
       }
     }
@@ -100,12 +100,12 @@ module XPath {
       AntchfxJsonqueryXPathExpressionString() {
         exists(Function f, string name | name.matches("Find%") |
           f.hasQualifiedName(package("github.com/antchfx/jsonquery", ""), name) and
-          this = f.getACall().getArgument(1)
+          this = f.getACallIncludingExternals().getArgument(1)
         )
         or
         exists(Function f, string name | name.matches("Query%") |
           f.hasQualifiedName(package("github.com/antchfx/jsonquery", ""), name) and
-          this = f.getACall().getArgument(1)
+          this = f.getACallIncludingExternals().getArgument(1)
         )
       }
     }
@@ -118,12 +118,12 @@ module XPath {
       GoXmlpathXmlpathXPathExpressionString() {
         exists(Function f, string name | name.matches("Compile%") |
           f.hasQualifiedName(XmlPath::packagePath(), name) and
-          this = f.getACall().getArgument(0)
+          this = f.getACallIncludingExternals().getArgument(0)
         )
         or
         exists(Function f, string name | name.matches("MustCompile%") |
           f.hasQualifiedName(XmlPath::packagePath(), name) and
-          this = f.getACall().getArgument(0)
+          this = f.getACallIncludingExternals().getArgument(0)
         )
       }
     }
@@ -136,12 +136,12 @@ module XPath {
       ChrisTrenkampGoxpathXPathExpressionString() {
         exists(Function f, string name | name.matches("Parse%") |
           f.hasQualifiedName(package("github.com/ChrisTrenkamp/goxpath", ""), name) and
-          this = f.getACall().getArgument(0)
+          this = f.getACallIncludingExternals().getArgument(0)
         )
         or
         exists(Function f, string name | name.matches("MustParse%") |
           f.hasQualifiedName(package("github.com/ChrisTrenkamp/goxpath", ""), name) and
-          this = f.getACall().getArgument(0)
+          this = f.getACallIncludingExternals().getArgument(0)
         )
       }
     }
@@ -154,12 +154,12 @@ module XPath {
       SanthoshTekuriXpathparserXPathExpressionString() {
         exists(Function f, string name | name.matches("Parse%") |
           f.hasQualifiedName(package("github.com/santhosh-tekuri/xpathparser", ""), name) and
-          this = f.getACall().getArgument(0)
+          this = f.getACallIncludingExternals().getArgument(0)
         )
         or
         exists(Function f, string name | name.matches("MustParse%") |
           f.hasQualifiedName(package("github.com/santhosh-tekuri/xpathparser", ""), name) and
-          this = f.getACall().getArgument(0)
+          this = f.getACallIncludingExternals().getArgument(0)
         )
       }
     }
@@ -172,17 +172,17 @@ module XPath {
       JbowtieGokogiriXPathExpressionString() {
         exists(Function f, string name | name.matches("Compile%") |
           f.hasQualifiedName(package("github.com/jbowtie/gokogiri", "xpath"), name) and
-          this = f.getACall().getArgument(0)
+          this = f.getACallIncludingExternals().getArgument(0)
         )
         or
         exists(Method m, string name | name.matches("Search%") |
           m.hasQualifiedName(package("github.com/jbowtie/gokogiri", "xml"), "Node", name) and
-          this = m.getACall().getArgument(0)
+          this = m.getACallIncludingExternals().getArgument(0)
         )
         or
         exists(Method m, string name | name.matches("EvalXPath%") |
           m.hasQualifiedName(package("github.com/jbowtie/gokogiri", "xml"), "Node", name) and
-          this = m.getACall().getArgument(0)
+          this = m.getACallIncludingExternals().getArgument(0)
         )
       }
     }

--- a/ql/lib/semmle/go/frameworks/Zap.qll
+++ b/ql/lib/semmle/go/frameworks/Zap.qll
@@ -44,7 +44,7 @@ module Zap {
    * function is called are included.
    */
   private class ZapCall extends LoggerCall::Range, DataFlow::MethodCallNode {
-    ZapCall() { this = any(ZapFunction f).getACall() }
+    ZapCall() { this = any(ZapFunction f).getACallIncludingExternals() }
 
     override DataFlow::Node getAMessageComponent() { result = this.getAnArgument() }
   }

--- a/ql/lib/semmle/go/frameworks/stdlib/DatabaseSql.qll
+++ b/ql/lib/semmle/go/frameworks/stdlib/DatabaseSql.qll
@@ -15,7 +15,7 @@ module DatabaseSql {
     Query() {
       exists(Method meth, string base, string m |
         meth.hasQualifiedName("database/sql", t, m) and
-        this = meth.getACall()
+        this = meth.getACallIncludingExternals()
       |
         t = ["DB", "Tx", "Conn", "Stmt"] and
         base = ["Exec", "Query", "QueryRow"] and
@@ -40,7 +40,7 @@ module DatabaseSql {
       exists(Method meth, string base, string t, string m, int n |
         t = ["DB", "Tx", "Conn"] and
         meth.hasQualifiedName("database/sql", t, m) and
-        this = meth.getACall().getArgument(n)
+        this = meth.getACallIncludingExternals().getArgument(n)
       |
         base = ["Exec", "Prepare", "Query", "QueryRow"] and
         (
@@ -71,7 +71,7 @@ module DatabaseSql {
           or
           meth.hasQualifiedName("database/sql/driver", "StmtQueryContext", "QueryContext")
         ) and
-        this = meth.getACall()
+        this = meth.getACallIncludingExternals()
       )
     }
 
@@ -103,7 +103,7 @@ module DatabaseSql {
           or
           meth.hasQualifiedName("database/sql/driver", "QueryerContext", "QueryContext") and n = 1
         ) and
-        this = meth.getACall().getArgument(n)
+        this = meth.getACallIncludingExternals().getArgument(n)
       )
     }
   }

--- a/ql/lib/semmle/go/frameworks/stdlib/Log.qll
+++ b/ql/lib/semmle/go/frameworks/stdlib/Log.qll
@@ -26,7 +26,7 @@ module Log {
   }
 
   private class LogCall extends LoggerCall::Range, DataFlow::CallNode {
-    LogCall() { this = any(LogFunction f).getACall() }
+    LogCall() { this = any(LogFunction f).getACallIncludingExternals() }
 
     override DataFlow::Node getAMessageComponent() { result = this.getAnArgument() }
   }

--- a/ql/lib/semmle/go/frameworks/stdlib/NetHttp.qll
+++ b/ql/lib/semmle/go/frameworks/stdlib/NetHttp.qll
@@ -126,7 +126,7 @@ module NetHttp {
     RequestBody() {
       exists(Function newRequest |
         newRequest.hasQualifiedName("net/http", "NewRequest") and
-        this = newRequest.getACall().getArgument(2)
+        this = newRequest.getACallIncludingExternals().getArgument(2)
       )
       or
       exists(Field body, Type request |
@@ -250,7 +250,7 @@ module NetHttp {
       or
       exists(Method m, string methName |
         m.hasQualifiedName("net/http", "Request", methName) and
-        this = m.getACall().getResult(0)
+        this = m.getACallIncludingExternals().getResult(0)
       |
         methName = ["Cookie", "Cookies", "MultipartReader", "PostFormValue", "Referer", "UserAgent"]
       )

--- a/ql/lib/semmle/go/frameworks/stdlib/Regexp.qll
+++ b/ql/lib/semmle/go/frameworks/stdlib/Regexp.qll
@@ -12,7 +12,7 @@ module Regexp {
     Pattern() {
       exists(Function fn | fnName.matches("Match%") or fnName.matches("%Compile%") |
         fn.hasQualifiedName("regexp", fnName) and
-        this = fn.getACall().getArgument(0)
+        this = fn.getACallIncludingExternals().getArgument(0)
       )
     }
 

--- a/ql/lib/semmle/go/security/AllocationSizeOverflow.qll
+++ b/ql/lib/semmle/go/security/AllocationSizeOverflow.qll
@@ -21,7 +21,9 @@ module AllocationSizeOverflow {
 
     override predicate isSource(DataFlow::Node nd) { nd instanceof Source }
 
-    override predicate isSink(DataFlow::Node nd) { nd = Builtin::len().getACall().getArgument(0) }
+    override predicate isSink(DataFlow::Node nd) {
+      nd = Builtin::len().getACallIncludingExternals().getArgument(0)
+    }
 
     override predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
       guard instanceof SanitizerGuard

--- a/ql/lib/semmle/go/security/CommandInjection.qll
+++ b/ql/lib/semmle/go/security/CommandInjection.qll
@@ -46,7 +46,7 @@ module CommandInjection {
       // Call whose argument list contains a "--"
       exists(DataFlow::CallNode c |
         this = c and
-        (c = Builtin::append().getACall() or c = any(SystemCommandExecution sce)) and
+        (c = Builtin::append().getACallIncludingExternals() or c = any(SystemCommandExecution sce)) and
         c.getArgument(doubleDashIndex).getStringValue() = "--"
       )
       or

--- a/ql/lib/semmle/go/security/ExternalAPIs.qll
+++ b/ql/lib/semmle/go/security/ExternalAPIs.qll
@@ -74,11 +74,11 @@ class ExternalAPIDataNode extends DataFlow::Node {
     // Not already modeled as a taint step
     not exists(DataFlow::Node next | TaintTracking::localTaintStep(this, next)) and
     // Not a call to a known safe external API
-    not call = any(SafeExternalAPIFunction f).getACall()
+    not call = any(SafeExternalAPIFunction f).getACallExcludingExternals()
   }
 
   /** Gets the called API `Function`. */
-  Function getFunction() { result.getACall() = call }
+  Function getFunction() { result.getACallExcludingExternals() = call }
 
   /** Gets the index which is passed untrusted data (where -1 indicates the receiver). */
   int getIndex() { result = i }

--- a/ql/lib/semmle/go/security/InsecureRandomnessCustomizations.qll
+++ b/ql/lib/semmle/go/security/InsecureRandomnessCustomizations.qll
@@ -60,7 +60,7 @@ module InsecureRandomness {
         // Some interfaces in the `crypto` package are the same as interfaces
         // elsewhere, e.g. tls.listener is the same as net.Listener
         not fn.hasQualifiedName(nonCryptoInterface(), _) and
-        this = fn.getACall().getAnArgument()
+        this = fn.getACallExcludingExternals().getAnArgument()
       )
     }
 

--- a/ql/lib/semmle/go/security/StoredXssCustomizations.qll
+++ b/ql/lib/semmle/go/security/StoredXssCustomizations.qll
@@ -44,7 +44,7 @@ module StoredXss {
       // the second parameter to a filepath.Walk function
       exists(DataFlow::FunctionNode f, Function walkFn | this = f.getParameter(0) |
         walkFn.hasQualifiedName("path/filepath", ["Walk", "WalkDir"]) and
-        walkFn.getACall().getArgument(1) = f.getASuccessor*()
+        walkFn.getACallIncludingExternals().getArgument(1) = f.getASuccessor*()
       )
       or
       // A call to os.FileInfo.Name

--- a/ql/lib/semmle/go/security/StringBreakCustomizations.qll
+++ b/ql/lib/semmle/go/security/StringBreakCustomizations.qll
@@ -53,7 +53,7 @@ module StringBreak {
   class JsonMarshalAsSource extends Source {
     JsonMarshalAsSource() {
       exists(MarshalingFunction jsonMarshal | jsonMarshal.getFormat() = "JSON" |
-        this = jsonMarshal.getOutput().getNode(jsonMarshal.getACall())
+        this = jsonMarshal.getOutput().getNode(jsonMarshal.getACallIncludingExternals())
       )
     }
   }
@@ -76,7 +76,7 @@ module StringBreak {
   class UnmarshalSanitizer extends Sanitizer {
     UnmarshalSanitizer() {
       exists(UnmarshalingFunction jsonUnmarshal | jsonUnmarshal.getFormat() = "JSON" |
-        this = jsonUnmarshal.getOutput().getNode(jsonUnmarshal.getACall())
+        this = jsonUnmarshal.getOutput().getNode(jsonUnmarshal.getACallIncludingExternals())
       )
     }
   }

--- a/ql/lib/semmle/go/security/TaintedPathCustomizations.qll
+++ b/ql/lib/semmle/go/security/TaintedPathCustomizations.qll
@@ -71,7 +71,7 @@ module TaintedPath {
       exists(Function f, FunctionOutput outp |
         f.hasQualifiedName("path/filepath", "Rel") and
         outp.isResult(0) and
-        this = outp.getNode(f.getACall())
+        this = outp.getNode(f.getACallIncludingExternals())
       )
     }
   }
@@ -119,7 +119,7 @@ module TaintedPath {
         p.isNil()
       |
         exists(DataFlow::Node call, DataFlow::Node res |
-          call = f.getACall() and
+          call = f.getACallIncludingExternals() and
           DataFlow::localFlow(outp.getNode(call), res)
         |
           p.checkOn(this, outcome, res) and
@@ -142,7 +142,7 @@ module TaintedPath {
     PrefixCheck() {
       exists(Function f |
         f.hasQualifiedName("strings", "HasPrefix") and
-        this = f.getACall()
+        this = f.getACallIncludingExternals()
       )
     }
 

--- a/ql/lib/semmle/go/security/Xss.qll
+++ b/ql/lib/semmle/go/security/Xss.qll
@@ -97,7 +97,7 @@ module SharedXss {
   class JsonMarshalSanitizer extends Sanitizer {
     JsonMarshalSanitizer() {
       exists(MarshalingFunction mf | mf.getFormat() = "JSON" |
-        this = mf.getOutput().getNode(mf.getACall())
+        this = mf.getOutput().getNode(mf.getACallIncludingExternals())
       )
     }
   }

--- a/ql/src/InconsistentCode/ConstantLengthComparison.ql
+++ b/ql/src/InconsistentCode/ConstantLengthComparison.ql
@@ -20,7 +20,7 @@ where
   // `idx` reads `a[i]`
   idx.reads(a.getANode(), i.getARead()) and
   // `lenA` is `len(a)`
-  lenA = Builtin::len().getACall() and
+  lenA = Builtin::len().getACallIncludingExternals() and
   lenA.getArgument(0) = a.getANode() and
   // and is checked against a constant
   exists(DataFlow::Node const | exists(const.getIntValue()) |

--- a/ql/src/InconsistentCode/LengthComparisonOffByOne.ql
+++ b/ql/src/InconsistentCode/LengthComparisonOffByOne.ql
@@ -36,7 +36,7 @@ DataFlow::Node getAUse(Index i) {
  * Gets a call to `len(array)`.
  */
 DataFlow::CallNode arrayLen(DataFlow::SsaNode array) {
-  result = Builtin::len().getACall() and
+  result = Builtin::len().getACallIncludingExternals() and
   result.getArgument(0) = array.getAUse()
 }
 

--- a/ql/src/RedundantCode/NegativeLengthCheck.ql
+++ b/ql/src/RedundantCode/NegativeLengthCheck.ql
@@ -17,7 +17,7 @@ from ComparisonExpr cmp, DataFlow::Node op, int ub, string d, string r
 where
   (
     exists(BuiltinFunction bf | bf = Builtin::len() or bf = Builtin::cap() |
-      op = bf.getACall() and d = "'" + bf.getName() + "'"
+      op = bf.getACallIncludingExternals() and d = "'" + bf.getName() + "'"
     )
     or
     op.getType().getUnderlyingType() instanceof UnsignedIntegerType and

--- a/ql/src/Security/CWE-209/StackTraceExposure.ql
+++ b/ql/src/Security/CWE-209/StackTraceExposure.ql
@@ -56,8 +56,8 @@ class StackTraceExposureConfig extends TaintTracking::Configuration {
 
   override predicate isSource(DataFlow::Node node) {
     node.(DataFlow::PostUpdateNode).getPreUpdateNode() =
-      any(StackFunction f).getACall().getArgument(0) or
-    node = any(DebugStackFunction f).getACall().getResult()
+      any(StackFunction f).getACallIncludingExternals().getArgument(0) or
+    node = any(DebugStackFunction f).getACallIncludingExternals().getResult()
   }
 
   override predicate isSink(DataFlow::Node node) { node instanceof HTTP::ResponseBody }

--- a/ql/src/Security/CWE-322/InsecureHostKeyCallback.ql
+++ b/ql/src/Security/CWE-322/InsecureHostKeyCallback.ql
@@ -42,7 +42,7 @@ class HostKeyCallbackFunc extends DataFlow::Node {
 class InsecureHostKeyCallbackFunc extends HostKeyCallbackFunc {
   InsecureHostKeyCallbackFunc() {
     // Either a call to InsecureIgnoreHostKey(), which we know returns an insecure callback.
-    this = any(InsecureIgnoreHostKey f).getACall().getAResult()
+    this = any(InsecureIgnoreHostKey f).getACallIncludingExternals().getAResult()
     or
     // Or a callback function in the source code (named or anonymous) that always returns nil.
     forex(DataFlow::ResultNode returnValue |

--- a/ql/src/Security/CWE-327/InsecureTLS.ql
+++ b/ql/src/Security/CWE-327/InsecureTLS.ql
@@ -185,7 +185,7 @@ class TlsInsecureCipherSuitesFlowConfig extends TaintTracking::Configuration {
     exists(Function insecureCipherSuites |
       insecureCipherSuites.hasQualifiedName("crypto/tls", "InsecureCipherSuites")
     |
-      source = insecureCipherSuites.getACall().getResult()
+      source = insecureCipherSuites.getACallIncludingExternals().getResult()
     )
   }
 

--- a/ql/src/Security/CWE-352/ConstantOauth2State.ql
+++ b/ql/src/Security/CWE-352/ConstantOauth2State.ql
@@ -32,7 +32,7 @@ class ConstantStateFlowConf extends DataFlow::Configuration {
   ConstantStateFlowConf() { this = "ConstantStateFlowConf" }
 
   predicate isSink(DataFlow::Node sink, DataFlow::CallNode call) {
-    exists(AuthCodeURL m | call = m.getACall() | sink = call.getArgument(0))
+    exists(AuthCodeURL m | call = m.getACallIncludingExternals() | sink = call.getArgument(0))
   }
 
   override predicate isSource(DataFlow::Node source) {
@@ -110,7 +110,7 @@ class PrivateUrlFlowsToAuthCodeUrlCall extends DataFlow::Configuration {
   }
 
   predicate isSink(DataFlow::Node sink, DataFlow::CallNode call) {
-    exists(AuthCodeURL m | call = m.getACall() | sink = call.getReceiver())
+    exists(AuthCodeURL m | call = m.getACallIncludingExternals() | sink = call.getReceiver())
   }
 
   override predicate isSink(DataFlow::Node sink) { this.isSink(sink, _) }
@@ -139,7 +139,7 @@ class FlowToPrint extends DataFlow::Configuration {
   }
 
   override predicate isSource(DataFlow::Node source) {
-    source = any(AuthCodeURL m).getACall().getResult()
+    source = any(AuthCodeURL m).getACallIncludingExternals().getResult()
   }
 
   override predicate isSink(DataFlow::Node sink) { this.isSink(sink, _) }
@@ -165,14 +165,14 @@ DataFlow::Node getAStdinNode() {
  * instance wrapping `os.Stdin`.
  */
 DataFlow::CallNode getAScannerCall() {
-  result = any(Fmt::Scanner f).getACall()
+  result = any(Fmt::Scanner f).getACallIncludingExternals()
   or
   exists(Fmt::FScanner f |
-    result = f.getACall() and f.getReader().getNode(result) = getAStdinNode()
+    result = f.getACallIncludingExternals() and f.getReader().getNode(result) = getAStdinNode()
   )
   or
   exists(Bufio::NewScanner f |
-    result = f.getACall() and f.getReader().getNode(result) = getAStdinNode()
+    result = f.getACallIncludingExternals() and f.getReader().getNode(result) = getAStdinNode()
   )
 }
 

--- a/ql/src/Security/CWE-601/BadRedirectCheck.ql
+++ b/ql/src/Security/CWE-601/BadRedirectCheck.ql
@@ -46,9 +46,9 @@ predicate isCheckedForSecondSlash(SsaWithFields v) {
  */
 predicate isCleaned(DataFlow::Node nd) {
   exists(Function clean | clean.hasQualifiedName("path", "Clean") |
-    nd = clean.getACall()
+    nd = clean.getACallIncludingExternals()
     or
-    nd = clean.getACall().getArgument(0)
+    nd = clean.getACallIncludingExternals().getArgument(0)
   )
   or
   isCleaned(nd.getAPredecessor())

--- a/ql/src/experimental/CWE-090/LDAPInjection.qll
+++ b/ql/src/experimental/CWE-090/LDAPInjection.qll
@@ -32,7 +32,7 @@ private class EscapeFilterCall extends LdapSanitizer {
           "gopkg.in/ldap.v3"
         ], "EscapeFilter")
     |
-      this = f.getACall()
+      this = f.getACallIncludingExternals()
     )
   }
 }
@@ -53,7 +53,7 @@ private class GoLdapSink extends LdapSink {
           "gopkg.in/ldap.v3"
         ], "NewSearchRequest")
     |
-      this = f.getACall().getArgument([0, 6, 7])
+      this = f.getACallIncludingExternals().getArgument([0, 6, 7])
     )
   }
 }
@@ -79,7 +79,7 @@ private class LdapClientSink extends LdapSink {
       m.hasQualifiedName("github.com/jtblin/go-ldap-client", "LDAPClient",
         ["Authenticate", "GetGroupsOfUser"])
     |
-      this = m.getACall().getArgument(0)
+      this = m.getACallIncludingExternals().getArgument(0)
     )
   }
 }

--- a/ql/src/experimental/CWE-369/DivideByZero.ql
+++ b/ql/src/experimental/CWE-369/DivideByZero.ql
@@ -43,7 +43,7 @@ class DivideByZeroCheckConfig extends TaintTracking::Configuration {
   override predicate isSource(DataFlow::Node source) { source instanceof UntrustedFlowSource }
 
   override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(Function f, DataFlow::CallNode cn | cn = f.getACall() |
+    exists(Function f, DataFlow::CallNode cn | cn = f.getACallIncludingExternals() |
       f.hasQualifiedName("strconv", ["Atoi", "ParseInt", "ParseUint", "ParseFloat"]) and
       pred = cn.getArgument(0) and
       succ = cn.getResult(0)

--- a/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -120,7 +120,7 @@ class FlowConfPassthroughTypeConversionToTemplateExecutionCall extends TaintTrac
 predicate isSinkToTemplateExec(DataFlow::Node sink, DataFlow::CallNode call) {
   exists(Method fn, string methodName |
     fn.hasQualifiedName("html/template", "Template", methodName) and
-    call = fn.getACall()
+    call = fn.getACallIncludingExternals()
   |
     methodName = "Execute" and sink = call.getArgument(1)
     or

--- a/ql/src/experimental/CWE-918/validator.qll
+++ b/ql/src/experimental/CWE-918/validator.qll
@@ -106,7 +106,7 @@ private class StructValidationFunction extends DataFlow::BarrierGuard, DataFlow:
             .hasQualifiedName("github.com/go-playground/validator", "Validate", "Struct") and
         validationKindKey = "validate"
       ) and
-      bindCall = bindFunction.getACall() and
+      bindCall = bindFunction.getACallIncludingExternals() and
       checked = dereference(bindCall.getAnArgument()) and
       resultErr = bindCall.getResult().getASuccessor*() and
       nilProperty().checkOn(this, safeOutcome, resultErr)
@@ -145,7 +145,7 @@ class ValidatorVarCheck extends DataFlow::BarrierGuard, DataFlow::EqualityTestNo
   ValidatorVarCheck() {
     exists(Method validatorMethod, DataFlow::Node resultErr |
       validatorMethod.hasQualifiedName("github.com/go-playground/validator", "Validate", "Var") and
-      callToValidator = validatorMethod.getACall() and
+      callToValidator = validatorMethod.getACallIncludingExternals() and
       isAlphanumericValidationKind(callToValidator.getArgument(1).getStringValue()) and
       resultErr = callToValidator.getResult().getASuccessor*() and
       nilProperty().checkOn(this, outcome, resultErr)

--- a/ql/src/experimental/frameworks/CleverGo.qll
+++ b/ql/src/experimental/frameworks/CleverGo.qll
@@ -20,7 +20,7 @@ private module CleverGo {
     UntrustedSources() {
       // Methods on types of package: clevergo.tech/clevergo@v0.5.2
       exists(string receiverName, string methodName, Method mtd, FunctionOutput out |
-        this = out.getExitNode(mtd.getACall()) and
+        this = out.getExitNode(mtd.getACallIncludingExternals()) and
         mtd.hasQualifiedName(packagePath(), receiverName, methodName)
       |
         receiverName = "Context" and
@@ -72,7 +72,7 @@ private module CleverGo {
       or
       // Interfaces of package: clevergo.tech/clevergo@v0.5.2
       exists(string interfaceName, string methodName, Method mtd, FunctionOutput out |
-        this = out.getExitNode(mtd.getACall()) and
+        this = out.getExitNode(mtd.getACallIncludingExternals()) and
         mtd.implements(packagePath(), interfaceName, methodName)
       |
         interfaceName = "Decoder" and
@@ -184,7 +184,9 @@ private module CleverGo {
       // Receiver type: Context
       (
         // signature: func (*Context) Redirect(code int, url string) error
-        this = any(Method m | m.hasQualifiedName(package, "Context", "Redirect")).getACall() and
+        this =
+          any(Method m | m.hasQualifiedName(package, "Context", "Redirect"))
+              .getACallIncludingExternals() and
         urlNode = this.getArgument(1)
       )
     }
@@ -219,7 +221,7 @@ private module CleverGo {
   ) {
     exists(string methodName, Method met, DataFlow::CallNode bodySetterCall |
       met.hasQualifiedName(package, receiverName, methodName) and
-      bodySetterCall = met.getACall() and
+      bodySetterCall = met.getACallIncludingExternals() and
       receiverNode = bodySetterCall.getReceiver()
     |
       package = packagePath() and
@@ -327,7 +329,7 @@ private module CleverGo {
   ) {
     exists(string methodName, Method met, DataFlow::CallNode bodySetterCall |
       met.hasQualifiedName(package, receiverName, methodName) and
-      bodySetterCall = met.getACall() and
+      bodySetterCall = met.getACallIncludingExternals() and
       receiverNode = bodySetterCall.getReceiver()
     |
       package = packagePath() and
@@ -370,7 +372,7 @@ private module CleverGo {
   ) {
     exists(string methodName, Method met, DataFlow::CallNode bodySetterCall |
       met.hasQualifiedName(package, receiverName, methodName) and
-      bodySetterCall = met.getACall() and
+      bodySetterCall = met.getACallIncludingExternals() and
       receiverNode = bodySetterCall.getReceiver()
     |
       package = packagePath() and
@@ -417,7 +419,7 @@ private module CleverGo {
   ) {
     exists(string methodName, Method met |
       met.hasQualifiedName(package, receiverName, methodName) and
-      headerSetterCall = met.getACall() and
+      headerSetterCall = met.getACallIncludingExternals() and
       receiverNode = headerSetterCall.getReceiver()
     |
       package = packagePath() and
@@ -463,7 +465,7 @@ private module CleverGo {
   ) {
     exists(string methodName, Method met |
       met.hasQualifiedName(package, receiverName, methodName) and
-      setterCall = met.getACall() and
+      setterCall = met.getACallIncludingExternals() and
       receiverNode = setterCall.getReceiver()
     |
       package = packagePath() and
@@ -518,7 +520,7 @@ private module CleverGo {
   ) {
     exists(string methodName, Method met |
       met.hasQualifiedName(package, receiverName, methodName) and
-      setterCall = met.getACall() and
+      setterCall = met.getACallIncludingExternals() and
       receiverNode = setterCall.getReceiver()
     |
       package = packagePath() and

--- a/ql/src/experimental/frameworks/Fiber.qll
+++ b/ql/src/experimental/frameworks/Fiber.qll
@@ -139,7 +139,9 @@ private module Fiber {
       // Receiver type: Ctx
       (
         // signature: func (*Ctx) Redirect(location string, status ...int)
-        this = any(Method m | m.hasQualifiedName(package, "Ctx", "Redirect")).getACall() and
+        this =
+          any(Method m | m.hasQualifiedName(package, "Ctx", "Redirect"))
+              .getACallIncludingExternals() and
         urlNode = this.getArgument(0)
       )
     }
@@ -176,7 +178,7 @@ private module Fiber {
   ) {
     exists(string methodName, Method met |
       met.hasQualifiedName(package, receiverName, methodName) and
-      headerSetterCall = met.getACall() and
+      headerSetterCall = met.getACallIncludingExternals() and
       receiverNode = headerSetterCall.getReceiver()
     |
       package = fiberPackagePath() and
@@ -223,7 +225,7 @@ private module Fiber {
   ) {
     exists(string methodName, Method met, DataFlow::CallNode bodySetterCall |
       met.hasQualifiedName(package, receiverName, methodName) and
-      bodySetterCall = met.getACall() and
+      bodySetterCall = met.getACallIncludingExternals() and
       receiverNode = bodySetterCall.getReceiver()
     |
       package = fiberPackagePath() and
@@ -266,7 +268,7 @@ private module Fiber {
   ) {
     exists(string methodName, Method met, DataFlow::CallNode bodySetterCall |
       met.hasQualifiedName(package, receiverName, methodName) and
-      bodySetterCall = met.getACall() and
+      bodySetterCall = met.getACallIncludingExternals() and
       receiverNode = bodySetterCall.getReceiver()
     |
       package = fiberPackagePath() and
@@ -309,7 +311,7 @@ private module Fiber {
     UntrustedFlowSources() {
       // Methods on types of package: github.com/gofiber/fiber@v1.14.6
       exists(string receiverName, string methodName, Method mtd, FunctionOutput out |
-        this = out.getExitNode(mtd.getACall()) and
+        this = out.getExitNode(mtd.getACallIncludingExternals()) and
         mtd.hasQualifiedName(fiberPackagePath(), receiverName, methodName)
       |
         receiverName = "Ctx" and

--- a/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/ql/test/TestUtilities/InlineFlowTest.qll
@@ -43,7 +43,7 @@ import TestUtilities.InlineExpectationsTest
 
 private predicate defaultSource(DataFlow::Node source) {
   exists(Function fn | fn.hasQualifiedName(_, ["source", "taint"]) |
-    source = fn.getACall().getResult()
+    source = fn.getACallIncludingExternals().getResult()
   )
 }
 
@@ -53,7 +53,9 @@ class DefaultValueFlowConf extends DataFlow::Configuration {
   override predicate isSource(DataFlow::Node source) { defaultSource(source) }
 
   override predicate isSink(DataFlow::Node sink) {
-    exists(Function fn | fn.hasQualifiedName(_, "sink") | sink = fn.getACall().getAnArgument())
+    exists(Function fn | fn.hasQualifiedName(_, "sink") |
+      sink = fn.getACallIncludingExternals().getAnArgument()
+    )
   }
 
   override int fieldFlowBranchLimit() { result = 1000 }
@@ -65,7 +67,9 @@ class DefaultTaintFlowConf extends TaintTracking::Configuration {
   override predicate isSource(DataFlow::Node source) { defaultSource(source) }
 
   override predicate isSink(DataFlow::Node sink) {
-    exists(Function fn | fn.hasQualifiedName(_, "sink") | sink = fn.getACall().getAnArgument())
+    exists(Function fn | fn.hasQualifiedName(_, "sink") |
+      sink = fn.getACallIncludingExternals().getAnArgument()
+    )
   }
 
   override int fieldFlowBranchLimit() { result = 1000 }

--- a/ql/test/experimental/frameworks/CleverGo/TaintTracking.ql
+++ b/ql/test/experimental/frameworks/CleverGo/TaintTracking.ql
@@ -6,11 +6,15 @@ class Configuration extends TaintTracking::Configuration {
   Configuration() { this = "test-configuration" }
 
   override predicate isSource(DataFlow::Node source) {
-    exists(Function fn | fn.hasQualifiedName(_, "source") | source = fn.getACall().getResult())
+    exists(Function fn | fn.hasQualifiedName(_, "source") |
+      source = fn.getACallIncludingExternals().getResult()
+    )
   }
 
   override predicate isSink(DataFlow::Node sink) {
-    exists(Function fn | fn.hasQualifiedName(_, "sink") | sink = fn.getACall().getAnArgument())
+    exists(Function fn | fn.hasQualifiedName(_, "sink") |
+      sink = fn.getACallIncludingExternals().getAnArgument()
+    )
   }
 }
 

--- a/ql/test/experimental/frameworks/Fiber/TaintTracking.ql
+++ b/ql/test/experimental/frameworks/Fiber/TaintTracking.ql
@@ -6,11 +6,15 @@ class Configuration extends TaintTracking::Configuration {
   Configuration() { this = "test-configuration" }
 
   override predicate isSource(DataFlow::Node source) {
-    exists(Function fn | fn.hasQualifiedName(_, "source") | source = fn.getACall().getResult())
+    exists(Function fn | fn.hasQualifiedName(_, "source") |
+      source = fn.getACallIncludingExternals().getResult()
+    )
   }
 
   override predicate isSink(DataFlow::Node sink) {
-    exists(Function fn | fn.hasQualifiedName(_, "sink") | sink = fn.getACall().getAnArgument())
+    exists(Function fn | fn.hasQualifiedName(_, "sink") |
+      sink = fn.getACallIncludingExternals().getAnArgument()
+    )
   }
 }
 

--- a/ql/test/library-tests/semmle/go/concepts/Regexp/RegexpMatchFunction.ql
+++ b/ql/test/library-tests/semmle/go/concepts/Regexp/RegexpMatchFunction.ql
@@ -1,5 +1,5 @@
 import go
 
 from RegexpMatchFunction match, DataFlow::CallNode call
-where call = match.getACall()
+where call = match.getACallIncludingExternals()
 select match, match.getRegexp(call), match.getValue().getNode(call), match.getResult().getNode(call)

--- a/ql/test/library-tests/semmle/go/concepts/Regexp/RegexpReplaceFunction.ql
+++ b/ql/test/library-tests/semmle/go/concepts/Regexp/RegexpReplaceFunction.ql
@@ -1,5 +1,5 @@
 import go
 
 from RegexpReplaceFunction rrfc, DataFlow::CallNode call
-where call = rrfc.getACall()
+where call = rrfc.getACallIncludingExternals()
 select rrfc, rrfc.getRegexp(call), rrfc.getSource().getNode(call), rrfc.getResult().getNode(call)

--- a/ql/test/library-tests/semmle/go/dataflow/CallGraph/getACall.ql
+++ b/ql/test/library-tests/semmle/go/dataflow/CallGraph/getACall.ql
@@ -2,10 +2,10 @@ import go
 
 query predicate missingCall(DeclaredFunction f, DataFlow::CallNode call) {
   call.getACallee() = f.getFuncDecl() and
-  not call = f.getACall()
+  not call = f.getACallIncludingExternals()
 }
 
 query predicate spuriousCall(DeclaredFunction f, DataFlow::CallNode call) {
-  call = f.getACall() and
+  call = f.getACallIncludingExternals() and
   exists(FuncDecl fd | fd = f.getFuncDecl() | not call.getACallee() = fd)
 }

--- a/ql/test/library-tests/semmle/go/dataflow/PromotedFields/DataFlowConfig.ql
+++ b/ql/test/library-tests/semmle/go/dataflow/PromotedFields/DataFlowConfig.ql
@@ -13,11 +13,11 @@ class TestConfig extends DataFlow::Configuration {
   TestConfig() { this = "testconfig" }
 
   override predicate isSource(DataFlow::Node source) {
-    source = any(SourceFunction f).getACall().getAResult()
+    source = any(SourceFunction f).getACallIncludingExternals().getAResult()
   }
 
   override predicate isSink(DataFlow::Node sink) {
-    sink = any(SinkFunction f).getACall().getAnArgument()
+    sink = any(SinkFunction f).getACallIncludingExternals().getAnArgument()
   }
 }
 

--- a/ql/test/library-tests/semmle/go/dataflow/PromotedMethods/DataFlowConfig.ql
+++ b/ql/test/library-tests/semmle/go/dataflow/PromotedMethods/DataFlowConfig.ql
@@ -13,11 +13,11 @@ class TestConfig extends DataFlow::Configuration {
   TestConfig() { this = "testconfig" }
 
   override predicate isSource(DataFlow::Node source) {
-    source = any(SourceFunction f).getACall().getAResult()
+    source = any(SourceFunction f).getACallIncludingExternals().getAResult()
   }
 
   override predicate isSink(DataFlow::Node sink) {
-    sink = any(SinkFunction f).getACall().getAnArgument()
+    sink = any(SinkFunction f).getACallIncludingExternals().getAnArgument()
   }
 }
 

--- a/ql/test/library-tests/semmle/go/frameworks/Encoding/jsoniter.ql
+++ b/ql/test/library-tests/semmle/go/frameworks/Encoding/jsoniter.ql
@@ -6,7 +6,7 @@ class UntrustedFunction extends Function {
 }
 
 class UntrustedSource extends DataFlow::Node, UntrustedFlowSource::Range {
-  UntrustedSource() { this = any(UntrustedFunction f).getACall() }
+  UntrustedSource() { this = any(UntrustedFunction f).getACallIncludingExternals() }
 }
 
 from CommandInjection::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink

--- a/ql/test/library-tests/semmle/go/frameworks/K8sIoApiCoreV1/TaintFlowsInline.ql
+++ b/ql/test/library-tests/semmle/go/frameworks/K8sIoApiCoreV1/TaintFlowsInline.ql
@@ -13,11 +13,11 @@ class TestConfig extends TaintTracking::Configuration {
   TestConfig() { this = "testconfig" }
 
   override predicate isSource(DataFlow::Node source) {
-    source = any(SourceFunction f).getACall().getResult(0)
+    source = any(SourceFunction f).getACallIncludingExternals().getResult(0)
   }
 
   override predicate isSink(DataFlow::Node sink) {
-    sink = any(SinkFunction f).getACall().getArgument(0)
+    sink = any(SinkFunction f).getACallIncludingExternals().getArgument(0)
   }
 }
 

--- a/ql/test/library-tests/semmle/go/frameworks/K8sIoApimachineryPkgRuntime/TaintFlowsInline.ql
+++ b/ql/test/library-tests/semmle/go/frameworks/K8sIoApimachineryPkgRuntime/TaintFlowsInline.ql
@@ -13,11 +13,11 @@ class TestConfig extends TaintTracking::Configuration {
   TestConfig() { this = "testconfig" }
 
   override predicate isSource(DataFlow::Node source) {
-    source = any(SourceFunction f).getACall().getAResult()
+    source = any(SourceFunction f).getACallIncludingExternals().getAResult()
   }
 
   override predicate isSink(DataFlow::Node sink) {
-    sink = any(SinkFunction f).getACall().getAnArgument()
+    sink = any(SinkFunction f).getACallIncludingExternals().getAnArgument()
   }
 }
 

--- a/ql/test/library-tests/semmle/go/frameworks/Protobuf/TaintFlows.ql
+++ b/ql/test/library-tests/semmle/go/frameworks/Protobuf/TaintFlows.ql
@@ -5,7 +5,7 @@ class UntrustedFunction extends Function {
 }
 
 class UntrustedSource extends DataFlow::Node, UntrustedFlowSource::Range {
-  UntrustedSource() { this = any(UntrustedFunction f).getACall() }
+  UntrustedSource() { this = any(UntrustedFunction f).getACallIncludingExternals() }
 }
 
 class SinkFunction extends Function {
@@ -18,7 +18,7 @@ class TestConfig extends TaintTracking::Configuration {
   override predicate isSource(DataFlow::Node source) { source instanceof UntrustedFlowSource }
 
   override predicate isSink(DataFlow::Node sink) {
-    sink = any(SinkFunction f).getACall().getAnArgument()
+    sink = any(SinkFunction f).getACallIncludingExternals().getAnArgument()
   }
 }
 

--- a/ql/test/library-tests/semmle/go/frameworks/SQL/Gorm/gorm.ql
+++ b/ql/test/library-tests/semmle/go/frameworks/SQL/Gorm/gorm.ql
@@ -1,5 +1,5 @@
 import go
 
 from SQL::QueryString qs, Method meth, string a, string b, string c
-where meth.hasQualifiedName(a, b, c) and qs = meth.getACall().getArgument(0)
+where meth.hasQualifiedName(a, b, c) and qs = meth.getACallIncludingExternals().getArgument(0)
 select qs, a, b, c

--- a/ql/test/library-tests/semmle/go/frameworks/Spew/TaintFlows.ql
+++ b/ql/test/library-tests/semmle/go/frameworks/Spew/TaintFlows.ql
@@ -5,7 +5,7 @@ class UntrustedFunction extends Function {
 }
 
 class UntrustedSource extends DataFlow::Node, UntrustedFlowSource::Range {
-  UntrustedSource() { this = any(UntrustedFunction f).getACall() }
+  UntrustedSource() { this = any(UntrustedFunction f).getACallIncludingExternals() }
 }
 
 class SinkFunction extends Function {
@@ -18,7 +18,7 @@ class TestConfig extends TaintTracking::Configuration {
   override predicate isSource(DataFlow::Node source) { source instanceof UntrustedFlowSource }
 
   override predicate isSink(DataFlow::Node sink) {
-    sink = any(SinkFunction f).getACall().getAnArgument() or
+    sink = any(SinkFunction f).getACallIncludingExternals().getAnArgument() or
     sink = any(LoggerCall log).getAMessageComponent()
   }
 }

--- a/ql/test/library-tests/semmle/go/frameworks/StdlibTaintFlow/StdlibTaintFlow.ql
+++ b/ql/test/library-tests/semmle/go/frameworks/StdlibTaintFlow/StdlibTaintFlow.ql
@@ -15,13 +15,13 @@ class Link extends TaintTracking::FunctionModel {
 
 predicate isSource(DataFlow::Node source, DataFlow::CallNode call) {
   exists(Function fn | fn.hasQualifiedName(_, "newSource") |
-    call = fn.getACall() and source = call.getResult()
+    call = fn.getACallIncludingExternals() and source = call.getResult()
   )
 }
 
 predicate isSink(DataFlow::Node sink, DataFlow::CallNode call) {
   exists(Function fn | fn.hasQualifiedName(_, "sink") |
-    call = fn.getACall() and sink = call.getArgument(1)
+    call = fn.getACallIncludingExternals() and sink = call.getArgument(1)
   )
 }
 

--- a/ql/test/library-tests/semmle/go/frameworks/WebSocket/Read.ql
+++ b/ql/test/library-tests/semmle/go/frameworks/WebSocket/Read.ql
@@ -2,5 +2,5 @@ import go
 import semmle.go.frameworks.WebSocket
 
 from WebSocketReader r, DataFlow::Node nd
-where nd = r.getAnOutput().getNode(r.getACall())
+where nd = r.getAnOutput().getNode(r.getACallIncludingExternals())
 select nd

--- a/ql/test/library-tests/semmle/go/frameworks/Yaml/tests.ql
+++ b/ql/test/library-tests/semmle/go/frameworks/Yaml/tests.ql
@@ -8,7 +8,9 @@ class TaintFunctionModelTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(string file, int line, string element, string tag, string value) {
     tag = "ttfnmodelstep" and
-    exists(TaintTracking::FunctionModel model, DataFlow::CallNode call | call = model.getACall() |
+    exists(TaintTracking::FunctionModel model, DataFlow::CallNode call |
+      call = model.getACallIncludingExternals()
+    |
       call.hasLocationInfo(file, line, _, _, _) and
       element = call.toString() and
       value = "\"" + model.getAnInputNode(call) + " -> " + model.getAnOutputNode(call) + "\""
@@ -23,7 +25,7 @@ class MarshalerTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(string file, int line, string element, string tag, string value) {
     tag = "marshaler" and
-    exists(MarshalingFunction m, DataFlow::CallNode call | call = m.getACall() |
+    exists(MarshalingFunction m, DataFlow::CallNode call | call = m.getACallIncludingExternals() |
       call.hasLocationInfo(file, line, _, _, _) and
       element = call.toString() and
       value =
@@ -40,7 +42,7 @@ class UnmarshalerTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(string file, int line, string element, string tag, string value) {
     tag = "unmarshaler" and
-    exists(UnmarshalingFunction m, DataFlow::CallNode call | call = m.getACall() |
+    exists(UnmarshalingFunction m, DataFlow::CallNode call | call = m.getACallIncludingExternals() |
       call.hasLocationInfo(file, line, _, _, _) and
       element = call.toString() and
       value =


### PR DESCRIPTION
This was accidentally changed in https://github.com/github/codeql-go/pull/574 .