### PR TITLE
CI: Run on Windows 2019

### DIFF
--- a/.github/workflows/codeqltest.yml
+++ b/.github/workflows/codeqltest.yml
@@ -97,7 +97,7 @@ jobs:
 
   test-win:
     name: Test Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - name: Set up Go 1.17
       uses: actions/setup-go@v1


### PR DESCRIPTION
Tracer appears to not yet support win2022