### PR TITLE
Add Column, From, JoinClause, *Join, Having, OrderByClause methods for squirrel SQLi query

### DIFF
--- a/ql/lib/semmle/go/frameworks/SQL.qll
+++ b/ql/lib/semmle/go/frameworks/SQL.qll
@@ -88,14 +88,14 @@ module SQL {
             // first argument to `squirrel.Expr`
             fn.hasQualifiedName(sq, "Expr")
             or
-            // first argument to the `Prefix`, `Suffix` or `Where` method of one of the `*Builder` classes
+            // first argument `pred`, `sql`, `from` to most methods of one of the `*Builder` classes
             exists(string builder | builder.matches("%Builder") |
-              fn.(Method).hasQualifiedName(sq, builder, "Prefix") or
-              fn.(Method).hasQualifiedName(sq, builder, "Suffix") or
-              fn.(Method).hasQualifiedName(sq, builder, "Where") or
-              fn.(Method).hasQualifiedName(sq, builder, "Having") or
-              fn.(Method).hasQualifiedName(sq, builder, "JoinClause") or
-              fn.(Method).hasQualifiedName(sq, builder, "OrderByClause")
+              fn.(Method)
+                  .hasQualifiedName(sq, builder,
+                    [
+                      "Prefix", "Column", "From", "JoinClause", "Join", "LeftJoin", "RightJoin",
+                      "InnerJoin", "CrossJoin", "Where", "Having", "OrderByClause", "Suffix"
+                    ])
             )
           ) and
           this = fn.getACall().getArgument(0) and

--- a/ql/lib/semmle/go/frameworks/SQL.qll
+++ b/ql/lib/semmle/go/frameworks/SQL.qll
@@ -92,7 +92,10 @@ module SQL {
             exists(string builder | builder.matches("%Builder") |
               fn.(Method).hasQualifiedName(sq, builder, "Prefix") or
               fn.(Method).hasQualifiedName(sq, builder, "Suffix") or
-              fn.(Method).hasQualifiedName(sq, builder, "Where")
+              fn.(Method).hasQualifiedName(sq, builder, "Where") or
+              fn.(Method).hasQualifiedName(sq, builder, "Having") or
+              fn.(Method).hasQualifiedName(sq, builder, "JoinClause") or
+              fn.(Method).hasQualifiedName(sq, builder, "OrderByClause")
             )
           ) and
           this = fn.getACall().getArgument(0) and

--- a/ql/test/library-tests/semmle/go/frameworks/SQL/go.mod
+++ b/ql/test/library-tests/semmle/go/frameworks/SQL/go.mod
@@ -3,7 +3,7 @@ module semmle.go.frameworks.SQL
 go 1.13
 
 require (
-	github.com/Masterminds/squirrel v1.1.0
+	github.com/Masterminds/squirrel v1.5.2
 	github.com/go-pg/pg v8.0.6+incompatible
 	github.com/go-pg/pg/v9 v9.1.3
 	github.com/go-sql-driver/mysql v1.6.0 // indirect

--- a/ql/test/library-tests/semmle/go/frameworks/SQL/main.go
+++ b/ql/test/library-tests/semmle/go/frameworks/SQL/main.go
@@ -43,10 +43,17 @@ func test(db *sql.DB, ctx context.Context) {
 }
 
 func squirrelTest(querypart string) {
+	squirrel.Select("*").From("users").Prefix(querypart)               // $ querystring=querypart
+	squirrel.Select("*").From("users").Column(querypart)               // $ querystring=querypart
+	squirrel.Select("*").From("users").From(querypart)                 // $ querystring=querypart
+	squirrel.Select("*").From("users").JoinClause(querypart)           // $ querystring=querypart
+	squirrel.Select("*").From("users").Join(querypart)                 // $ querystring=querypart
+	squirrel.Select("*").From("users").LeftJoin(querypart)             // $ querystring=querypart
+	squirrel.Select("*").From("users").RightJoin(querypart)            // $ querystring=querypart
+	squirrel.Select("*").From("users").InnerJoin(querypart)            // $ querystring=querypart
 	squirrel.Select("*").From("users").Where(squirrel.Expr(querypart)) // $ querystring=querypart
 	squirrel.Select("*").From("users").Where(querypart)                // $ querystring=querypart
 	squirrel.Select("*").From("users").Having(querypart)               // $ querystring=querypart
-	squirrel.Select("*").From("users").JoinClause(querypart)           // $ querystring=querypart
 	squirrel.Select("*").From("users").OrderByClause(querypart)        // $ querystring=querypart
 	squirrel.Select("*").From("users").Suffix(querypart)               // $ querystring=querypart
 }

--- a/ql/test/library-tests/semmle/go/frameworks/SQL/main.go
+++ b/ql/test/library-tests/semmle/go/frameworks/SQL/main.go
@@ -45,6 +45,9 @@ func test(db *sql.DB, ctx context.Context) {
 func squirrelTest(querypart string) {
 	squirrel.Select("*").From("users").Where(squirrel.Expr(querypart)) // $ querystring=querypart
 	squirrel.Select("*").From("users").Where(querypart)                // $ querystring=querypart
+	squirrel.Select("*").From("users").Having(querypart)               // $ querystring=querypart
+	squirrel.Select("*").From("users").JoinClause(querypart)           // $ querystring=querypart
+	squirrel.Select("*").From("users").OrderByClause(querypart)        // $ querystring=querypart
 	squirrel.Select("*").From("users").Suffix(querypart)               // $ querystring=querypart
 }
 

--- a/ql/test/library-tests/semmle/go/frameworks/SQL/vendor/github.com/Masterminds/squirrel/stub.go
+++ b/ql/test/library-tests/semmle/go/frameworks/SQL/vendor/github.com/Masterminds/squirrel/stub.go
@@ -17,7 +17,7 @@ type BaseRunner interface {
 	Query(_ string, _ ...interface{}) (*sql.Rows, error)
 }
 
-func Expr(_ string, _ ...interface{}) interface{} {
+func Expr(_ string, _ ...interface{}) Sqlizer {
 	return nil
 }
 
@@ -40,6 +40,10 @@ func (_ SelectBuilder) Column(_ interface{}, _ ...interface{}) SelectBuilder {
 }
 
 func (_ SelectBuilder) Columns(_ ...string) SelectBuilder {
+	return SelectBuilder{}
+}
+
+func (_ SelectBuilder) CrossJoin(_ string, _ ...interface{}) SelectBuilder {
 	return SelectBuilder{}
 }
 
@@ -68,6 +72,10 @@ func (_ SelectBuilder) GroupBy(_ ...string) SelectBuilder {
 }
 
 func (_ SelectBuilder) Having(_ interface{}, _ ...interface{}) SelectBuilder {
+	return SelectBuilder{}
+}
+
+func (_ SelectBuilder) InnerJoin(_ string, _ ...interface{}) SelectBuilder {
 	return SelectBuilder{}
 }
 
@@ -103,11 +111,19 @@ func (_ SelectBuilder) OrderBy(_ ...string) SelectBuilder {
 	return SelectBuilder{}
 }
 
+func (_ SelectBuilder) OrderByClause(_ interface{}, _ ...interface{}) SelectBuilder {
+	return SelectBuilder{}
+}
+
 func (_ SelectBuilder) PlaceholderFormat(_ PlaceholderFormat) SelectBuilder {
 	return SelectBuilder{}
 }
 
 func (_ SelectBuilder) Prefix(_ string, _ ...interface{}) SelectBuilder {
+	return SelectBuilder{}
+}
+
+func (_ SelectBuilder) PrefixExpr(_ Sqlizer) SelectBuilder {
 	return SelectBuilder{}
 }
 
@@ -131,6 +147,10 @@ func (_ SelectBuilder) RemoveLimit() SelectBuilder {
 	return SelectBuilder{}
 }
 
+func (_ SelectBuilder) RemoveOffset() SelectBuilder {
+	return SelectBuilder{}
+}
+
 func (_ SelectBuilder) RightJoin(_ string, _ ...interface{}) SelectBuilder {
 	return SelectBuilder{}
 }
@@ -151,10 +171,18 @@ func (_ SelectBuilder) Suffix(_ string, _ ...interface{}) SelectBuilder {
 	return SelectBuilder{}
 }
 
+func (_ SelectBuilder) SuffixExpr(_ Sqlizer) SelectBuilder {
+	return SelectBuilder{}
+}
+
 func (_ SelectBuilder) ToSql() (string, []interface{}, error) {
 	return "", nil, nil
 }
 
 func (_ SelectBuilder) Where(_ interface{}, _ ...interface{}) SelectBuilder {
 	return SelectBuilder{}
+}
+
+type Sqlizer interface {
+	ToSql() (string, []interface{}, error)
 }

--- a/ql/test/query-tests/Security/CWE-089/go.mod
+++ b/ql/test/query-tests/Security/CWE-089/go.mod
@@ -3,6 +3,6 @@ module Security.CWE-089
 go 1.14
 
 require (
-	github.com/Masterminds/squirrel v1.1.0
+	github.com/Masterminds/squirrel v1.5.2
 	go.mongodb.org/mongo-driver v1.3.3
 )

--- a/ql/test/query-tests/Security/CWE-089/vendor/github.com/Masterminds/squirrel/stub.go
+++ b/ql/test/query-tests/Security/CWE-089/vendor/github.com/Masterminds/squirrel/stub.go
@@ -35,6 +35,10 @@ func (_ DeleteBuilder) Limit(_ uint64) DeleteBuilder {
 	return DeleteBuilder{}
 }
 
+func (_ DeleteBuilder) MustSql() (string, []interface{}) {
+	return "", nil
+}
+
 func (_ DeleteBuilder) Offset(_ uint64) DeleteBuilder {
 	return DeleteBuilder{}
 }
@@ -51,15 +55,35 @@ func (_ DeleteBuilder) Prefix(_ string, _ ...interface{}) DeleteBuilder {
 	return DeleteBuilder{}
 }
 
+func (_ DeleteBuilder) PrefixExpr(_ Sqlizer) DeleteBuilder {
+	return DeleteBuilder{}
+}
+
 func (_ DeleteBuilder) Query() (*sql.Rows, error) {
 	return nil, nil
+}
+
+func (_ DeleteBuilder) QueryContext(_ context.Context) (*sql.Rows, error) {
+	return nil, nil
+}
+
+func (_ DeleteBuilder) QueryRowContext(_ context.Context) RowScanner {
+	return nil
 }
 
 func (_ DeleteBuilder) RunWith(_ BaseRunner) DeleteBuilder {
 	return DeleteBuilder{}
 }
 
+func (_ DeleteBuilder) ScanContext(_ context.Context, _ ...interface{}) error {
+	return nil
+}
+
 func (_ DeleteBuilder) Suffix(_ string, _ ...interface{}) DeleteBuilder {
+	return DeleteBuilder{}
+}
+
+func (_ DeleteBuilder) SuffixExpr(_ Sqlizer) DeleteBuilder {
 	return DeleteBuilder{}
 }
 
@@ -71,7 +95,7 @@ func (_ DeleteBuilder) Where(_ interface{}, _ ...interface{}) DeleteBuilder {
 	return DeleteBuilder{}
 }
 
-func Expr(_ string, _ ...interface{}) interface{} {
+func Expr(_ string, _ ...interface{}) Sqlizer {
 	return nil
 }
 
@@ -93,6 +117,10 @@ func (_ InsertBuilder) Into(_ string) InsertBuilder {
 	return InsertBuilder{}
 }
 
+func (_ InsertBuilder) MustSql() (string, []interface{}) {
+	return "", nil
+}
+
 func (_ InsertBuilder) Options(_ ...string) InsertBuilder {
 	return InsertBuilder{}
 }
@@ -102,6 +130,10 @@ func (_ InsertBuilder) PlaceholderFormat(_ PlaceholderFormat) InsertBuilder {
 }
 
 func (_ InsertBuilder) Prefix(_ string, _ ...interface{}) InsertBuilder {
+	return InsertBuilder{}
+}
+
+func (_ InsertBuilder) PrefixExpr(_ Sqlizer) InsertBuilder {
 	return InsertBuilder{}
 }
 
@@ -145,6 +177,10 @@ func (_ InsertBuilder) Suffix(_ string, _ ...interface{}) InsertBuilder {
 	return InsertBuilder{}
 }
 
+func (_ InsertBuilder) SuffixExpr(_ Sqlizer) InsertBuilder {
+	return InsertBuilder{}
+}
+
 func (_ InsertBuilder) ToSql() (string, []interface{}, error) {
 	return "", nil, nil
 }
@@ -168,6 +204,10 @@ func (_ SelectBuilder) Column(_ interface{}, _ ...interface{}) SelectBuilder {
 }
 
 func (_ SelectBuilder) Columns(_ ...string) SelectBuilder {
+	return SelectBuilder{}
+}
+
+func (_ SelectBuilder) CrossJoin(_ string, _ ...interface{}) SelectBuilder {
 	return SelectBuilder{}
 }
 
@@ -196,6 +236,10 @@ func (_ SelectBuilder) GroupBy(_ ...string) SelectBuilder {
 }
 
 func (_ SelectBuilder) Having(_ interface{}, _ ...interface{}) SelectBuilder {
+	return SelectBuilder{}
+}
+
+func (_ SelectBuilder) InnerJoin(_ string, _ ...interface{}) SelectBuilder {
 	return SelectBuilder{}
 }
 
@@ -231,11 +275,19 @@ func (_ SelectBuilder) OrderBy(_ ...string) SelectBuilder {
 	return SelectBuilder{}
 }
 
+func (_ SelectBuilder) OrderByClause(_ interface{}, _ ...interface{}) SelectBuilder {
+	return SelectBuilder{}
+}
+
 func (_ SelectBuilder) PlaceholderFormat(_ PlaceholderFormat) SelectBuilder {
 	return SelectBuilder{}
 }
 
 func (_ SelectBuilder) Prefix(_ string, _ ...interface{}) SelectBuilder {
+	return SelectBuilder{}
+}
+
+func (_ SelectBuilder) PrefixExpr(_ Sqlizer) SelectBuilder {
 	return SelectBuilder{}
 }
 
@@ -259,6 +311,10 @@ func (_ SelectBuilder) RemoveLimit() SelectBuilder {
 	return SelectBuilder{}
 }
 
+func (_ SelectBuilder) RemoveOffset() SelectBuilder {
+	return SelectBuilder{}
+}
+
 func (_ SelectBuilder) RightJoin(_ string, _ ...interface{}) SelectBuilder {
 	return SelectBuilder{}
 }
@@ -279,12 +335,20 @@ func (_ SelectBuilder) Suffix(_ string, _ ...interface{}) SelectBuilder {
 	return SelectBuilder{}
 }
 
+func (_ SelectBuilder) SuffixExpr(_ Sqlizer) SelectBuilder {
+	return SelectBuilder{}
+}
+
 func (_ SelectBuilder) ToSql() (string, []interface{}, error) {
 	return "", nil, nil
 }
 
 func (_ SelectBuilder) Where(_ interface{}, _ ...interface{}) SelectBuilder {
 	return SelectBuilder{}
+}
+
+type Sqlizer interface {
+	ToSql() (string, []interface{}, error)
 }
 
 var StatementBuilder StatementBuilderType = StatementBuilderType{}
@@ -303,6 +367,10 @@ func (_ StatementBuilderType) PlaceholderFormat(_ PlaceholderFormat) StatementBu
 	return StatementBuilderType{}
 }
 
+func (_ StatementBuilderType) Replace(_ string) InsertBuilder {
+	return InsertBuilder{}
+}
+
 func (_ StatementBuilderType) RunWith(_ BaseRunner) StatementBuilderType {
 	return StatementBuilderType{}
 }
@@ -313,6 +381,10 @@ func (_ StatementBuilderType) Select(_ ...string) SelectBuilder {
 
 func (_ StatementBuilderType) Update(_ string) UpdateBuilder {
 	return UpdateBuilder{}
+}
+
+func (_ StatementBuilderType) Where(_ interface{}, _ ...interface{}) StatementBuilderType {
+	return StatementBuilderType{}
 }
 
 type UpdateBuilder struct{}
@@ -329,6 +401,10 @@ func (_ UpdateBuilder) Limit(_ uint64) UpdateBuilder {
 	return UpdateBuilder{}
 }
 
+func (_ UpdateBuilder) MustSql() (string, []interface{}) {
+	return "", nil
+}
+
 func (_ UpdateBuilder) Offset(_ uint64) UpdateBuilder {
 	return UpdateBuilder{}
 }
@@ -342,6 +418,10 @@ func (_ UpdateBuilder) PlaceholderFormat(_ PlaceholderFormat) UpdateBuilder {
 }
 
 func (_ UpdateBuilder) Prefix(_ string, _ ...interface{}) UpdateBuilder {
+	return UpdateBuilder{}
+}
+
+func (_ UpdateBuilder) PrefixExpr(_ Sqlizer) UpdateBuilder {
 	return UpdateBuilder{}
 }
 
@@ -382,6 +462,10 @@ func (_ UpdateBuilder) SetMap(_ map[string]interface{}) UpdateBuilder {
 }
 
 func (_ UpdateBuilder) Suffix(_ string, _ ...interface{}) UpdateBuilder {
+	return UpdateBuilder{}
+}
+
+func (_ UpdateBuilder) SuffixExpr(_ Sqlizer) UpdateBuilder {
 	return UpdateBuilder{}
 }
 

--- a/ql/test/query-tests/Security/CWE-089/vendor/modules.txt
+++ b/ql/test/query-tests/Security/CWE-089/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/Masterminds/squirrel v1.1.0
+# github.com/Masterminds/squirrel v1.5.2
 ## explicit
 github.com/Masterminds/squirrel
 # go.mongodb.org/mongo-driver v1.3.3


### PR DESCRIPTION
## Changes
Building on @tunnelshade's work in #611, add a few additional methods with similar signatures/issues.
These are vulnerable sinks if the first parameter is tainted input.
Some of these functions accept `interface{}` type in which case only `string` type (`StringType`) is tainted/vulnerable.

## Links
* [SelectBuilder.Column](https://pkg.go.dev/github.com/Masterminds/squirrel#SelectBuilder.Column)
* [SelectBuilder.From](https://pkg.go.dev/github.com/Masterminds/squirrel#SelectBuilder.From)
* [SelectBuilder.JoinClause](https://pkg.go.dev/github.com/Masterminds/squirrel#SelectBuilder.JoinClause)
* [SelectBuilder.LeftJoin](https://pkg.go.dev/github.com/Masterminds/squirrel#SelectBuilder.LeftJoin)
* [SelectBuilder.RightJoin](https://pkg.go.dev/github.com/Masterminds/squirrel#SelectBuilder.RightJoin)
* [SelectBuilder.InnerJoin](https://pkg.go.dev/github.com/Masterminds/squirrel#SelectBuilder.InnerJoin)
* [SelectBuilder.CrossJoin](https://pkg.go.dev/github.com/Masterminds/squirrel#SelectBuilder.CrossJoin)
* [SelectBuilder.Having](https://pkg.go.dev/github.com/Masterminds/squirrel#SelectBuilder.Having)
* [SelectBuilder.OrderByClause](https://pkg.go.dev/github.com/Masterminds/squirrel#SelectBuilder.OrderByClause)