### PR TITLE
Refactor `ReturnValue[n]` in data flow libraries

### DIFF
--- a/ql/lib/semmle/go/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ql/lib/semmle/go/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -95,6 +95,12 @@ private string getContentSpecificCsv(Content c) {
 /** Gets the textual representation of the content in the format used for flow summaries. */
 string getComponentSpecificCsv(SummaryComponent sc) {
   exists(Content c | sc = TContentSummaryComponent(c) and result = getContentSpecificCsv(c))
+  or
+  exists(ReturnKind rk, int n | n = rk.getIndex() |
+    sc = TReturnSummaryComponent(rk) and
+    result = "ReturnValue[" + n + "]" and
+    n != 0
+  )
 }
 
 /** Holds if input specification component `c` needs a reference. */


### PR DESCRIPTION
The way that `ReturnValue[n]` was supported in https://github.com/github/codeql-go/pull/574 involved editing some files that will be overwritten when the data flow libraries are next synced. We move this code from `FlowSummaryImpl.qll` into `FlowSummaryImplSpecific.qll` to avoid this problem.

We also add special treatment of `ReturnValue[n]` in one place where it was missing.