### PR TITLE
use more set literals

### DIFF
--- a/ql/lib/semmle/go/frameworks/SystemCommandExecutors.qll
+++ b/ql/lib/semmle/go/frameworks/SystemCommandExecutors.qll
@@ -38,7 +38,7 @@ private class SystemCommandExecutors extends SystemCommandExecution::Range, Data
       // NOTE: syscall.ForkExec exists only on unix.
       // NOTE: syscall.CreateProcess and syscall.CreateProcessAsUser exist only on windows.
       pkg = "syscall" and
-      (name = "Exec" or name = "ForkExec" or name = "StartProcess" or name = "CreateProcess") and
+      name = ["Exec", "ForkExec", "StartProcess", "CreateProcess"] and
       cmdArg = 0
       or
       pkg = "syscall" and
@@ -93,13 +93,7 @@ module CryptoSsh {
     SshCommandExecution() {
       // Catch method calls on the `Session` object:
       exists(Method method, string methodName |
-        methodName = "CombinedOutput"
-        or
-        methodName = "Output"
-        or
-        methodName = "Run"
-        or
-        methodName = "Start"
+        methodName = ["CombinedOutput", "Output", "Run", "Start"]
       |
         method.hasQualifiedName(packagePath(), "Session", methodName) and
         this = method.getACall()
@@ -217,9 +211,7 @@ private predicate isProgrammingLanguageCli(DataFlow::Node node) {
   )
 }
 
-private string getASshCommand() {
-  result = "ssh" or result = "ssh-argv0" or result = "putty.exe" or result = "kitty.exe"
-}
+private string getASshCommand() { result = ["ssh", "ssh-argv0", "putty.exe", "kitty.exe"] }
 
 /**
  * A data-flow node whose string value might refer to an SSH client or similar, whose arguments can be

--- a/ql/lib/semmle/go/security/OpenUrlRedirectCustomizations.qll
+++ b/ql/lib/semmle/go/security/OpenUrlRedirectCustomizations.qll
@@ -126,7 +126,7 @@ private class SafeUrlSink extends SafeUrlFlow::Sink {
 private class UnsafeFieldReadSanitizer extends SafeUrlFlow::SanitizerEdge {
   UnsafeFieldReadSanitizer() {
     exists(DataFlow::FieldReadNode frn, string name |
-      (name = "User" or name = "RawQuery" or name = "Fragment" or name = "User") and
+      name = ["User", "RawQuery", "Fragment", "User"] and
       frn.getField().hasQualifiedName("net/url", "URL")
     |
       this = frn.getBase()

--- a/ql/lib/semmle/go/security/SensitiveActions.qll
+++ b/ql/lib/semmle/go/security/SensitiveActions.qll
@@ -85,7 +85,7 @@ module SensitiveExpr {
    * Instead, use the predicates below to work with classifications.
    */
   class Classification extends string {
-    Classification() { this = "secret" or this = "id" or this = "password" or this = "certificate" }
+    Classification() { this = ["secret", "id", "password", "certificate"] }
   }
 
   /** Gets the classification for secret or trusted data. */

--- a/ql/src/InconsistentCode/LengthComparisonOffByOne.ql
+++ b/ql/src/InconsistentCode/LengthComparisonOffByOne.ql
@@ -29,7 +29,7 @@ class Index extends TIndex {
 DataFlow::Node getAUse(Index i) {
   i = VariableIndex(any(DataFlow::SsaNode v | result = v.getAUse()))
   or
-  i = ConstantIndex(any(int v | v = result.getIntValue()))
+  i = ConstantIndex(result.getIntValue())
 }
 
 /**

--- a/ql/src/experimental/CWE-327/CryptoLibraries.qll
+++ b/ql/src/experimental/CWE-327/CryptoLibraries.qll
@@ -48,10 +48,7 @@ private module AlgorithmNames {
   }
 
   predicate isStrongPasswordHashingAlgorithm(string name) {
-    name = "ARGON2" or
-    name = "PBKDF2" or
-    name = "BCRYPT" or
-    name = "SCRYPT"
+    name = ["ARGON2", "PBKDF2", "BCRYPT", "SCRYPT"]
   }
 
   predicate isWeakPasswordHashingAlgorithm(string name) { none() }


### PR DESCRIPTION
and simplify an `any(..)` that was redundant.  

I've been patching `github/codeql` again, and I thought that you guys shouldn't miss out.  