### PR TITLE
Don't use codeql pack install --verify

### DIFF
--- a/.github/workflows/codeqltest.yml
+++ b/.github/workflows/codeqltest.yml
@@ -98,8 +98,6 @@ jobs:
   test-win:
     name: Test Windows
     runs-on: windows-latest
-    env:
-      CODEQL_LOCK_MODE: verify
     steps:
     - name: Set up Go 1.17
       uses: actions/setup-go@v1


### PR DESCRIPTION
This shouldn't fail, but currently does due to a bug and is unnecessary in any case.