### PR TITLE
Add an example query for inexhaustive switches

### DIFF
--- a/ql/examples/snippets/incompleteswitchoverenum.ql
+++ b/ql/examples/snippets/incompleteswitchoverenum.ql
@@ -1,0 +1,17 @@
+/**
+ * @name Incomplete switch over enum
+ * @description A switch statement of enum type should explicitly reference each
+ *   of the members of that enum.
+ * @kind problem
+ * @id go/examples/incomplete-switch
+ */
+
+import go
+
+from ExpressionSwitchStmt ss, DeclaredConstant c, NamedType t
+where
+  t.getUnderlyingType() instanceof IntegerType and
+  t = ss.getExpr().getType() and
+  c.getType() = t and
+  forall(CaseClause case | case = ss.getACase() | not case = c.getAReference().getParent())
+select ss, "This switch statement is not exhaustive: missing $@", c, c.getName()


### PR DESCRIPTION
I worked on this for an internal query but it ended up being covered by a linter rule. However, it's simple enough that it might make an interesting example.