### PR TITLE
Drop redundant columns from `files` and `folders` relations in `xml.dbscheme`

### DIFF
--- a/ql/lib/xml.dbscheme
+++ b/ql/lib/xml.dbscheme
@@ -51,16 +51,12 @@ numlines(
 
 files(
   unique int id: @file,
-  string name: string ref,
-  string simple: string ref,
-  string ext: string ref,
-  int fromSource: int ref // deprecated
+  string name: string ref
 );
 
 folders(
   unique int id: @folder,
-  string name: string ref,
-  string simple: string ref
+  string name: string ref
 );
 
 @container = @folder | @file


### PR DESCRIPTION
https://github.com/github/codeql-go/pull/560 follow-up.