### PR TITLE
Update `Function.getACall()`

### DIFF
--- a/ql/lib/semmle/go/Scopes.qll
+++ b/ql/lib/semmle/go/Scopes.qll
@@ -366,11 +366,18 @@ class PromotedField extends Field {
 
 /** A built-in or declared function. */
 class Function extends ValueEntity, @functionobject {
-  /** Gets a call to this function. */
+  /**
+   * Gets a call to this function.
+   *
+   * This includes calls that target this function indirectly, by calling an
+   * interface method that this function implements.
+   */
   pragma[nomagic]
   DataFlow::CallNode getACall() {
+    // Direct calls to this function
     this = result.getTarget()
     or
+    // Direct calls and calls to interface methods that this function implements
     this = result.getACalleeIncludingExternals().asFunction()
   }
 

--- a/ql/lib/semmle/go/Scopes.qll
+++ b/ql/lib/semmle/go/Scopes.qll
@@ -373,13 +373,7 @@ class Function extends ValueEntity, @functionobject {
    * interface method that this function implements.
    */
   pragma[nomagic]
-  DataFlow::CallNode getACall() {
-    // Direct calls to this function
-    this = result.getTarget()
-    or
-    // Direct calls and calls to interface methods that this function implements
-    this = result.getACalleeIncludingExternals().asFunction()
-  }
+  DataFlow::CallNode getACall() { this = result.getACalleeIncludingExternals().asFunction() }
 
   /** Gets the declaration of this function, if any. */
   FuncDecl getFuncDecl() { none() }

--- a/ql/lib/semmle/go/security/ExternalAPIs.qll
+++ b/ql/lib/semmle/go/security/ExternalAPIs.qll
@@ -74,7 +74,7 @@ class ExternalAPIDataNode extends DataFlow::Node {
     // Not already modeled as a taint step
     not exists(DataFlow::Node next | TaintTracking::localTaintStep(this, next)) and
     // Not a call to a known safe external API
-    not call = any(SafeExternalAPIFunction f).getACall()
+    not call.getTarget() instanceof SafeExternalAPIFunction
   }
 
   /** Gets the called API `Function`. */

--- a/ql/lib/semmle/go/security/InsecureRandomnessCustomizations.qll
+++ b/ql/lib/semmle/go/security/InsecureRandomnessCustomizations.qll
@@ -60,7 +60,7 @@ module InsecureRandomness {
         // Some interfaces in the `crypto` package are the same as interfaces
         // elsewhere, e.g. tls.listener is the same as net.Listener
         not fn.hasQualifiedName(nonCryptoInterface(), _) and
-        this = fn.getACall().getAnArgument()
+        exists(DataFlow::CallNode call | call.getTarget() = fn and this = call.getAnArgument())
       )
     }
 


### PR DESCRIPTION
Improve documentation to make it clear that it includes indirect calls through interface methods, and do not use it in two places where we only want direct calls.