### PR TITLE
Address incorrectly referenced parameter in QLdoc

### DIFF
--- a/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -558,7 +558,7 @@ module Public {
 
   /** A representation of a parameter initialization. */
   abstract class ParameterNode extends DataFlow::Node {
-    /** Holds if this node initializes the `i`th parameter of `fd`. */
+    /** Holds if this node initializes the `i`th parameter of `c`. */
     abstract predicate isParameterOf(Callable c, int i);
   }
 


### PR DESCRIPTION
The qldoc of the predicate `isParameterOf` mentions the parameter `fd` that does not exists and is possible replaced by `c`