### PR TITLE
add BeegoInput.RequestBody source to Beego framework

### DIFF
--- a/ql/lib/semmle/go/frameworks/Beego.qll
+++ b/ql/lib/semmle/go/frameworks/Beego.qll
@@ -104,6 +104,18 @@ module Beego {
   }
 
   /**
+   * `BeegoInputRequestBody` sources of untrusted data.
+   */
+  private class BeegoInputRequestBodySource extends UntrustedFlowSource::Range {
+    BeegoInputRequestBodySource() {
+      exists(DataFlow::FieldReadNode frn 
+        | this = frn 
+        | frn.getField().hasQualifiedName(contextPackagePath(), "BeegoInput", "RequestBody")
+      ) 
+    }
+  }
+
+  /**
    * `beego/context.Context` sources of untrusted data.
    */
   private class BeegoContextSource extends UntrustedFlowSource::Range {


### PR DESCRIPTION
The `Controller.Context.BeegoInput.RequestBody` source is not currently modelled. It seems like a go-to way to access a JSON request body using this framework.

Looks to me, like it's the only field in the class worth modelling:
https://pkg.go.dev/github.com/beego/beego/v2/server/web/context#BeegoInput

Here are examples of how this is used in practice:
https://cs.github.com/?q=Input.RequestBody%20language%3AGo&scopeName=All%20repos&scope=

I also wanted to add some tests showcasing this source but I must admit I'm quite overwhelmed as I'm new to CodeQL and most of the docs/guidelines are for people submitting new queries.
