### PR TITLE
Match gopkg.in import of squirrel for SQLi query

### DIFF
--- a/ql/lib/semmle/go/frameworks/SQL.qll
+++ b/ql/lib/semmle/go/frameworks/SQL.qll
@@ -83,7 +83,7 @@ module SQL {
       SquirrelQueryString() {
         exists(Function fn |
           exists(string sq |
-            sq = package(["github.com/Masterminds", "github.com/lann"], "squirrel")
+            sq = package(["github.com/Masterminds/squirrel", "gopkg.in/Masterminds/squirrel.v1", "github.com/lann/squirrel"], "")
           |
             // first argument to `squirrel.Expr`
             fn.hasQualifiedName(sq, "Expr")

--- a/ql/lib/semmle/go/frameworks/SQL.qll
+++ b/ql/lib/semmle/go/frameworks/SQL.qll
@@ -83,7 +83,11 @@ module SQL {
       SquirrelQueryString() {
         exists(Function fn |
           exists(string sq |
-            sq = package(["github.com/Masterminds/squirrel", "gopkg.in/Masterminds/squirrel", "github.com/lann/squirrel"], "")
+            sq =
+              package([
+                  "github.com/Masterminds/squirrel", "gopkg.in/Masterminds/squirrel",
+                  "github.com/lann/squirrel"
+                ], "")
           |
             // first argument to `squirrel.Expr`
             fn.hasQualifiedName(sq, "Expr")

--- a/ql/lib/semmle/go/frameworks/SQL.qll
+++ b/ql/lib/semmle/go/frameworks/SQL.qll
@@ -83,7 +83,7 @@ module SQL {
       SquirrelQueryString() {
         exists(Function fn |
           exists(string sq |
-            sq = package(["github.com/Masterminds/squirrel", "gopkg.in/Masterminds/squirrel.v1", "github.com/lann/squirrel"], "")
+            sq = package(["github.com/Masterminds/squirrel", "gopkg.in/Masterminds/squirrel", "github.com/lann/squirrel"], "")
           |
             // first argument to `squirrel.Expr`
             fn.hasQualifiedName(sq, "Expr")


### PR DESCRIPTION
## Changes
You can import [Masterminds/squirrel](https://github.com/Masterminds/squirrel) as `gopkg.in/Masterminds/squirrel.v1`.
This was removed in 2018 from the README (https://github.com/Masterminds/squirrel/commit/d13326f0be730e8aa260f440b63fd00c858a03d0) but was previously the recommended method.
This PR adds that path to the matched packages for SQLI queries.