### PR TITLE
[codeql-go] Authorization Bypass Through User-Controlled Key in go-restful CVE-2022-1996

### DIFF
--- a/ql/test/library-tests/semmle/go/frameworks/Gorestful/go.mod
+++ b/ql/test/library-tests/semmle/go/frameworks/Gorestful/go.mod
@@ -3,6 +3,6 @@ module gorestfultest
 go 1.14
 
 require (
-	github.com/emicklei/go-restful/v3 v3.2.0
+	github.com/emicklei/go-restful/v3 v3.8.0
 	github.com/json-iterator/go v1.1.10 // indirect
 )


### PR DESCRIPTION
## Description bugs🐛
Authorization Bypass Through User-Controlled Key in GitHub repository emicklei/go-restful prior to v3.8.0.

**CVE-2022-1996**
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N`
**Severity Critical**
`9.1 / 10`

## Requested about fixed
Merging this pull request would fix 1 vulnerabilities alert on [ql/test/library-tests/semmle/go/frameworks/Gorestful/go.mod](https://github.com/github/codeql-go/blob/-/ql/test/library-tests/semmle/go/frameworks/Gorestful/go.mod).
