### PR TITLE
Extend DataFlowCallable to include file scopes

### DIFF
--- a/ql/lib/change-notes/2022-04-08-fix-global-dataflow.md
+++ b/ql/lib/change-notes/2022-04-08-fix-global-dataflow.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed a bug where dataflow steps were ignored if both ends were inside the initialiser routine of a file-level variable.

--- a/ql/lib/semmle/go/dataflow/internal/DataFlowDispatch.qll
+++ b/ql/lib/semmle/go/dataflow/internal/DataFlowDispatch.qll
@@ -93,7 +93,7 @@ DataFlowCallable viableCallable(CallExpr ma) {
     else
       if isInterfaceMethodCall(call)
       then result = getRestrictedInterfaceTarget(call)
-      else result = call.getACalleeIncludingExternals()
+      else result.asCallable() = call.getACalleeIncludingExternals()
   )
 }
 


### PR DESCRIPTION
The motivation is so that getEnclosingCallable() can cope with
nodes that are not in a callable.