### PR TITLE
Revert change to Function.getACall() (hotfix)

### DIFF
--- a/ql/lib/semmle/go/Scopes.qll
+++ b/ql/lib/semmle/go/Scopes.qll
@@ -366,12 +366,18 @@ class PromotedField extends Field {
 
 /** A built-in or declared function. */
 class Function extends ValueEntity, @functionobject {
-  /** Gets a call to this function. */
+  /**
+   * Gets a call to this function, excluding some calls to external functions.
+   *
+   * This excludes calls that target this function indirectly (by calling an
+   * interface method that this function implements) if this is an external
+   * function (for example, a standard library function).
+   */
   pragma[nomagic]
   DataFlow::CallNode getACall() {
     this = result.getTarget()
     or
-    this = result.getACalleeIncludingExternals().asFunction()
+    this.getFuncDecl() = result.getACallee()
   }
 
   /** Gets the declaration of this function, if any. */


### PR DESCRIPTION
This change was introduced accidentally in [this PR](https://github.com/github/codeql-go/pull/574/files#diff-763b83e1ba302fd6806d680b6796829b3e058712782ca207bfc46749ee54d3fdR374).