### PR TITLE
Open redirect

### DIFF
--- a/ql/test/library-tests/semmle/go/frameworks/Macaron/go.mod
+++ b/ql/test/library-tests/semmle/go/frameworks/Macaron/go.mod
@@ -2,4 +2,5 @@ module codeql-go-tests/frameworks/macaron
 
 go 1.14
 
-require gopkg.in/macaron.v1 v1.3.5
+require gopkg.in/macaron.v1 v1.3.7
+


### PR DESCRIPTION
## Description bugs 🐛
macaron before 1.3.7 has an open redirect in the static handler, as demonstrated by the http://127.0.0.1:4000//example.com/ URL.

**CVE-2020-12666**
`CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N`
**Severity Moderate** `6.1 / 10`